### PR TITLE
Fix QR rendering and DEFLATE deadlock in web tools

### DIFF
--- a/tools/examples/README.md
+++ b/tools/examples/README.md
@@ -35,6 +35,7 @@ there's no build step; just reload the page.
 used by [`tools/generator/index.html`](../generator/index.html) and the
 Android app (see [`SPEC.md`](../../SPEC.md)), using the browser's
 SubtleCrypto and CompressionStream APIs. QR codes are rendered onto
-`<canvas>` via the [`qrcode`](https://www.npmjs.com/package/qrcode) CDN
-script — the same one the generator and reader use, so it requires an
-internet connection on first load.
+`<canvas>` via the [`qrcode`](https://www.npmjs.com/package/qrcode) package,
+dynamically imported from a CDN as an ES module on first use — the same one
+the generator and reader use, so it requires an internet connection on first
+load.

--- a/tools/examples/index.html
+++ b/tools/examples/index.html
@@ -11,10 +11,9 @@
   optional DEFLATE, see ../../SPEC.md) and rendered as a QR code on page load.
 
   Requires a modern browser (WebCrypto SubtleCrypto, CompressionStream) and an
-  internet connection on first load, to fetch the qrcode library from a CDN —
-  same requirements as the generator and reader.
+  internet connection on first load, to dynamically import the qrcode library
+  from a CDN — same requirements as the generator and reader.
 -->
-<script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.4/lib/browser.min.js"></script>
 <style>
   *, *::before, *::after { box-sizing: border-box; }
   body   { font-family: system-ui, sans-serif; margin: 0; background: #f5f5f5; color: #222; }
@@ -235,7 +234,10 @@ async function sha256first8(bytes) {
 async function zlibCompress(bytes) {
   const cs = new CompressionStream('deflate');
   const w = cs.writable.getWriter();
-  await w.write(bytes); await w.close();
+  // Don't await write()/close() here — CompressionStream's writable side has
+  // backpressure (highWaterMark 1), so they won't resolve until the readable
+  // side below is read. Fire-and-forget, then drain the reader.
+  w.write(bytes); w.close();
   const chunks = [];
   const r = cs.readable.getReader();
   for (;;) { const { done, value } = await r.read(); if (done) break; chunks.push(value); }
@@ -661,7 +663,16 @@ each with its own icon.</p>
 ];
 
 // ── QR rendering ──────────────────────────────────────────────────────────
-function renderQr(container, uri) {
+// Dynamically imported on first use (the npm "qrcode" package ships no
+// browser-ready UMD bundle, so we load jsDelivr's ES-module build instead).
+let qrcodeModulePromise;
+function loadQRCode() {
+  if (!qrcodeModulePromise) qrcodeModulePromise = import('https://cdn.jsdelivr.net/npm/qrcode@1.5.4/+esm');
+  return qrcodeModulePromise;
+}
+
+async function renderQr(container, uri) {
+  const QRCode = await loadQRCode();
   return new Promise((resolve, reject) => {
     QRCode.toCanvas(uri, { errorCorrectionLevel: 'L', margin: 2, width: 200 }, (err, canvas) => {
       if (err) { reject(err); return; }

--- a/tools/generator/index.html
+++ b/tools/generator/index.html
@@ -8,11 +8,9 @@
   Static HTML generator for TagDrop QR codes.
   No server required — open this file directly in a browser.
 
-  Requires internet for QR rendering (loads qrcode library from CDN).
-  For fully offline use: download browser.min.js and place it next to this file,
-  then change the <script src> below to point to the local copy.
+  Requires internet for QR rendering (dynamically imports the qrcode library
+  from a CDN as an ES module on first use).
 -->
-<script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.4/lib/browser.min.js"></script>
 <style>
   *, *::before, *::after { box-sizing: border-box; }
   body { font-family: system-ui, sans-serif; margin: 0; background: #f5f5f5; color: #222; }
@@ -314,7 +312,10 @@ async function sha256first8(bytes) {
 async function zlibCompress(bytes) {
   const cs = new CompressionStream('deflate');
   const w = cs.writable.getWriter();
-  await w.write(bytes); await w.close();
+  // Don't await write()/close() here — CompressionStream's writable side has
+  // backpressure (highWaterMark 1), so they won't resolve until the readable
+  // side below is read. Fire-and-forget, then drain the reader.
+  w.write(bytes); w.close();
   const chunks = [];
   const r = cs.readable.getReader();
   for (;;) { const { done, value } = await r.read(); if (done) break; chunks.push(value); }
@@ -378,7 +379,16 @@ async function encodePaperManifest({ label, set, slug, files, related }) {
 function toHex(u8) { return Array.from(u8).map(b => b.toString(16).padStart(2,'0')).join(''); }
 
 // ── QR rendering ──────────────────────────────────────────────────────────
-function renderQr(container, uri) {
+// Dynamically imported on first use (the npm "qrcode" package ships no
+// browser-ready UMD bundle, so we load jsDelivr's ES-module build instead).
+let qrcodeModulePromise;
+function loadQRCode() {
+  if (!qrcodeModulePromise) qrcodeModulePromise = import('https://cdn.jsdelivr.net/npm/qrcode@1.5.4/+esm');
+  return qrcodeModulePromise;
+}
+
+async function renderQr(container, uri) {
+  const QRCode = await loadQRCode();
   return new Promise((resolve, reject) => {
     container.innerHTML = '';
     QRCode.toCanvas(uri, { errorCorrectionLevel: 'L', margin: 2, width: 220 }, (err, canvas) => {

--- a/tools/reader/index.html
+++ b/tools/reader/index.html
@@ -218,8 +218,12 @@ function cborDecodeSequence(bytes) {
 async function zlibDecompress(bytes) {
   const ds = new DecompressionStream('deflate');
   const writer = ds.writable.getWriter();
-  await writer.write(bytes);
-  await writer.close();
+  // Don't await write()/close() here — DecompressionStream's writable side has
+  // backpressure (highWaterMark 1), so they won't resolve until the readable
+  // side below is read. Fire-and-forget (swallow errors here; a malformed
+  // stream surfaces via the reader.read() rejection below instead).
+  writer.write(bytes).catch(() => {});
+  writer.close().catch(() => {});
   const chunks = [];
   const reader = ds.readable.getReader();
   for (;;) {


### PR DESCRIPTION
The qrcode@1.5.4 CDN script (lib/browser.min.js) is plain CommonJS with
require() calls and never defines a global QRCode in a browser — every QR
render in the generator and examples page failed with "QR rendering
failed - is the qrcode library loaded?" regardless of connectivity. Switch
to dynamically importing jsDelivr's bundled +esm build on first use.

Also fix a deadlock in zlibCompress/zlibDecompress: awaiting
writer.write()/close() before reading from the CompressionStream/
DecompressionStream readable side hangs forever, since the writable side's
backpressure isn't released until something reads. Write/close without
awaiting, then drain the reader. This affected any compressed payload in
the generator, examples page, and reader.

Verified end-to-end in a real Chromium via Playwright: all 18 example QR
codes render, generator single-file and paper flows (with compression)
render, and the reader decodes compressed and uncompressed payloads,
manifests, and paper manifests correctly.

https://claude.ai/code/session_01ANzFmmDsoaRewQTwZb5Rbi