### PR TITLE
ci: also build the unsigned release APK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   test-and-build:
-    name: Unit tests & debug build
+    name: Unit tests & APK builds
     runs-on: ubuntu-latest
 
     steps:
@@ -45,3 +45,14 @@ jobs:
         with:
           name: app-debug
           path: app/build/outputs/apk/debug/app-debug.apk
+
+      # Mirrors the unsigned release build F-Droid's build server produces
+      # (and then signs with its own key), to catch release-only build issues.
+      - name: Build release APK (unsigned)
+        run: ./gradlew assembleRelease
+
+      - name: Upload release APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-unsigned
+          path: app/build/outputs/apk/release/app-release-unsigned.apk


### PR DESCRIPTION
## Summary
- Adds an `assembleRelease` step to CI, mirroring the unsigned release build F-Droid's server runs (then signs with its own key)
- Uploads `app-release-unsigned.apk` as a build artifact alongside the existing debug APK
- Renames the job from "Unit tests & debug build" to "Unit tests & APK builds"

## Context
While double-checking F-Droid readiness (issue #21), I confirmed `./gradlew assembleRelease` builds cleanly from a fresh checkout — no signing config, no proprietary deps, `compileSdk`/`targetSdk 34`. This adds that same check to CI so release-only build issues are caught on every push/PR, not just discovered at F-Droid build time.

## Test plan
- [x] Verified `./gradlew assembleRelease` succeeds locally, producing `app/build/outputs/apk/release/app-release-unsigned.apk`
- [ ] CI run on this PR builds both debug and release APKs successfully

https://claude.ai/code/session_01ANzFmmDsoaRewQTwZb5Rbi


---
_Generated by [Claude Code](https://claude.ai/code/session_01ANzFmmDsoaRewQTwZb5Rbi)_