### PR TITLE
Add §9 AES-256-GCM encryption (Kotlin + browser), §10 signature spec, credits

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -91,11 +91,16 @@ The `payload` map — the third item of the envelope sequence (§2) — uses **i
 | 18 | `collection_label` | text (opt) | S, M, P |
 | 19 | `collection_tag` | text (opt) | S, M, P |
 | 24 | `icon` | text (opt) | S, M, P |
+| 28 | `encryption` | uint (opt) | S, M |
+| 29 | `nonce` | bytes (12, opt) | S, M |
+| 30 | `key_material` | bytes (32, opt) | S, M, P |
+| 31 | `retain_key` | bool (opt, default `true`) | S, M, P |
 
 **S** = Single, **M** = Manifest, **C** = Chunk, **P** = PaperManifest
 
 Key 25 is reserved for a future small embedded image icon (raw bytes), as an
-alternative to the emoji `icon` field above.
+alternative to the emoji `icon` field above. Keys 28–31 are defined in §9
+(Encryption).
 
 ### File entry sub-keys (elements of key 15)
 
@@ -119,6 +124,8 @@ Each element is a CBOR map:
 | 23 | `paper_id` | bytes (8, opt) — root hash of the related paper |
 | 26 | `lat` | float64 (opt) — latitude of the related paper |
 | 27 | `lng` | float64 (opt) — longitude of the related paper |
+| 30 | `key_material` | bytes (32, opt) — decryption key for the related paper's content, see §9 |
+| 31 | `retain_key` | bool (opt, default `true`) — see §9 |
 
 ---
 
@@ -261,7 +268,7 @@ Paper (root hash)
 2. **Scan chunks** in any order. The app tracks which `chunk_index` values have been collected.
 3. When `chunks_received == chunk_count`: assemble in ascending `chunk_index` order → concatenate bytes.
 4. Verify: `SHA-256(assembled) == sha256` from manifest. Reject on mismatch.
-5. Decompress if `compression != 0`.
+5. Decrypt if `encryption != 0` (§9), then decompress if `compression != 0`.
 6. Deliver MIME-typed content to the viewer.
 
 **Resumability (issue #14):** Because assembly only needs the CBOR map stored in each QR, a partially-collected set can be saved to a database and resumed later. Each chunk carries `cache_id` so the app can match newly-scanned chunks to a pending collection.
@@ -486,7 +493,134 @@ DEFLATE typically achieves 50–70% size reduction on HTML and text, effectively
 
 ---
 
-## 9. Backward Compatibility: Legacy `data:` URIs
+## 9. Encryption
+
+`content` (key 5) and the assembled chunk bytes (§5) may optionally be
+encrypted, independently of compression (§8).
+
+| `encryption` value | Algorithm |
+|---|---|
+| 0 (or absent) | None |
+| 1 | AES-256-GCM |
+| 2–255 | Reserved |
+
+| Key | Field | Type | Used in |
+|---|---|---|---|
+| 28 | `encryption` | uint (opt) | S, M |
+| 29 | `nonce` | bytes (12, opt) | S, M |
+| 30 | `key_material` | bytes (32, opt) | S, M, P, `related` entries |
+| 31 | `retain_key` | bool (opt, default `true`) | wherever `key_material` appears |
+
+**Order of operations:** compress (§8) first, then encrypt — encrypted bytes
+are high-entropy and don't compress further, so encryption is always the
+last transform applied before transmission, and the first reversed on
+receipt. `sha256` (key 8, §5) continues to cover the assembled bytes exactly
+as transmitted, i.e. after compression *and* encryption, so a partially- or
+incorrectly-assembled multi-code cache can be detected before a decryption
+key is even available.
+
+**AES-256-GCM:** `nonce` (key 29) is the 12-byte GCM nonce, and MUST be
+unique for every encryption performed under a given key — a reused nonce
+breaks AES-GCM's confidentiality entirely. `content` / assembled-chunk
+bytes, when `encryption = 1`, are `ciphertext || 16-byte authentication tag`
+(tag appended) — the default output of both `javax.crypto.Cipher`
+("AES/GCM/NoPadding") on Android and `SubtleCrypto.encrypt()` in browsers,
+so no extra framing is needed in either reference implementation.
+
+```
+payload map {
+  2: h'<8 random bytes>',
+  4: "text/html",
+  5: h'<ciphertext || 16-byte GCM tag>',
+  12: 1,                    // compression — applied before encryption
+  28: 1,                    // encryption: AES-256-GCM
+  29: h'<12-byte nonce>',
+}
+```
+
+### Decryption keys
+
+A decryption key is **32 raw bytes** (`key_material`, key 30) — an
+AES-256-GCM key, used directly with no passphrase or key-derivation step. It
+can appear:
+
+- on any Single, Manifest, or Paper Manifest payload, as a top-level field —
+  "this code also carries a key for other content," independent of whatever
+  `content` (if any) the code itself carries; or
+- on an element of a Paper Manifest's `related` array (key 16, §4.4) —
+  "scanning this paper reveals a key for the related paper," for trails
+  meant to be discovered in sequence.
+
+A Single payload containing `key_material` may omit `content` and
+`mime_type` entirely (otherwise required for Single payloads, §4.1) — a code
+can be *just a key*, with no displayable content of its own:
+
+```
+payload map {
+  30: h'<32-byte AES-256 key>',
+  31: false,                 // retain_key — use once against what's cached now, then forget
+}
+```
+
+`retain_key` (key 31, default `true`) is the author's recommendation for
+whether the app should remember this key for future matches across scanning
+sessions (`true`), or use it only against content already cached *right now*
+and then discard it (`false`). It's a recommendation, not an enforceable
+guarantee — an app or user can always choose to remember a key regardless.
+
+**Discovery, not declaration:** no field says which content a given
+`key_material` decrypts, and no field says a given encrypted `content`
+requires a particular key. Instead, whenever the app learns a new
+`key_material`, it attempts AES-256-GCM decryption (using each candidate's
+`nonce`) against every encrypted `content`/assembled-chunk blob it has
+cached but couldn't previously open — a successful authentication-tag check
+is the match. Symmetrically, whenever a new encrypted payload is cached,
+it's tried against every previously-seen `key_material` (subject to that
+key's `retain_key`). This is cheap — AES-GCM decryption of a few KB against
+a handful of candidates is negligible — and means **scan order doesn't
+matter**: the key first, the content first, or either in a later session,
+the app reconciles them whichever order they arrive in.
+
+### Privacy properties
+
+A few of the choices above double as standard **plausible deniability**
+measures — the inability for an observer to distinguish "this contains
+something hidden" from "this is just opaque data," even with some of the
+format in plain view. The same property underlies things like VeraCrypt's
+hidden volumes or OTR's deniable authentication.
+
+- **Ciphertext is indistinguishable from random.** AES-GCM ciphertext with a
+  fresh nonce is computationally indistinguishable from random bytes. The
+  only fields visible without the key are the envelope (`version`, `type`)
+  and whatever metadata the author chose to leave in the clear — `content`
+  itself reveals nothing about what it decrypts to, or whether any
+  particular `key_material` unlocks it.
+- **Decoders tolerate trailing bytes.** A CBOR Sequence (RFC 8742, §2) is
+  self-delimiting — a decoder reads exactly as many bytes as the known items
+  require and stops. TagDrop decoders MUST NOT treat additional bytes after
+  a complete, valid envelope+payload sequence as an error. A code can
+  therefore carry a second, independent envelope+payload sequence after the
+  first, encrypted under a different key — to a decoder that doesn't know to
+  look for it, indistinguishable from padding.
+- **Keys and content are the same shape.** As above, a `key_material`-only
+  code and a small encrypted Single code look identical — both are short,
+  high-entropy CBOR maps. Nothing marks "this is a key."
+- **Ephemeral-by-default caching is recommended.** Implementations SHOULD
+  NOT persist encrypted content they cannot yet decrypt beyond the current
+  session, unless a `key_material` scanned alongside it has
+  `retain_key = true`. Storage with no record of "content I can't open"
+  reveals less than storage that has one.
+
+None of this is mandatory, and most uses of TagDrop (sticker trails,
+treasure hunts) won't need any of it — but the format doesn't preclude it,
+and each property above is a deliberate small design choice rather than an
+afterthought. These are properties of the *format*; an implementation that
+logs scan history, retains keys against a user's wishes, or makes network
+requests undermines them regardless of what the bytes on the wire look like.
+
+---
+
+## 10. Backward Compatibility: Legacy `data:` URIs
 
 Codes containing a raw `data:` URI (without the `tagdrop:` scheme) are recognised and handled in **legacy mode**:
 
@@ -497,7 +631,7 @@ New content should use the `tagdrop:` scheme. Legacy support will be maintained 
 
 ---
 
-## 10. NFC Transport (future)
+## 11. NFC Transport (future)
 
 The CBOR sequence (`version`, `type`, `payload` — §2; the same bytes that get Base45-encoded into the `tagdrop:` URI) can be stored directly in an NFC NDEF record with:
 
@@ -513,7 +647,7 @@ A NFC-NDEF capable multi-tag sequence would use the same manifest/chunk split, w
 
 ---
 
-## 11. Alternative Carriers
+## 12. Alternative Carriers
 
 The format is carrier-agnostic. Any medium that can carry a UTF-8 string supports the `tagdrop:` URI form. Any medium that carries raw bytes supports the raw CBOR sequence form.
 
@@ -528,18 +662,18 @@ The format is carrier-agnostic. Any medium that can carry a UTF-8 string support
 
 ---
 
-## 12. Version Negotiation
+## 13. Version Negotiation
 
 `version` is the first item of the envelope sequence (§2) — a single CBOR integer, decodable independently of everything that follows it. A reader encountering an unsupported `version` should stop immediately and show a human-readable "unsupported format version" message, without attempting to decode `type` or `payload` — a future version is free to redefine either, even to something other than CBOR.
 
 Version history:
 | Version | Changes |
 |---|---|
-| 1 | Initial release. `version`/`type` envelope as a 2-item CBOR sequence (§2); `type` 0–3 for Single/Manifest/Chunk/PaperManifest. Payload map keys 2–19, 20–24 (25 reserved), 26–27 (key 1 retired — see §3). DEFLATE compression. Base45 URI encoding (`tagdrop:<base45>`). Content-addressed IDs. Optional ad-hoc collections (`collection_id`, `collection_label`, `collection_tag`). Optional emoji `icon` (key 24), with key 25 reserved for a future image icon. Optional `lat`/`lng` (keys 26/27, float64) on `related` paper entries (key 16), for placeholder map pins. |
+| 1 | Initial release. `version`/`type` envelope as a 2-item CBOR sequence (§2); `type` 0–3 for Single/Manifest/Chunk/PaperManifest. Payload map keys 2–19, 20–24 (25 reserved), 26–27 (key 1 retired — see §3). DEFLATE compression. Base45 URI encoding (`tagdrop:<base45>`). Content-addressed IDs. Optional ad-hoc collections (`collection_id`, `collection_label`, `collection_tag`). Optional emoji `icon` (key 24), with key 25 reserved for a future image icon. Optional `lat`/`lng` (keys 26/27, float64) on `related` paper entries (key 16), for placeholder map pins. Optional AES-256-GCM encryption (`encryption`/`nonce`, keys 28/29) applied after compression, and optional `key_material`/`retain_key` (keys 30/31) carried inline or via `related` entries, matched by trial decryption rather than declared targets — see §9. |
 
 ---
 
-## 13. Reference Implementations
+## 14. Reference Implementations
 
 - **Android app:** `app/src/main/java/com/github/mofosyne/tagdrop/data/format/`
   - `TagDropCodec.kt` — encode/decode all payload types; `contentId()`, `rootHashOf()`, `createSingle()`
@@ -556,13 +690,13 @@ Version history:
 
 ---
 
-## 14. Design Notes and Alternatives Considered
+## 15. Design Notes and Alternatives Considered
 
 **Why not extend `data:` URI syntax?** (issues #2, #4, #13) Adding parameters like `;seq-id=`, `;seq-total=`, `;crc=` to the data URI was the original approach. It fails because data: URIs are opaque to QR readers — there's no way to route them to the app by scheme. The `tagdrop:` scheme gives us OS-level routing and a clean separation between the envelope and payload.
 
 **Why a version/type envelope instead of URI path segments or per-map keys?** An earlier draft put `v1/<type>/` in the URI path and a `version` key inside each payload map. That works for QR, but raw-byte carriers (NFC NDEF, JABCode raw — §10/§11) have no URI wrapper, so type/version information would either be lost or have to be guessed from which map keys happen to be present — fragile, and ambiguous for future payload types. Prefixing every payload with a 2-item CBOR Sequence (RFC 8742) — `CBOR(version) || CBOR(type)`, 1 byte each for the foreseeable range of values — makes the same bytes self-describing on every carrier: Base45-encode them for `tagdrop:<base45>`, or store them raw in an NDEF record, with identical decode logic either way. It also lets the URI collapse to `tagdrop:<base45>` (no `//`, no `/<type>/` segment), gives a clean disambiguation rule against `tagdrop://<rootHash>/<slug>` navigation links (§2), and — being a sequence rather than a CBOR array — costs one less byte than `[version, type, payload]` and doesn't require `payload` to be CBOR-wrapped, leaving room for a non-CBOR `payload` in a future version. `version` lives *only* in the envelope, not redundantly inside `payload` too: two fields claiming to describe the same fact can disagree, forcing a reader to pick which one to trust — the same class of ambiguity RFC 9112 §6.3 closes off by forbidding conflicting `Content-Length`/`Transfer-Encoding` framing in HTTP/1.1. CBOR's own self-describing-data convention (the tag-55799 "magic number", RFC 8949 §3.4.5.3) is likewise an external prefix rather than a duplicated internal field, reinforcing that self-description belongs in the envelope.
 
-**Why not NDEF as the primary format?** (issue #16) NDEF is a memory-layout format for NFC chips with a specific capability container. Adapting it for QR codes adds complexity without benefit — the QR code already handles error correction and binary framing. We use NDEF only as a transport option for NFC tags (§10).
+**Why not NDEF as the primary format?** (issue #16) NDEF is a memory-layout format for NFC chips with a specific capability container. Adapting it for QR codes adds complexity without benefit — the QR code already handles error correction and binary framing. We use NDEF only as a transport option for NFC tags (§11).
 
 **Binary mode vs alphanumeric Base45:** Raw binary QR codes store 8 bits/char. Alphanumeric Base45 stores 2 bytes in 3 characters at 5.5 bits/char = ~8.25 bits/byte of original data. The tiny efficiency loss is worth the interoperability gain: alphanumeric QR codes are more reliably decoded by all readers, and the `tagdrop:` prefix is human-readable.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -95,12 +95,17 @@ The `payload` map — the third item of the envelope sequence (§2) — uses **i
 | 29 | `nonce` | bytes (12, opt) | S, M |
 | 30 | `key_material` | bytes (32, opt) | S, M, P |
 | 31 | `retain_key` | bool (opt, default `true`) | S, M, P |
+| 32 | `signature_algorithm` | uint (opt) | S, M, P |
+| 33 | `signature` | bytes (2420, opt) | S, M, P |
+| 34 | `signer_pubkey` | bytes (1312, opt) | S, M, P |
+| 35 | `signer_id` | bytes (8, opt) | S, M, P |
+| 36 | `signer_label` | text (opt) | S, M, P |
 
 **S** = Single, **M** = Manifest, **C** = Chunk, **P** = PaperManifest
 
 Key 25 is reserved for a future small embedded image icon (raw bytes), as an
 alternative to the emoji `icon` field above. Keys 28–31 are defined in §9
-(Encryption).
+(Encryption); keys 32–36 are defined in §10 (Verified Authorship).
 
 ### File entry sub-keys (elements of key 15)
 
@@ -620,7 +625,121 @@ requests undermines them regardless of what the bytes on the wire look like.
 
 ---
 
-## 10. Backward Compatibility: Legacy `data:` URIs
+## 10. Verified Authorship (Signatures)
+
+A payload may optionally be **signed**, proving "the holder of a particular
+private key produced this exact payload." Signing is orthogonal to
+encryption (§9) and to content-addressing (§3, §4.5) — a signed code has the
+same `cache_id` / `root_hash` and `sha256` as its unsigned equivalent, and
+signing is **opt-in**: most TagDrop codes (stickers, treasure hunts, paper
+backups) need no signature at all.
+
+| `signature_algorithm` value | Algorithm |
+|---|---|
+| 0 (or absent) | Unsigned |
+| 1 | ML-DSA-44 (Dilithium2, FIPS 204) |
+| 2–255 | Reserved |
+
+| Key | Field | Type | Used in |
+|---|---|---|---|
+| 32 | `signature_algorithm` | uint (opt) | S, M, P |
+| 33 | `signature` | bytes (2420, opt) | S, M, P |
+| 34 | `signer_pubkey` | bytes (1312, opt) | S, M, P |
+| 35 | `signer_id` | bytes (8, opt) | S, M, P |
+| 36 | `signer_label` | text (opt) | S, M, P |
+
+**Implementation status:** specified for forward-compatibility, not yet
+implemented in either reference implementation (§15). ML-DSA-44 is not
+available in `java.security`/Android's crypto providers or in
+`SubtleCrypto` (Web Crypto), so adding it requires a new dependency in both
+— e.g. BouncyCastle for the Kotlin app, and a pure-JS PQC library (such as
+`@noble/post-quantum`) for the browser tools, which currently depend on
+nothing but a QR CDN script. Readers that don't recognise keys 32–36 ignore
+them per §3's forward-compatibility rule and treat the code as unsigned.
+
+**Why post-quantum, not ECDSA/Ed25519?** Shor's algorithm breaks the
+discrete-log and elliptic-curve problems outright — a future quantum
+computer doesn't just weaken ECDSA/Ed25519, it forges signatures under those
+schemes entirely. By contrast, Grover's algorithm only *halves* AES's
+effective key length, which is why AES-256-GCM (§9) needs no change for
+quantum resistance. A signature scheme adopted now should not be one that a
+sufficiently large quantum computer invalidates retroactively for every code
+ever signed with it. ML-DSA-44 (Dilithium2, NIST security category 2, FIPS
+204, standardized 2024) is a lattice-based scheme with no known efficient
+quantum attack, and its sizes are **fixed regardless of message length** —
+2420-byte signature, 1312-byte public key, 2560-byte private key (never
+transmitted). For small codes (a few hundred bytes) that's significant
+overhead; for content already spanning multiple chunks (§4.2) — e.g. an
+essay of a few KB — a constant ~2.4 KB signature is proportionally minor,
+and the public key (§ below) is amortized across an entire trail or
+collection.
+
+**Signed message:** `SHA-256(envelope || payload)` where `payload` is the
+CBOR map with keys 32–36 *absent* — i.e. the SHA-256 of the exact bytes an
+unsigned code would encode to. For a Paper Manifest (type 3), `root_hash`
+(key 2) is computed first per §4.5 (also with keys 32–36 absent), and the
+signature is then computed over the payload map *including* that final
+`root_hash` but still excluding keys 32–36. In both cases, signing happens
+last and feeds back into nothing — `cache_id`/`root_hash`/`sha256` are
+identical whether or not keys 32–36 are subsequently added.
+
+**Verification:** a verifier strips keys 32–36, recomputes the same
+SHA-256, and checks `signature` (key 33) against that hash using
+`signer_pubkey` (key 34) via ML-DSA-44 `Verify`. `signer_id` (key 35) =
+`SHA-256(signer_pubkey)[0:8]` — the same truncated-SHA-256-prefix convention
+as `cache_id`/`collection_id`/`paper_id` (§3).
+
+**Key caching (amortizing the ~3.7 KB first-use cost):** `signer_id` is
+present on every signed payload, but `signer_pubkey` (1312 bytes) only needs
+to be included on the *first* signed code an app encounters from a given
+`signer_id` — the app caches `signer_id → (signer_pubkey, signer_label)`.
+Subsequent codes from the same signer omit `signer_pubkey` and cost only
+`signature` + `signer_id` (~2428 bytes). If a code omits `signer_pubkey` and
+the verifier has no cached entry for its `signer_id`, the signature can't
+yet be checked — it's held pending, and verified retroactively once a code
+carrying that `signer_pubkey` is scanned, the same "complete opportunistically,
+in any order" pattern as chunk assembly (§5) and key matching (§9).
+
+**Trust model:** trust-on-first-use (TOFU), like SSH host keys — there is no
+PKI, certificate authority, or revocation. A verified signature proves "the
+same private key signed this as everything else cached under this
+`signer_id`," not a real-world identity. `signer_label` (key 36, free text)
+lets an author attach a human-readable name (e.g. "City Parks Dept.
+Trail"); it is self-asserted and meaningful only as a consistent label
+across that signer's codes, exactly like a comment in `~/.ssh/known_hosts`.
+
+**Downgrade:** stripping keys 32–36 from a signed code yields a valid
+unsigned code with the same `cache_id`/`sha256` — content-addressing doesn't
+distinguish "never signed" from "signature removed." This is an accepted
+limitation: a signature can be *removed* but not *forged* or *retargeted*
+(ML-DSA verification ties `signature`, `signer_pubkey`, and the exact
+payload bytes together), so the only thing an attacker can do is strip an
+authorship claim, never add or substitute one.
+
+**Interaction with §9's privacy properties:** a signature is an explicit,
+persistent identity marker — the opposite of plausible deniability. Authors
+relying on §9's privacy properties (encrypted content, key-only codes,
+deniable framing) SHOULD NOT sign that content: a repeated `signer_id`
+links codes to the same author even when their content is unreadable.
+Verified Authorship and §9's privacy properties are intended as alternative
+use cases of the same format, not a combination.
+
+```
+payload map {
+  2: h'<8 random bytes>',         // cache_id
+  4: "text/markdown",
+  5: h'<content bytes>',
+  32: 1,                           // signature_algorithm: ML-DSA-44
+  33: h'<2420-byte signature>',
+  34: h'<1312-byte public key>',   // only on first code from this signer
+  35: h'<8-byte signer_id>',
+  36: "Alice's Trail",              // optional human-readable label
+}
+```
+
+---
+
+## 11. Backward Compatibility: Legacy `data:` URIs
 
 Codes containing a raw `data:` URI (without the `tagdrop:` scheme) are recognised and handled in **legacy mode**:
 
@@ -631,7 +750,7 @@ New content should use the `tagdrop:` scheme. Legacy support will be maintained 
 
 ---
 
-## 11. NFC Transport (future)
+## 12. NFC Transport (future)
 
 The CBOR sequence (`version`, `type`, `payload` — §2; the same bytes that get Base45-encoded into the `tagdrop:` URI) can be stored directly in an NFC NDEF record with:
 
@@ -647,7 +766,7 @@ A NFC-NDEF capable multi-tag sequence would use the same manifest/chunk split, w
 
 ---
 
-## 12. Alternative Carriers
+## 13. Alternative Carriers
 
 The format is carrier-agnostic. Any medium that can carry a UTF-8 string supports the `tagdrop:` URI form. Any medium that carries raw bytes supports the raw CBOR sequence form.
 
@@ -662,18 +781,18 @@ The format is carrier-agnostic. Any medium that can carry a UTF-8 string support
 
 ---
 
-## 13. Version Negotiation
+## 14. Version Negotiation
 
 `version` is the first item of the envelope sequence (§2) — a single CBOR integer, decodable independently of everything that follows it. A reader encountering an unsupported `version` should stop immediately and show a human-readable "unsupported format version" message, without attempting to decode `type` or `payload` — a future version is free to redefine either, even to something other than CBOR.
 
 Version history:
 | Version | Changes |
 |---|---|
-| 1 | Initial release. `version`/`type` envelope as a 2-item CBOR sequence (§2); `type` 0–3 for Single/Manifest/Chunk/PaperManifest. Payload map keys 2–19, 20–24 (25 reserved), 26–27 (key 1 retired — see §3). DEFLATE compression. Base45 URI encoding (`tagdrop:<base45>`). Content-addressed IDs. Optional ad-hoc collections (`collection_id`, `collection_label`, `collection_tag`). Optional emoji `icon` (key 24), with key 25 reserved for a future image icon. Optional `lat`/`lng` (keys 26/27, float64) on `related` paper entries (key 16), for placeholder map pins. Optional AES-256-GCM encryption (`encryption`/`nonce`, keys 28/29) applied after compression, and optional `key_material`/`retain_key` (keys 30/31) carried inline or via `related` entries, matched by trial decryption rather than declared targets — see §9. |
+| 1 | Initial release. `version`/`type` envelope as a 2-item CBOR sequence (§2); `type` 0–3 for Single/Manifest/Chunk/PaperManifest. Payload map keys 2–19, 20–24 (25 reserved), 26–27 (key 1 retired — see §3). DEFLATE compression. Base45 URI encoding (`tagdrop:<base45>`). Content-addressed IDs. Optional ad-hoc collections (`collection_id`, `collection_label`, `collection_tag`). Optional emoji `icon` (key 24), with key 25 reserved for a future image icon. Optional `lat`/`lng` (keys 26/27, float64) on `related` paper entries (key 16), for placeholder map pins. Optional AES-256-GCM encryption (`encryption`/`nonce`, keys 28/29) applied after compression, and optional `key_material`/`retain_key` (keys 30/31) carried inline or via `related` entries, matched by trial decryption rather than declared targets — see §9. Optional ML-DSA-44 post-quantum signatures (`signature_algorithm`/`signature`/`signer_pubkey`/`signer_id`/`signer_label`, keys 32–36), additive over the unsigned payload and not affecting `cache_id`/`root_hash`/`sha256` — see §10 (not yet implemented in reference implementations). |
 
 ---
 
-## 14. Reference Implementations
+## 15. Reference Implementations
 
 - **Android app:** `app/src/main/java/com/github/mofosyne/tagdrop/data/format/`
   - `TagDropCodec.kt` — encode/decode all payload types; `contentId()`, `rootHashOf()`, `createSingle()`
@@ -690,13 +809,13 @@ Version history:
 
 ---
 
-## 15. Design Notes and Alternatives Considered
+## 16. Design Notes and Alternatives Considered
 
 **Why not extend `data:` URI syntax?** (issues #2, #4, #13) Adding parameters like `;seq-id=`, `;seq-total=`, `;crc=` to the data URI was the original approach. It fails because data: URIs are opaque to QR readers — there's no way to route them to the app by scheme. The `tagdrop:` scheme gives us OS-level routing and a clean separation between the envelope and payload.
 
-**Why a version/type envelope instead of URI path segments or per-map keys?** An earlier draft put `v1/<type>/` in the URI path and a `version` key inside each payload map. That works for QR, but raw-byte carriers (NFC NDEF, JABCode raw — §10/§11) have no URI wrapper, so type/version information would either be lost or have to be guessed from which map keys happen to be present — fragile, and ambiguous for future payload types. Prefixing every payload with a 2-item CBOR Sequence (RFC 8742) — `CBOR(version) || CBOR(type)`, 1 byte each for the foreseeable range of values — makes the same bytes self-describing on every carrier: Base45-encode them for `tagdrop:<base45>`, or store them raw in an NDEF record, with identical decode logic either way. It also lets the URI collapse to `tagdrop:<base45>` (no `//`, no `/<type>/` segment), gives a clean disambiguation rule against `tagdrop://<rootHash>/<slug>` navigation links (§2), and — being a sequence rather than a CBOR array — costs one less byte than `[version, type, payload]` and doesn't require `payload` to be CBOR-wrapped, leaving room for a non-CBOR `payload` in a future version. `version` lives *only* in the envelope, not redundantly inside `payload` too: two fields claiming to describe the same fact can disagree, forcing a reader to pick which one to trust — the same class of ambiguity RFC 9112 §6.3 closes off by forbidding conflicting `Content-Length`/`Transfer-Encoding` framing in HTTP/1.1. CBOR's own self-describing-data convention (the tag-55799 "magic number", RFC 8949 §3.4.5.3) is likewise an external prefix rather than a duplicated internal field, reinforcing that self-description belongs in the envelope.
+**Why a version/type envelope instead of URI path segments or per-map keys?** An earlier draft put `v1/<type>/` in the URI path and a `version` key inside each payload map. That works for QR, but raw-byte carriers (NFC NDEF, JABCode raw — §12/§13) have no URI wrapper, so type/version information would either be lost or have to be guessed from which map keys happen to be present — fragile, and ambiguous for future payload types. Prefixing every payload with a 2-item CBOR Sequence (RFC 8742) — `CBOR(version) || CBOR(type)`, 1 byte each for the foreseeable range of values — makes the same bytes self-describing on every carrier: Base45-encode them for `tagdrop:<base45>`, or store them raw in an NDEF record, with identical decode logic either way. It also lets the URI collapse to `tagdrop:<base45>` (no `//`, no `/<type>/` segment), gives a clean disambiguation rule against `tagdrop://<rootHash>/<slug>` navigation links (§2), and — being a sequence rather than a CBOR array — costs one less byte than `[version, type, payload]` and doesn't require `payload` to be CBOR-wrapped, leaving room for a non-CBOR `payload` in a future version. `version` lives *only* in the envelope, not redundantly inside `payload` too: two fields claiming to describe the same fact can disagree, forcing a reader to pick which one to trust — the same class of ambiguity RFC 9112 §6.3 closes off by forbidding conflicting `Content-Length`/`Transfer-Encoding` framing in HTTP/1.1. CBOR's own self-describing-data convention (the tag-55799 "magic number", RFC 8949 §3.4.5.3) is likewise an external prefix rather than a duplicated internal field, reinforcing that self-description belongs in the envelope.
 
-**Why not NDEF as the primary format?** (issue #16) NDEF is a memory-layout format for NFC chips with a specific capability container. Adapting it for QR codes adds complexity without benefit — the QR code already handles error correction and binary framing. We use NDEF only as a transport option for NFC tags (§11).
+**Why not NDEF as the primary format?** (issue #16) NDEF is a memory-layout format for NFC chips with a specific capability container. Adapting it for QR codes adds complexity without benefit — the QR code already handles error correction and binary framing. We use NDEF only as a transport option for NFC tags (§12).
 
 **Binary mode vs alphanumeric Base45:** Raw binary QR codes store 8 bits/char. Alphanumeric Base45 stores 2 bytes in 3 characters at 5.5 bits/char = ~8.25 bits/byte of original data. The tiny efficiency loss is worth the interoperability gain: alphanumeric QR codes are more reliably decoded by all readers, and the `tagdrop:` prefix is human-readable.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -720,7 +720,12 @@ authorship claim, never add or substitute one.
 persistent identity marker — the opposite of plausible deniability. Authors
 relying on §9's privacy properties (encrypted content, key-only codes,
 deniable framing) SHOULD NOT sign that content: a repeated `signer_id`
-links codes to the same author even when their content is unreadable.
+links codes to the same author even when their content is unreadable. Worse,
+signing is **non-repudiable and retroactive** — a private key seized later
+(device confiscation, coercion) lets an adversary prove authorship of every
+code ever signed with it, including ones distributed long before the key was
+compromised. For an author whose safety depends on deniability, a signing
+key is a standing liability with no way to "take back" past signatures.
 Verified Authorship and §9's privacy properties are intended as alternative
 use cases of the same format, not a combination.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -524,6 +524,17 @@ as transmitted, i.e. after compression *and* encryption, so a partially- or
 incorrectly-assembled multi-code cache can be detected before a decryption
 key is even available.
 
+**`cache_id` for encrypted content is random, not content-addressed.**
+§4.5 defines `cache_id = SHA-256(uncompressed content)[0:8]` so that
+identical content always gets the same ID — useful for deduplication, but
+exactly the wrong property for encrypted content: it would let anyone
+compute the `cache_id` of a known plaintext and check whether any encrypted
+code in the wild carries it, confirming "this hidden content equals known
+document X" without the key. When `encryption != 0`, `cache_id` (key 2)
+MUST instead be 8 random bytes, independent of the plaintext — deliberately
+giving up cross-author deduplication for encrypted content in exchange for
+not leaking a content-equality oracle.
+
 **AES-256-GCM:** `nonce` (key 29) is the 12-byte GCM nonce, and MUST be
 unique for every encryption performed under a given key — a reused nonce
 breaks AES-GCM's confidentiality entirely. `content` / assembled-chunk

--- a/SPEC.md
+++ b/SPEC.md
@@ -477,7 +477,7 @@ icon slot in the app's UI is designed to host either form.
 | `compression` value | Algorithm |
 |---|---|
 | 0 (or absent) | None |
-| 1 | DEFLATE (RFC 1951, raw, no zlib header) |
+| 1 | DEFLATE, zlib-wrapped (RFC 1950) |
 | 2–255 | Reserved |
 
 Compression is applied to the complete assembled payload (in multi-code) or the content field directly (in single-code). The `sha256` in the manifest is over the **compressed** assembled bytes (before decompression), so integrity can be verified before decompression.
@@ -552,7 +552,7 @@ Version history:
 - **Android database:** `app/src/main/java/com/github/mofosyne/tagdrop/data/db/`
   - `FoundCache.kt` — Room entity for scanned file caches
   - `ScannedPaper.kt` — Room entity for scanned paper manifests
-  - `AppDatabase.kt` — Room DB v4 with migrations
+  - `AppDatabase.kt` — Room database with migrations
 
 ---
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/ChunkAssembler.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/ChunkAssembler.kt
@@ -16,6 +16,9 @@ class ChunkAssembler {
     private var manifest: TagDropPayload.Manifest? = null
     private val chunks = mutableMapOf<Int, ByteArray>()
 
+    /** Set once a `key_material` (SPEC §9) successfully decrypts the assembled bytes. */
+    private var resolvedContent: ByteArray? = null
+
     sealed class State {
         /** No manifest scanned yet. */
         object WaitingForManifest : State()
@@ -29,7 +32,7 @@ class ChunkAssembler {
             val hint: String?,
             val filename: String?,
             val mimeType: String,
-            val content: ByteArray,  // already decompressed
+            val content: ByteArray,  // already decrypted (if needed) and decompressed
             val collectionId: ByteArray?,
             val collectionLabel: String?,
             val collectionTag: String?,
@@ -38,12 +41,21 @@ class ChunkAssembler {
 
         /** All chunks received but assembly failed integrity check. */
         object HashMismatch : State()
+
+        /**
+         * All chunks received and SHA-256 verified, but the assembled bytes are
+         * encrypted (SPEC §9) and no `key_material` tried so far has decrypted them.
+         * Call [ChunkAssembler.tryKey] when a candidate key becomes available —
+         * scan order between key and content doesn't matter.
+         */
+        data class AwaitingKey(val cacheId: ByteArray, val hint: String?, val nonce: ByteArray) : State()
     }
 
     fun add(payload: TagDropPayload): State = when (payload) {
         is TagDropPayload.Manifest -> {
             manifest = payload
             chunks.clear()
+            resolvedContent = null
             computeState()
         }
         is TagDropPayload.Chunk -> {
@@ -58,6 +70,32 @@ class ChunkAssembler {
 
     fun currentState(): State = computeState()
 
+    /**
+     * Tries [keyMaterial] against the assembled (verified) ciphertext, per SPEC §9's
+     * "discovery, not declaration" matching. If it authenticates, the content is
+     * decrypted and cached, resolving an [State.AwaitingKey]. Returns the resulting
+     * state either way — a non-matching key leaves [State.AwaitingKey] unchanged.
+     */
+    fun tryKey(keyMaterial: ByteArray): State {
+        val m = manifest
+        if (m == null || m.encryption != TagDropCodec.ENCRYPTION_AES256GCM || resolvedContent != null) {
+            return currentState()
+        }
+        val nonce = m.nonce ?: return currentState()
+        val assembled = assembledAndVerified() ?: return currentState()
+        TagDropCodec.decryptAesGcm(assembled, keyMaterial, nonce)?.let { resolvedContent = it }
+        return computeState()
+    }
+
+    /** Joins all chunks in order and checks `sha256`, or returns null if incomplete or hash-mismatched. */
+    private fun assembledAndVerified(): ByteArray? {
+        val m = manifest ?: return null
+        if (chunks.size < m.chunkCount) return null
+        val assembled = (0 until m.chunkCount).map { idx -> chunks[idx] ?: return null }.reduce(ByteArray::plus)
+        if (!MessageDigest.getInstance("SHA-256").digest(assembled).contentEquals(m.sha256)) return null
+        return assembled
+    }
+
     private fun computeState(): State {
         val m = manifest ?: return State.WaitingForManifest
 
@@ -70,18 +108,25 @@ class ChunkAssembler {
             chunks[idx] ?: return State.Collecting(chunks.size, m.chunkCount, m.cacheId, m.hint)
         }.reduce(ByteArray::plus)
 
-        // Integrity check
+        // Integrity check — covers the fully-transmitted bytes, i.e. after compression AND encryption (SPEC §9)
         if (!MessageDigest.getInstance("SHA-256").digest(assembled).contentEquals(m.sha256)) {
             return State.HashMismatch
         }
 
-        val content = TagDropCodec.decompressPayload(assembled, m.compression)
+        val plain = if (m.encryption == TagDropCodec.ENCRYPTION_AES256GCM) {
+            resolvedContent ?: return State.AwaitingKey(m.cacheId, m.hint, m.nonce ?: return State.HashMismatch)
+        } else {
+            assembled
+        }
+
+        val content = TagDropCodec.decompressPayload(plain, m.compression)
         return State.Complete(m.cacheId, m.hint, m.filename, m.mimeType, content, m.collectionId, m.collectionLabel, m.collectionTag, m.icon)
     }
 
     fun reset() {
         manifest = null
         chunks.clear()
+        resolvedContent = null
     }
 
     val hasManifest get() = manifest != null

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/MiniCbor.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/MiniCbor.kt
@@ -10,6 +10,7 @@ import java.io.ByteArrayOutputStream
  *   - Text strings    (major type 3)
  *   - Arrays          (major type 4)
  *   - Maps with integer keys (major type 5)
+ *   - Booleans        (major type 7, additional info 20/21)
  *   - Float64         (major type 7, additional info 27)
  *   - Null (0xf6)
  *
@@ -54,6 +55,7 @@ object MiniCbor {
         when (v) {
             is Int       -> writeHead(out, 0, v.toLong())
             is Long      -> writeHead(out, 0, v)
+            is Boolean   -> out.write(if (v) 0xF5 else 0xF4) // true (0xf5) / false (0xf4)
             is ByteArray -> { writeHead(out, 2, v.size.toLong()); out.write(v) }
             is String    -> {
                 val bytes = v.toByteArray(Charsets.UTF_8)
@@ -144,6 +146,8 @@ object MiniCbor {
             4 -> List(arg.toInt()) { readValue(stream) }
             5 -> readMapFromStream(stream, arg.toInt())
             7 -> when (b and 0x1F) {
+                20 -> false                   // false (0xf4)
+                21 -> true                    // true (0xf5)
                 22 -> Unit                    // null (0xf6)
                 27 -> Double.fromBits(arg)    // float64 (0xfb)
                 else -> throw IllegalArgumentException("Unsupported simple value 0x${b.toString(16)}")

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
@@ -3,8 +3,12 @@ package com.github.mofosyne.tagdrop.data.format
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.security.MessageDigest
+import java.security.SecureRandom
 import java.util.zip.DeflaterOutputStream
 import java.util.zip.InflaterInputStream
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
 
 /**
  * Encodes and decodes TagDrop QR payloads.
@@ -41,6 +45,10 @@ import java.util.zip.InflaterInputStream
  *   19 collection_tag   text, optional      (Single, Manifest, PaperManifest)
  *   24 icon              text, optional      (Single, Manifest, PaperManifest) — emoji icon
  *   25 reserved for future image icon (bytes — small embedded icon image)
+ *   28 encryption    uint, optional   0=none 1=AES-256-GCM (Single, Manifest) — SPEC §9
+ *   29 nonce         bytes(12), optional, present iff encryption != 0 (Single, Manifest) — SPEC §9
+ *   30 key_material  bytes(32), optional — a decryption key for OTHER content (Single, Manifest, PaperManifest) — SPEC §9
+ *   31 retain_key    bool, optional, default true — wherever key_material appears — SPEC §9
  *
  * File entry sub-keys (within key 15 elements):
  *   20 slug        text
@@ -54,11 +62,20 @@ import java.util.zip.InflaterInputStream
  *   23 paper_id    bytes(8), optional
  *   26 lat         float64, optional — latitude of the related paper
  *   27 lng         float64, optional — longitude of the related paper
+ *   30 key_material bytes(32), optional — decryption key for the related paper — SPEC §9
+ *   31 retain_key   bool, optional, default true — SPEC §9
  */
 object TagDropCodec {
 
     const val COMPRESSION_NONE    = 0
     const val COMPRESSION_DEFLATE = 1
+
+    const val ENCRYPTION_NONE      = 0
+    const val ENCRYPTION_AES256GCM = 1
+
+    private const val AES_KEY_BYTES   = 32
+    private const val GCM_NONCE_BYTES = 12
+    private const val GCM_TAG_BITS    = 128
 
     /** Encoded URI length that reliably fits in one QR code (CreateActivity/CreatePaperActivity warn past this). */
     const val MAX_URI_LENGTH = 2000
@@ -106,6 +123,10 @@ object TagDropCodec {
     // K_ICON_IMAGE = 25 — reserved for a future small embedded image icon (bytes)
     private const val K_LAT         = 26
     private const val K_LNG         = 27
+    private const val K_ENCRYPTION    = 28
+    private const val K_NONCE         = 29
+    private const val K_KEY_MATERIAL  = 30
+    private const val K_RETAIN_KEY    = 31
 
     // ── Content addressing (IPFS-inspired) ───────────────────────────────────
 
@@ -121,30 +142,126 @@ object TagDropCodec {
     fun rootHashOf(paperManifestCbor: ByteArray): ByteArray =
         MessageDigest.getInstance("SHA-256").digest(paperManifestCbor).copyOf(8)
 
+    /**
+     * 8 random bytes — `cache_id` for encrypted content (SPEC §9). Encrypted content
+     * uses a random ID rather than [contentId] so the ID itself can't be used as a
+     * content-equality oracle against a known plaintext.
+     */
+    fun randomCacheId(): ByteArray = ByteArray(8).also { SecureRandom().nextBytes(it) }
+
+    // ── Encryption (SPEC §9) ──────────────────────────────────────────────────
+
+    /** Generates a fresh 32-byte AES-256-GCM key (`key_material`, SPEC §9). */
+    fun generateKeyMaterial(): ByteArray = ByteArray(AES_KEY_BYTES).also { SecureRandom().nextBytes(it) }
+
+    /** Generates a fresh 12-byte AES-GCM nonce. MUST be unique per encryption under a given key (SPEC §9). */
+    fun generateNonce(): ByteArray = ByteArray(GCM_NONCE_BYTES).also { SecureRandom().nextBytes(it) }
+
+    /** AES-256-GCM encrypt; returns `ciphertext || 16-byte tag` (SPEC §9). */
+    fun encryptAesGcm(plaintext: ByteArray, key: ByteArray, nonce: ByteArray): ByteArray {
+        require(key.size == AES_KEY_BYTES) { "AES-256-GCM key_material must be $AES_KEY_BYTES bytes" }
+        require(nonce.size == GCM_NONCE_BYTES) { "AES-GCM nonce must be $GCM_NONCE_BYTES bytes" }
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), GCMParameterSpec(GCM_TAG_BITS, nonce))
+        return cipher.doFinal(plaintext)
+    }
+
+    /**
+     * AES-256-GCM decrypt of `ciphertext || tag`. Returns null if [key]/[nonce] don't
+     * authenticate — per SPEC §9 this is the "discovery" match test: a failed auth tag
+     * just means this candidate key doesn't apply to this content, not an error.
+     */
+    fun decryptAesGcm(ciphertextAndTag: ByteArray, key: ByteArray, nonce: ByteArray): ByteArray? {
+        require(key.size == AES_KEY_BYTES) { "AES-256-GCM key_material must be $AES_KEY_BYTES bytes" }
+        require(nonce.size == GCM_NONCE_BYTES) { "AES-GCM nonce must be $GCM_NONCE_BYTES bytes" }
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "AES"), GCMParameterSpec(GCM_TAG_BITS, nonce))
+        return runCatching { cipher.doFinal(ciphertextAndTag) }.getOrNull()
+    }
+
+    /**
+     * Decompresses (and decrypts, if [payload] is encrypted) its content. Returns null
+     * if the content is encrypted and [key] is missing or doesn't authenticate (SPEC §9).
+     */
+    fun resolveContent(payload: TagDropPayload.Single, key: ByteArray? = null): ByteArray? {
+        val raw = if (payload.encryption == ENCRYPTION_AES256GCM) {
+            val nonce = payload.nonce ?: return null
+            val decrypted = key?.let { decryptAesGcm(payload.content, it, nonce) } ?: return null
+            decrypted
+        } else {
+            payload.content
+        }
+        return decompressPayload(raw, payload.compression)
+    }
+
     // ── Factory helpers ───────────────────────────────────────────────────────
 
-    /** Build a Single payload with an auto-computed content-addressed ID. */
+    /**
+     * Build a Single payload with an auto-computed content-addressed ID.
+     *
+     * If [encryptionKey] is given (32 bytes, see [generateKeyMaterial]), the
+     * (possibly-compressed) content is AES-256-GCM encrypted under a fresh nonce
+     * (SPEC §9), `encryption`/`nonce` are set, and `cacheId` is random rather than
+     * content-addressed — see [randomCacheId].
+     */
     fun createSingle(
         hint: String?, filename: String?, mimeType: String,
         rawContent: ByteArray, compress: Boolean = false, collectionId: ByteArray? = null,
-        collectionLabel: String? = null, collectionTag: String? = null, icon: String? = null
+        collectionLabel: String? = null, collectionTag: String? = null, icon: String? = null,
+        encryptionKey: ByteArray? = null
     ): TagDropPayload.Single {
-        val (content, compression) = if (compress) {
+        val (compressed, compression) = if (compress) {
             compress(rawContent) to COMPRESSION_DEFLATE
         } else {
             rawContent to COMPRESSION_NONE
         }
+        val cacheId: ByteArray
+        val content: ByteArray
+        val encryption: Int
+        val nonce: ByteArray?
+        if (encryptionKey != null) {
+            nonce = generateNonce()
+            content = encryptAesGcm(compressed, encryptionKey, nonce)
+            encryption = ENCRYPTION_AES256GCM
+            cacheId = randomCacheId()
+        } else {
+            content = compressed
+            encryption = ENCRYPTION_NONE
+            nonce = null
+            cacheId = contentId(rawContent)
+        }
         return TagDropPayload.Single(
-            cacheId         = contentId(rawContent),
+            cacheId         = cacheId,
             hint            = hint,
             filename        = filename,
             mimeType        = mimeType,
             compression     = compression,
             content         = content,
+            encryption      = encryption,
+            nonce           = nonce,
             collectionId    = collectionId,
             collectionLabel = collectionLabel,
             collectionTag   = collectionTag,
             icon            = icon
+        )
+    }
+
+    /**
+     * Build a "key-only" Single payload (SPEC §9): carries [keyMaterial] for other
+     * content, with no `content`/`mime_type` of its own. `cacheId` is random — there's
+     * no content to address.
+     */
+    fun createKeyCode(keyMaterial: ByteArray, retainKey: Boolean = true, hint: String? = null): TagDropPayload.Single {
+        require(keyMaterial.size == AES_KEY_BYTES) { "key_material must be $AES_KEY_BYTES bytes" }
+        return TagDropPayload.Single(
+            cacheId     = randomCacheId(),
+            hint        = hint,
+            filename    = null,
+            mimeType    = "",
+            compression = COMPRESSION_NONE,
+            content     = ByteArray(0),
+            keyMaterial = keyMaterial,
+            retainKey   = retainKey
         )
     }
 
@@ -159,19 +276,40 @@ object TagDropCodec {
      * of the same content share an ID. The manifest's sha256 covers the assembled
      * (possibly compressed) bytes; chunks split those bytes into equal-sized pieces
      * (the last one may be shorter).
+     *
+     * If [encryptionKey] is given (32 bytes, see [generateKeyMaterial]), the assembled
+     * (possibly-compressed) bytes are AES-256-GCM encrypted under a fresh nonce (SPEC
+     * §9) before being split into chunks, `encryption`/`nonce` are set on the manifest,
+     * `sha256` covers the encrypted bytes, and `cacheId` is random rather than
+     * content-addressed — see [randomCacheId].
      */
     fun createManifestAndChunks(
         hint: String?, filename: String?, mimeType: String,
         rawContent: ByteArray, compress: Boolean = false, chunkCount: Int,
         collectionId: ByteArray? = null, collectionLabel: String? = null,
-        collectionTag: String? = null, icon: String? = null
+        collectionTag: String? = null, icon: String? = null,
+        encryptionKey: ByteArray? = null
     ): Pair<TagDropPayload.Manifest, List<TagDropPayload.Chunk>> {
         require(chunkCount >= 1) { "chunkCount must be >= 1" }
-        val cacheId = contentId(rawContent)
-        val (assembled, compression) = if (compress) {
+        val (compressed, compression) = if (compress) {
             compress(rawContent) to COMPRESSION_DEFLATE
         } else {
             rawContent to COMPRESSION_NONE
+        }
+        val cacheId: ByteArray
+        val assembled: ByteArray
+        val encryption: Int
+        val nonce: ByteArray?
+        if (encryptionKey != null) {
+            nonce = generateNonce()
+            assembled = encryptAesGcm(compressed, encryptionKey, nonce)
+            encryption = ENCRYPTION_AES256GCM
+            cacheId = randomCacheId()
+        } else {
+            assembled = compressed
+            encryption = ENCRYPTION_NONE
+            nonce = null
+            cacheId = contentId(rawContent)
         }
         val totalBytes = assembled.size
         val sha256 = MessageDigest.getInstance("SHA-256").digest(assembled)
@@ -185,6 +323,8 @@ object TagDropCodec {
             chunkCount      = chunkCount,
             totalBytes      = totalBytes,
             sha256          = sha256,
+            encryption      = encryption,
+            nonce           = nonce,
             collectionId    = collectionId,
             collectionLabel = collectionLabel,
             collectionTag   = collectionTag,
@@ -220,19 +360,26 @@ object TagDropCodec {
     }
 
     /** Raw CBOR sequence (envelope + payload) for a Single payload — useful for on-device inspection. */
-    fun singleCbor(payload: TagDropPayload.Single): ByteArray =
-        envelope(TYPE_SINGLE, listOf(
+    fun singleCbor(payload: TagDropPayload.Single): ByteArray {
+        // A key-only code (SPEC §9) omits content/mime_type entirely rather than encoding them empty.
+        val keyOnly = payload.keyMaterial != null && payload.content.isEmpty() && payload.mimeType.isEmpty()
+        return envelope(TYPE_SINGLE, listOf(
             K_CACHE_ID    to payload.cacheId,
             K_HINT        to payload.hint,
             K_FILENAME    to payload.filename,
-            K_MIME        to payload.mimeType,
+            K_MIME        to payload.mimeType.takeIf { !keyOnly },
             K_COMPRESSION to payload.compression.takeIf { it != COMPRESSION_NONE },
-            K_CONTENT     to payload.content,
+            K_CONTENT     to payload.content.takeIf { !keyOnly },
+            K_ENCRYPTION  to payload.encryption.takeIf { it != ENCRYPTION_NONE },
+            K_NONCE       to payload.nonce,
             K_COLLECTION_ID    to payload.collectionId,
             K_COLLECTION_LABEL to payload.collectionLabel,
             K_COLLECTION_TAG   to payload.collectionTag,
-            K_ICON             to payload.icon
+            K_ICON             to payload.icon,
+            K_KEY_MATERIAL to payload.keyMaterial,
+            K_RETAIN_KEY   to false.takeIf { payload.keyMaterial != null && !payload.retainKey }
         ))
+    }
 
     /** Raw CBOR sequence (envelope + payload) for a Manifest payload — useful for on-device inspection. */
     fun manifestCbor(payload: TagDropPayload.Manifest): ByteArray =
@@ -245,10 +392,14 @@ object TagDropCodec {
             K_CHUNK_COUNT to payload.chunkCount,
             K_TOTAL_BYTES to payload.totalBytes,
             K_SHA256      to payload.sha256,
+            K_ENCRYPTION  to payload.encryption.takeIf { it != ENCRYPTION_NONE },
+            K_NONCE       to payload.nonce,
             K_COLLECTION_ID    to payload.collectionId,
             K_COLLECTION_LABEL to payload.collectionLabel,
             K_COLLECTION_TAG   to payload.collectionTag,
-            K_ICON             to payload.icon
+            K_ICON             to payload.icon,
+            K_KEY_MATERIAL to payload.keyMaterial,
+            K_RETAIN_KEY   to false.takeIf { payload.keyMaterial != null && !payload.retainKey }
         ))
 
     /** Raw CBOR sequence (envelope + payload) for a Chunk payload — useful for on-device inspection. */
@@ -293,13 +444,17 @@ object TagDropCodec {
                     K_SLUG     to r.slug,
                     K_PAPER_ID to r.paperId,
                     K_LAT      to r.lat,
-                    K_LNG      to r.lng
+                    K_LNG      to r.lng,
+                    K_KEY_MATERIAL to r.keyMaterial,
+                    K_RETAIN_KEY   to false.takeIf { r.keyMaterial != null && !r.retainKey }
                 ))
             },
             K_COLLECTION_ID    to payload.collectionId,
             K_COLLECTION_LABEL to payload.collectionLabel,
             K_COLLECTION_TAG   to payload.collectionTag,
-            K_ICON             to payload.icon
+            K_ICON             to payload.icon,
+            K_KEY_MATERIAL to payload.keyMaterial,
+            K_RETAIN_KEY   to false.takeIf { payload.keyMaterial != null && !payload.retainKey }
         )
 
     /**
@@ -313,13 +468,15 @@ object TagDropCodec {
         label: String?, set: String?, slug: String?,
         files: List<TagDropPayload.FileEntry>, related: List<TagDropPayload.RelatedPaper> = emptyList(),
         collectionId: ByteArray? = null, collectionLabel: String? = null,
-        collectionTag: String? = null, icon: String? = null
+        collectionTag: String? = null, icon: String? = null,
+        keyMaterial: ByteArray? = null, retainKey: Boolean = true
     ): TagDropPayload.PaperManifest {
         val draft = TagDropPayload.PaperManifest(
             rootHash = ByteArray(8), label = label, set = set, slug = slug,
             files = files, related = related,
             collectionId = collectionId, collectionLabel = collectionLabel,
-            collectionTag = collectionTag, icon = icon
+            collectionTag = collectionTag, icon = icon,
+            keyMaterial = keyMaterial, retainKey = retainKey
         )
         val cborNoHash = envelope(TYPE_PAPER_MANIFEST, paperManifestPairs(draft, rootHash = null))
         return draft.copy(rootHash = rootHashOf(cborNoHash))
@@ -371,9 +528,13 @@ object TagDropCodec {
         cacheId         = m.bytes(K_CACHE_ID),
         hint            = m.text(K_HINT),
         filename        = m.text(K_FILENAME),
-        mimeType        = m.text(K_MIME)!!,
+        mimeType        = m.text(K_MIME) ?: "",
         compression     = m.uint(K_COMPRESSION)?.toInt() ?: COMPRESSION_NONE,
-        content         = m.bytes(K_CONTENT),
+        content         = m.bytesOrNull(K_CONTENT) ?: ByteArray(0),
+        encryption      = m.uint(K_ENCRYPTION)?.toInt() ?: ENCRYPTION_NONE,
+        nonce           = m.bytesOrNull(K_NONCE),
+        keyMaterial     = m.bytesOrNull(K_KEY_MATERIAL),
+        retainKey       = m.boolOrNull(K_RETAIN_KEY) ?: true,
         collectionId    = m.bytesOrNull(K_COLLECTION_ID),
         collectionLabel = m.text(K_COLLECTION_LABEL),
         collectionTag   = m.text(K_COLLECTION_TAG),
@@ -389,6 +550,10 @@ object TagDropCodec {
         chunkCount      = m.uint(K_CHUNK_COUNT)!!.toInt(),
         totalBytes      = m.uint(K_TOTAL_BYTES)!!.toInt(),
         sha256          = m.bytes(K_SHA256),
+        encryption      = m.uint(K_ENCRYPTION)?.toInt() ?: ENCRYPTION_NONE,
+        nonce           = m.bytesOrNull(K_NONCE),
+        keyMaterial     = m.bytesOrNull(K_KEY_MATERIAL),
+        retainKey       = m.boolOrNull(K_RETAIN_KEY) ?: true,
         collectionId    = m.bytesOrNull(K_COLLECTION_ID),
         collectionLabel = m.text(K_COLLECTION_LABEL),
         collectionTag   = m.text(K_COLLECTION_TAG),
@@ -415,12 +580,14 @@ object TagDropCodec {
         val related = (m[K_RELATED] as? List<*>)?.mapNotNull { entry ->
             val em = entry as? Map<Int, Any> ?: return@mapNotNull null
             TagDropPayload.RelatedPaper(
-                hint    = em.text(K_HINT) ?: return@mapNotNull null,
-                set     = em.text(K_SET),
-                slug    = em.text(K_SLUG),
-                paperId = em[K_PAPER_ID] as? ByteArray,
-                lat     = em.doubleOrNull(K_LAT),
-                lng     = em.doubleOrNull(K_LNG)
+                hint        = em.text(K_HINT) ?: return@mapNotNull null,
+                set         = em.text(K_SET),
+                slug        = em.text(K_SLUG),
+                paperId     = em[K_PAPER_ID] as? ByteArray,
+                lat         = em.doubleOrNull(K_LAT),
+                lng         = em.doubleOrNull(K_LNG),
+                keyMaterial = em.bytesOrNull(K_KEY_MATERIAL),
+                retainKey   = em.boolOrNull(K_RETAIN_KEY) ?: true
             )
         } ?: emptyList()
 
@@ -434,7 +601,9 @@ object TagDropCodec {
             collectionId    = m.bytesOrNull(K_COLLECTION_ID),
             collectionLabel = m.text(K_COLLECTION_LABEL),
             collectionTag   = m.text(K_COLLECTION_TAG),
-            icon            = m.text(K_ICON)
+            icon            = m.text(K_ICON),
+            keyMaterial     = m.bytesOrNull(K_KEY_MATERIAL),
+            retainKey       = m.boolOrNull(K_RETAIN_KEY) ?: true
         )
     }
 
@@ -469,6 +638,8 @@ object TagDropCodec {
 
     private fun Map<Int, Any>.doubleOrNull(key: Int): Double? = get(key) as? Double
 
+    private fun Map<Int, Any>.boolOrNull(key: Int): Boolean? = get(key) as? Boolean
+
     // ── Debug ─────────────────────────────────────────────────────────────────
 
     /** Human-readable names for TagDrop's CBOR payload-map integer keys, used by [describeCbor]. */
@@ -481,7 +652,9 @@ object TagDropCodec {
         K_COLLECTION_ID to "collection_id", K_COLLECTION_LABEL to "collection_label",
         K_COLLECTION_TAG to "collection_tag", K_FILE_SLUG to "slug", K_FILE_MIME to "mime_type",
         K_FILE_ID to "file_id", K_PAPER_ID to "paper_id", K_ICON to "icon",
-        K_LAT to "lat", K_LNG to "lng"
+        K_LAT to "lat", K_LNG to "lng",
+        K_ENCRYPTION to "encryption", K_NONCE to "nonce",
+        K_KEY_MATERIAL to "key_material", K_RETAIN_KEY to "retain_key"
     )
 
     /** Human-readable names for the envelope's `type` values, used by [describeCbor]. */

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
@@ -19,12 +19,16 @@ sealed class TagDropPayload {
 
     /** Complete cache encoded in a single QR. */
     data class Single(
-        val cacheId: ByteArray,   // SHA-256(uncompressed content)[0:8] — content-addressed
+        val cacheId: ByteArray,   // SHA-256(uncompressed content)[0:8] — content-addressed; random if encrypted (SPEC §9)
         val hint: String?,
         val filename: String?,
-        val mimeType: String,
+        val mimeType: String,     // empty for a key-only code (SPEC §9)
         val compression: Int,     // 0 = none, 1 = deflate
-        val content: ByteArray,   // raw (possibly compressed) payload bytes
+        val content: ByteArray,   // raw (possibly compressed+encrypted) payload bytes; empty for a key-only code
+        val encryption: Int = 0,                // 0 = none, 1 = AES-256-GCM (SPEC §9)
+        val nonce: ByteArray? = null,           // 12-byte AES-GCM nonce, present iff encryption != 0 (SPEC §9)
+        val keyMaterial: ByteArray? = null,     // optional — a decryption key for OTHER content (SPEC §9)
+        val retainKey: Boolean = true,          // recommendation for whether keyMaterial should be remembered (SPEC §9)
         val collectionId: ByteArray? = null,    // optional — groups related QR codes (see SPEC §7)
         val collectionLabel: String? = null,    // optional — human-readable name for the collection
         val collectionTag: String? = null,      // optional — hashtag-style cross-collection tag
@@ -39,14 +43,18 @@ sealed class TagDropPayload {
      * Designed for geographic distribution: each chunk can be at a different location.
      */
     data class Manifest(
-        val cacheId: ByteArray,   // SHA-256(uncompressed content)[0:8]
+        val cacheId: ByteArray,   // SHA-256(uncompressed content)[0:8]; random if encrypted (SPEC §9)
         val hint: String?,
         val filename: String?,
         val mimeType: String,
         val compression: Int,
         val chunkCount: Int,
         val totalBytes: Int,
-        val sha256: ByteArray,    // SHA-256 of the assembled (uncompressed) content
+        val sha256: ByteArray,    // SHA-256 of the assembled, compressed AND encrypted bytes (SPEC §9)
+        val encryption: Int = 0,                // 0 = none, 1 = AES-256-GCM (SPEC §9)
+        val nonce: ByteArray? = null,           // 12-byte AES-GCM nonce, present iff encryption != 0 (SPEC §9)
+        val keyMaterial: ByteArray? = null,     // optional — a decryption key for OTHER content (SPEC §9)
+        val retainKey: Boolean = true,          // recommendation for whether keyMaterial should be remembered (SPEC §9)
         val collectionId: ByteArray? = null,    // optional — groups related QR codes (see SPEC §7)
         val collectionLabel: String? = null,    // optional — human-readable name for the collection
         val collectionTag: String? = null,      // optional — hashtag-style cross-collection tag
@@ -83,7 +91,9 @@ sealed class TagDropPayload {
         val slug: String?   = null,    // that paper's address within the set
         val paperId: ByteArray? = null,// root hash of that paper, if pre-computed
         val lat: Double? = null,       // latitude of the related paper, if known
-        val lng: Double? = null        // longitude of the related paper, if known
+        val lng: Double? = null,       // longitude of the related paper, if known
+        val keyMaterial: ByteArray? = null,  // optional — a decryption key for the related paper (SPEC §9)
+        val retainKey: Boolean = true        // recommendation for whether keyMaterial should be remembered (SPEC §9)
     ) {
         override fun equals(other: Any?) = other is RelatedPaper && hint == other.hint
         override fun hashCode() = hint.hashCode()
@@ -111,7 +121,9 @@ sealed class TagDropPayload {
         val collectionId: ByteArray? = null,    // optional — groups related QR codes (see SPEC §7)
         val collectionLabel: String? = null,    // optional — human-readable name for the collection
         val collectionTag: String? = null,      // optional — hashtag-style cross-collection tag
-        val icon: String? = null                // optional — emoji icon for this page/collection
+        val icon: String? = null,               // optional — emoji icon for this page/collection
+        val keyMaterial: ByteArray? = null,     // optional — a decryption key for OTHER content (SPEC §9)
+        val retainKey: Boolean = true           // recommendation for whether keyMaterial should be remembered (SPEC §9)
     ) : TagDropPayload() {
         override fun equals(other: Any?) = other is PaperManifest && rootHash.contentEquals(other.rootHash)
         override fun hashCode() = rootHash.contentHashCode()

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/ChunkAssemblerTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/ChunkAssemblerTest.kt
@@ -179,4 +179,100 @@ class ChunkAssemblerTest {
         // ChunkAssembler decompresses internally; content should be the raw bytes
         assertArrayEquals(raw, state.content)
     }
+
+    // ── Encryption (SPEC §9) ──────────────────────────────────────────────────
+
+    private fun encryptedManifest(cacheId: ByteArray, ciphertext: ByteArray, nonce: ByteArray, chunkCount: Int) =
+        TagDropPayload.Manifest(
+            cacheId     = cacheId,
+            hint        = "test hint",
+            filename    = "secret.txt",
+            mimeType    = "text/plain",
+            compression = TagDropCodec.COMPRESSION_NONE,
+            chunkCount  = chunkCount,
+            totalBytes  = ciphertext.size,
+            sha256      = sha256(ciphertext),
+            encryption  = TagDropCodec.ENCRYPTION_AES256GCM,
+            nonce       = nonce
+        )
+
+    @Test fun encryptedManifestAwaitsKeyOnceChunksComplete() {
+        val key       = TagDropCodec.generateKeyMaterial()
+        val nonce     = TagDropCodec.generateNonce()
+        val content   = "secret trail notes".toByteArray()
+        val ciphertext = TagDropCodec.encryptAesGcm(content, key, nonce)
+        val cacheId   = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+        val parts     = chunks(cacheId, ciphertext, 8)
+
+        val a = ChunkAssembler()
+        a.add(encryptedManifest(cacheId, ciphertext, nonce, parts.size))
+        for (chunk in parts.dropLast(1)) {
+            assertTrue(a.add(chunk) is ChunkAssembler.State.Collecting)
+        }
+
+        val final = a.add(parts.last())
+        assertTrue(final is ChunkAssembler.State.AwaitingKey)
+        assertArrayEquals(cacheId, (final as ChunkAssembler.State.AwaitingKey).cacheId)
+        assertArrayEquals(nonce, final.nonce)
+    }
+
+    @Test fun tryKeyWithWrongKeyStaysAwaitingKey() {
+        val key        = TagDropCodec.generateKeyMaterial()
+        val wrongKey   = TagDropCodec.generateKeyMaterial()
+        val nonce      = TagDropCodec.generateNonce()
+        val content    = "secret trail notes".toByteArray()
+        val ciphertext = TagDropCodec.encryptAesGcm(content, key, nonce)
+        val cacheId    = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+        val parts      = chunks(cacheId, ciphertext, 8)
+
+        val a = ChunkAssembler()
+        a.add(encryptedManifest(cacheId, ciphertext, nonce, parts.size))
+        parts.forEach { a.add(it) }
+        assertTrue(a.currentState() is ChunkAssembler.State.AwaitingKey)
+
+        assertTrue(a.tryKey(wrongKey) is ChunkAssembler.State.AwaitingKey)
+    }
+
+    @Test fun tryKeyWithCorrectKeyResolvesToComplete() {
+        val key        = TagDropCodec.generateKeyMaterial()
+        val nonce      = TagDropCodec.generateNonce()
+        val content    = "secret trail notes".toByteArray()
+        val ciphertext = TagDropCodec.encryptAesGcm(content, key, nonce)
+        val cacheId    = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+        val parts      = chunks(cacheId, ciphertext, 8)
+
+        val a = ChunkAssembler()
+        a.add(encryptedManifest(cacheId, ciphertext, nonce, parts.size))
+        parts.forEach { a.add(it) }
+
+        val state = a.tryKey(key)
+        assertTrue(state is ChunkAssembler.State.Complete)
+        assertArrayEquals(content, (state as ChunkAssembler.State.Complete).content)
+        assertEquals("test hint", state.hint)
+        assertEquals("secret.txt", state.filename)
+    }
+
+    @Test fun tryKeyBeforeChunksCompleteHasNoEffectButOrderIsIndependent() {
+        val key        = TagDropCodec.generateKeyMaterial()
+        val nonce      = TagDropCodec.generateNonce()
+        val content    = "secret trail notes".toByteArray()
+        val ciphertext = TagDropCodec.encryptAesGcm(content, key, nonce)
+        val cacheId    = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+        val parts      = chunks(cacheId, ciphertext, 8)
+
+        val a = ChunkAssembler()
+        a.add(encryptedManifest(cacheId, ciphertext, nonce, parts.size))
+
+        // The key can be scanned before all chunks have arrived — trying it then
+        // has no effect yet (nothing to decrypt), but isn't an error either.
+        assertTrue(a.tryKey(key) is ChunkAssembler.State.Collecting)
+
+        parts.forEach { a.add(it) }
+        assertTrue(a.currentState() is ChunkAssembler.State.AwaitingKey)
+
+        // Trying the same key again now that chunks are complete resolves it.
+        val state = a.tryKey(key)
+        assertTrue(state is ChunkAssembler.State.Complete)
+        assertArrayEquals(content, (state as ChunkAssembler.State.Complete).content)
+    }
 }

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropCodecTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropCodecTest.kt
@@ -674,4 +674,169 @@ class TagDropCodecTest {
         val compressed = TagDropCodec.compress(original)
         assertArrayEquals(original, TagDropCodec.decompressPayload(compressed, TagDropCodec.COMPRESSION_DEFLATE))
     }
+
+    // ── Encryption (SPEC §9) ──────────────────────────────────────────────────
+
+    @Test fun encryptAesGcmRoundTrip() {
+        val key = TagDropCodec.generateKeyMaterial()
+        val nonce = TagDropCodec.generateNonce()
+        assertEquals(32, key.size)
+        assertEquals(12, nonce.size)
+
+        val plaintext = "secret message".toByteArray()
+        val ciphertext = TagDropCodec.encryptAesGcm(plaintext, key, nonce)
+        assertArrayEquals(plaintext, TagDropCodec.decryptAesGcm(ciphertext, key, nonce))
+    }
+
+    @Test fun decryptAesGcmWrongKeyReturnsNull() {
+        val key = TagDropCodec.generateKeyMaterial()
+        val wrongKey = TagDropCodec.generateKeyMaterial()
+        val nonce = TagDropCodec.generateNonce()
+        val ciphertext = TagDropCodec.encryptAesGcm("secret".toByteArray(), key, nonce)
+        assertNull(TagDropCodec.decryptAesGcm(ciphertext, wrongKey, nonce))
+    }
+
+    @Test fun decryptAesGcmWrongNonceReturnsNull() {
+        val key = TagDropCodec.generateKeyMaterial()
+        val nonce = TagDropCodec.generateNonce()
+        val wrongNonce = TagDropCodec.generateNonce()
+        val ciphertext = TagDropCodec.encryptAesGcm("secret".toByteArray(), key, nonce)
+        assertNull(TagDropCodec.decryptAesGcm(ciphertext, key, wrongNonce))
+    }
+
+    @Test fun createSingleUnencryptedHasNoEncryptionFields() {
+        val content = "plain content".toByteArray()
+        val payload = TagDropCodec.createSingle(null, null, "text/plain", content)
+        assertEquals(TagDropCodec.ENCRYPTION_NONE, payload.encryption)
+        assertNull(payload.nonce)
+        assertArrayEquals(TagDropCodec.contentId(content), payload.cacheId)
+
+        val decoded = TagDropCodec.decode(TagDropCodec.encode(payload)) as TagDropPayload.Single
+        assertEquals(TagDropCodec.ENCRYPTION_NONE, decoded.encryption)
+        assertNull(decoded.nonce)
+        assertNull(decoded.keyMaterial)
+    }
+
+    @Test fun createSingleEncryptedRoundTrip() {
+        val key = TagDropCodec.generateKeyMaterial()
+        val content = "Hello, encrypted TagDrop!".toByteArray()
+        val payload = TagDropCodec.createSingle(null, null, "text/plain", content, encryptionKey = key)
+
+        assertEquals(TagDropCodec.ENCRYPTION_AES256GCM, payload.encryption)
+        assertEquals(12, payload.nonce?.size)
+        // Encrypted content uses a random cache_id, not a content-addressed one (SPEC §9).
+        assertFalse(payload.cacheId.contentEquals(TagDropCodec.contentId(content)))
+
+        val decoded = TagDropCodec.decode(TagDropCodec.encode(payload)) as TagDropPayload.Single
+        assertEquals(TagDropCodec.ENCRYPTION_AES256GCM, decoded.encryption)
+        assertArrayEquals(payload.nonce, decoded.nonce)
+        assertArrayEquals(payload.cacheId, decoded.cacheId)
+        assertArrayEquals(payload.content, decoded.content)
+
+        assertArrayEquals(content, TagDropCodec.resolveContent(decoded, key))
+        assertNull(TagDropCodec.resolveContent(decoded, TagDropCodec.generateKeyMaterial()))
+        assertNull(TagDropCodec.resolveContent(decoded, null))
+    }
+
+    @Test fun createSingleEncryptedWithCompression() {
+        val key = TagDropCodec.generateKeyMaterial()
+        val content = "<html><body>Hello!</body></html>".repeat(20).toByteArray()
+        val payload = TagDropCodec.createSingle(null, null, "text/html", content, compress = true, encryptionKey = key)
+        assertEquals(TagDropCodec.COMPRESSION_DEFLATE, payload.compression)
+
+        val decoded = TagDropCodec.decode(TagDropCodec.encode(payload)) as TagDropPayload.Single
+        assertArrayEquals(content, TagDropCodec.resolveContent(decoded, key))
+    }
+
+    // ── createKeyCode factory ─────────────────────────────────────────────────
+
+    @Test fun createKeyCodeRoundTrip() {
+        val key = TagDropCodec.generateKeyMaterial()
+        val payload = TagDropCodec.createKeyCode(key, hint = "key for the trailhead box")
+        assertEquals("", payload.mimeType)
+        assertTrue(payload.content.isEmpty())
+        assertEquals(8, payload.cacheId.size)
+
+        val decoded = TagDropCodec.decode(TagDropCodec.encode(payload)) as TagDropPayload.Single
+        assertArrayEquals(key, decoded.keyMaterial)
+        assertEquals("key for the trailhead box", decoded.hint)
+        assertEquals("", decoded.mimeType)
+        assertTrue(decoded.content.isEmpty())
+        assertTrue(decoded.retainKey)
+    }
+
+    @Test fun createKeyCodeOmitsMimeAndContentFromCbor() {
+        val payload = TagDropCodec.createKeyCode(TagDropCodec.generateKeyMaterial())
+        val cbor = TagDropCodec.singleCbor(payload)
+        val items = MiniCbor.decodeSequence(cbor)
+        @Suppress("UNCHECKED_CAST")
+        val map = items[2] as Map<Int, Any>
+        assertFalse("mime_type (4) should be omitted for key-only codes", map.containsKey(4))
+        assertFalse("content (5) should be omitted for key-only codes", map.containsKey(5))
+        assertTrue("key_material (30) should be present", map.containsKey(30))
+    }
+
+    @Test fun createKeyCodeWithRetainKeyFalse() {
+        val key = TagDropCodec.generateKeyMaterial()
+        val payload = TagDropCodec.createKeyCode(key, retainKey = false)
+        val decoded = TagDropCodec.decode(TagDropCodec.encode(payload)) as TagDropPayload.Single
+        assertFalse(decoded.retainKey)
+    }
+
+    @Test fun retainKeyDefaultTrueOmittedFromCbor() {
+        val payload = TagDropCodec.createKeyCode(TagDropCodec.generateKeyMaterial())  // retainKey = true (default)
+        val cbor = TagDropCodec.singleCbor(payload)
+        val items = MiniCbor.decodeSequence(cbor)
+        @Suppress("UNCHECKED_CAST")
+        val map = items[2] as Map<Int, Any>
+        assertFalse("retain_key (31) defaults to true and should be omitted", map.containsKey(31))
+    }
+
+    // ── createManifestAndChunks with encryption ──────────────────────────────
+
+    @Test fun createManifestAndChunksWithEncryptionUsesRandomCacheId() {
+        val key = TagDropCodec.generateKeyMaterial()
+        val content = "Hello, TagDrop!".repeat(200).toByteArray()
+        val (manifest, _) = TagDropCodec.createManifestAndChunks(
+            null, null, "text/plain", content, chunkCount = 3, encryptionKey = key
+        )
+        assertEquals(TagDropCodec.ENCRYPTION_AES256GCM, manifest.encryption)
+        assertEquals(12, manifest.nonce?.size)
+        assertFalse(manifest.cacheId.contentEquals(TagDropCodec.contentId(content)))
+    }
+
+    @Test fun createManifestAndChunksWithEncryptionRoundTripViaChunkAssembler() {
+        val key = TagDropCodec.generateKeyMaterial()
+        val content = "The quick brown fox jumps over the lazy dog. ".repeat(100).toByteArray()
+        val (manifest, chunks) = TagDropCodec.createManifestAndChunks(
+            "hint", "fox.txt", "text/plain", content, compress = true,
+            chunkCount = TagDropCodec.chunkCountForBytes(TagDropCodec.compress(content).size),
+            encryptionKey = key
+        )
+        assertEquals(TagDropCodec.COMPRESSION_DEFLATE, manifest.compression)
+        assertEquals(TagDropCodec.ENCRYPTION_AES256GCM, manifest.encryption)
+
+        // Round-trip every piece through encode/decode, like a real scan would.
+        val decodedManifest = TagDropCodec.decode(TagDropCodec.encode(manifest)) as TagDropPayload.Manifest
+        val decodedChunks = chunks.map { TagDropCodec.decode(TagDropCodec.encode(it)) as TagDropPayload.Chunk }
+
+        val assembler = ChunkAssembler()
+        assembler.add(decodedManifest)
+        decodedChunks.shuffled(java.util.Random(42)).forEach { assembler.add(it) }
+
+        // All chunks present and hash-verified, but content is still encrypted.
+        val awaiting = assembler.currentState()
+        assertTrue(awaiting is ChunkAssembler.State.AwaitingKey)
+        assertArrayEquals(manifest.nonce, (awaiting as ChunkAssembler.State.AwaitingKey).nonce)
+
+        // A non-matching key leaves the state unchanged (SPEC §9 "discovery, not declaration").
+        assertTrue(assembler.tryKey(TagDropCodec.generateKeyMaterial()) is ChunkAssembler.State.AwaitingKey)
+
+        // The correct key resolves to the original, decompressed content.
+        val complete = assembler.tryKey(key)
+        assertTrue(complete is ChunkAssembler.State.Complete)
+        assertArrayEquals(content, (complete as ChunkAssembler.State.Complete).content)
+        assertEquals("hint", complete.hint)
+        assertEquals("fox.txt", complete.filename)
+    }
 }

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,12 @@ immediately, with no internet connection, server, or account required.
 Think of it as a **digital geocache**: instead of a logbook in a box, the
 "cache" is the QR code itself.
 
+The name and offline, anonymous, leave-it-in-the-wild spirit are inspired by
+[Dead Drops](https://deaddrops.com/) (Aram Bartholl, 2010) — an ongoing
+project embedding USB drives in public walls for anonymous offline file
+sharing. TagDrop applies the same idea to printed QR codes: no device,
+network, or account needed to read or write a drop.
+
 <img src="docs/example-qr.png" alt="Example TagDrop QR code encoding a short text message" width="200">
 
 *A real TagDrop code — scan it with the app or the

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,10 @@ QR scanner that follows `tagdrop:` links) can scan it and view the content
 immediately, with no internet connection, server, or account required.
 
 Think of it as a **digital geocache**: instead of a logbook in a box, the
-"cache" is the QR code itself.
+"cache" is the QR code itself. [Geocaching](https://www.geocaching.com/)
+(since 2000) was the original inspiration — hide a "cache," let people find
+and log it — TagDrop just swaps the physical container and logbook for a
+printed code and on-screen content.
 
 The name and offline, anonymous, leave-it-in-the-wild spirit are inspired by
 [Dead Drops](https://deaddrops.com/) (Aram Bartholl, 2010) — an ongoing

--- a/tools/examples/index.html
+++ b/tools/examples/index.html
@@ -45,6 +45,8 @@
     border-radius: 12px; font-size: 0.7rem; background: #e8eaf6; color: #3949ab;
   }
   .qr-card .qr-badge.compress { background: #e8f5e9; color: #2e7d32; }
+  .qr-card .qr-badge.encrypted { background: #fce4ec; color: #ad1457; }
+  .qr-card .qr-badge.key        { background: #fff3e0; color: #e65100; }
   .qr-card .qr-id   { font-family: monospace; font-size: 0.65rem; color: #aaa; margin-top: 4px; word-break: break-all; }
   .qr-card .qr-uri  { margin-top: 8px; width: 100%; }
   .qr-card .qr-uri input {
@@ -97,6 +99,20 @@
       Scan any one with the <a href="../reader/index.html">web reader</a> or the Android app.
     </p>
     <div class="qr-grid" id="standalone-grid"></div>
+  </section>
+
+  <section id="sec-encrypted">
+    <h2>Encrypted Content (SPEC §9)</h2>
+    <p class="section-desc">
+      AES-256-GCM encrypted content, plus a separate <strong>key code</strong>.
+      Scan either one first — the reader hash-verifies the content code right away but
+      keeps it locked until the key code is also scanned (in either order), per SPEC §9's
+      "discovery, not declaration": no field declares which content a key unlocks, so the
+      reader tries it by trial decryption. The content code's <code>cache_id</code> is
+      random rather than content-addressed, so it can't be used as a content-equality oracle.
+    </p>
+    <div class="paper-info" id="encryption-info"></div>
+    <div class="qr-grid" id="encryption-grid"></div>
   </section>
 
   <section id="sec-multi">
@@ -189,6 +205,7 @@ function cfloat(v) { return { __float64: true, value: v }; }
 function cborValue(out, v) {
   if (v === null || v === undefined) return;
   if (v && v.__float64) { cborFloat64(out, v.value); }
+  else if (typeof v === 'boolean') { out.push(v ? 0xF5 : 0xF4); } // true (0xf5) / false (0xf4)
   else if (typeof v === 'number') { writeHead(out, 0, v); }
   else if (v instanceof Uint8Array) { writeHead(out, 2, v.length); v.forEach(b => out.push(b)); }
   else if (typeof v === 'string') {
@@ -267,13 +284,42 @@ const K = { CACHE_ID:2, HINT:3, MIME:4, CONTENT:5,
             FILENAME:11, COMPRESSION:12, SET:13, SLUG:14, FILES:15, RELATED:16,
             COLLECTION_ID:17, COLLECTION_LABEL:18, COLLECTION_TAG:19,
             FILE_SLUG:20, FILE_MIME:21, FILE_ID:22, PAPER_ID:23, ICON:24,
-            LAT:26, LNG:27 };
+            LAT:26, LNG:27,
+            ENCRYPTION:28, NONCE:29, KEY_MATERIAL:30, RETAIN_KEY:31 };
+
+// ── Encryption (SPEC §9) ────────────────────────────────────────────────────
+function generateKeyMaterial() { return crypto.getRandomValues(new Uint8Array(32)); }
+function generateNonce() { return crypto.getRandomValues(new Uint8Array(12)); }
+
+// 8 random bytes — cache_id for encrypted content (SPEC §9): random rather than
+// content-addressed, so the ID itself can't be used as a content-equality oracle.
+function randomCacheId() { return crypto.getRandomValues(new Uint8Array(8)); }
+
+// AES-256-GCM encrypt; returns ciphertext || 16-byte tag (SPEC §9).
+async function encryptAesGcm(plaintext, key, nonce) {
+  const cryptoKey = await crypto.subtle.importKey('raw', key, 'AES-GCM', false, ['encrypt']);
+  return new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv: nonce }, cryptoKey, plaintext));
+}
 
 // ── Encoding ──────────────────────────────────────────────────────────────
-async function encodeSingle({ hint, filename, mimeType, rawBytes, compress }) {
+/**
+ * If encryptionKey is given (32 bytes), the (possibly-compressed) content is
+ * AES-256-GCM encrypted under a fresh nonce (or the given one, for reproducible
+ * examples), encryption/nonce are set, and cache_id is random rather than
+ * content-addressed (SPEC §9).
+ */
+async function encodeSingle({ hint, filename, mimeType, rawBytes, compress, encryptionKey, nonce }) {
   let content = rawBytes, compression = null;
   if (compress) { content = await zlibCompress(rawBytes); compression = 1; }
-  const cacheId = await sha256first8(rawBytes);
+  let cacheId, encryption = null, usedNonce = null;
+  if (encryptionKey) {
+    usedNonce = nonce || generateNonce();
+    content = await encryptAesGcm(content, encryptionKey, usedNonce);
+    encryption = 1;
+    cacheId = randomCacheId();
+  } else {
+    cacheId = await sha256first8(rawBytes);
+  }
   const payload = cborMap([
     [K.CACHE_ID,    cacheId],
     [K.HINT,        hint || null],
@@ -281,6 +327,26 @@ async function encodeSingle({ hint, filename, mimeType, rawBytes, compress }) {
     [K.MIME,        mimeType],
     [K.COMPRESSION, compression],
     [K.CONTENT,     content],
+    [K.ENCRYPTION,  encryption],
+    [K.NONCE,       usedNonce],
+  ]);
+  return { uri: 'tagdrop:' + base45Encode(cborSequence(TYPE_SINGLE, payload)), cacheId, encryption, nonce: usedNonce };
+}
+
+/**
+ * Builds a "key-only" Single payload (SPEC §9): carries keyMaterial for other
+ * content, with no content/mime_type of its own. cache_id is random — there's
+ * no content to address. Per SPEC §9's "discovery, not declaration", no field
+ * says which content this key unlocks — a reader tries it against any encrypted
+ * content it has cached.
+ */
+function encodeKeyCode({ keyMaterial, hint, retainKey }) {
+  const cacheId = randomCacheId();
+  const payload = cborMap([
+    [K.CACHE_ID,     cacheId],
+    [K.HINT,         hint || null],
+    [K.KEY_MATERIAL, keyMaterial],
+    [K.RETAIN_KEY,   retainKey === false ? false : null],
   ]);
   return { uri: 'tagdrop:' + base45Encode(cborSequence(TYPE_SINGLE, payload)), cacheId };
 }
@@ -439,6 +505,27 @@ h1{color:#1a1a2e}code{background:#f0f0f0;padding:2px 6px;border-radius:3px}
     }, null, 2),
   },
 ];
+
+// Encrypted content (SPEC §9) — AES-256-GCM. The key/nonce are generated fresh
+// on each page load (see main()), so the two QR codes below differ between
+// reloads but always pair correctly with each other.
+const ENCRYPTED_EXAMPLE = {
+  label: 'Encrypted note',
+  mimeType: 'text/plain',
+  compress: false,
+  hint: 'Encrypted — scan the key code too',
+  keyHint: 'Key for "Encrypted note"',
+  filename: 'secret.txt',
+  content:
+`This message is encrypted with AES-256-GCM (SPEC §9).
+
+If you're reading this in the TagDrop app or web reader, you scanned both
+this content code and its separate key code — in either order — and the
+reader matched them by trial decryption ("discovery, not declaration").
+
+The cache_id on this code is random, not derived from this content, so it
+can't be used to test whether you already have a copy of this message.`,
+};
 
 // Content too large for a single QR (~800 bytes recommended max) — split into
 // a Manifest (type=1) plus several Chunks (type=2) per SPEC.md §4.2-4.3.
@@ -815,13 +902,13 @@ async function renderQr(container, uri) {
 // ── Card rendering ────────────────────────────────────────────────────────
 const messages = document.getElementById('page-messages');
 
-async function addCard(grid, { label, mime, extraBadge, id, uri, isManifest }) {
+async function addCard(grid, { label, mime, extraBadge, badgeClass, id, uri, isManifest }) {
   const div = document.createElement('div');
   div.className = 'qr-card' + (isManifest ? ' manifest' : '');
   const qrSlot = document.createElement('div');
   div.appendChild(qrSlot);
   const mimeBadge = `<span class="qr-badge">${escHtml(mime)}</span>`;
-  const extra = extraBadge ? ` <span class="qr-badge compress">${escHtml(extraBadge)}</span>` : '';
+  const extra = extraBadge ? ` <span class="qr-badge ${badgeClass || 'compress'}">${escHtml(extraBadge)}</span>` : '';
   div.insertAdjacentHTML('beforeend', `
     <div class="qr-label">${escHtml(label)}</div>
     <div>${mimeBadge}${extra}</div>
@@ -869,6 +956,34 @@ async function main() {
       isManifest: false,
     });
   }
+
+  // Encrypted content + key code (SPEC §9)
+  const ee = ENCRYPTED_EXAMPLE;
+  const eeRawBytes = new TextEncoder().encode(ee.content);
+  const eeKey = generateKeyMaterial();
+  const eeEncoded = await encodeSingle({
+    hint: ee.hint, filename: ee.filename, mimeType: ee.mimeType,
+    rawBytes: eeRawBytes, compress: ee.compress, encryptionKey: eeKey,
+  });
+  const eeKeyCode = encodeKeyCode({ keyMaterial: eeKey, hint: ee.keyHint });
+
+  document.getElementById('encryption-info').innerHTML = `
+    <strong>${escHtml(ee.label)}</strong>
+    — ${escHtml(ee.mimeType)}, AES-256-GCM encrypted<br>
+    Cache ID: <code>${toHex(eeEncoded.cacheId)}</code> (random — not content-addressed)<br>
+    Nonce: <code>${toHex(eeEncoded.nonce)}</code>
+    <div class="step">① Scan the <strong>content</strong> code — it hash-verifies but stays locked ("awaiting key").</div>
+    <div class="step">② Scan the <strong>key</strong> code, in any order. The reader tries it against cached ciphertext and unlocks a match.</div>`;
+
+  const encryptionGrid = document.getElementById('encryption-grid');
+  await addCard(encryptionGrid, {
+    label: ee.label, mime: ee.mimeType, extraBadge: 'encrypted', badgeClass: 'encrypted',
+    id: toHex(eeEncoded.cacheId), uri: eeEncoded.uri, isManifest: false,
+  });
+  await addCard(encryptionGrid, {
+    label: 'Key code', mime: 'key_material', extraBadge: 'key', badgeClass: 'key',
+    id: toHex(eeKeyCode.cacheId), uri: eeKeyCode.uri, isManifest: false,
+  });
 
   // Multi-code cache: Manifest + Chunks
   const mc = MULTI_CHUNK_EXAMPLE;

--- a/tools/generator/index.html
+++ b/tools/generator/index.html
@@ -62,6 +62,13 @@
   .qr-label { font-weight: 600; font-size: 0.9rem; word-break: break-all; }
   .qr-sub   { font-size: 0.75rem; color: #888; margin-top: 2px; }
   .qr-id    { font-family: monospace; font-size: 0.7rem; color: #aaa; margin-top: 4px; }
+  .qr-badge {
+    display: inline-block; margin: 2px 0; padding: 2px 8px;
+    border-radius: 12px; font-size: 0.7rem; background: #e8eaf6; color: #3949ab;
+  }
+  .qr-badge.encrypted { background: #fce4ec; color: #ad1457; }
+  .qr-badge.key       { background: #fff3e0; color: #e65100; }
+  .qr-item.key-item   { border: 2px dashed #e65100; }
 
   .warn { background: #fff8e1; border-left: 4px solid #f9a825; padding: 10px 14px;
           border-radius: 4px; margin-top: 12px; font-size: 0.85rem; }
@@ -136,6 +143,14 @@
         <label style="margin:0">
           <input type="checkbox" id="s-compress"> Compress with DEFLATE
           <small style="display:block;color:#888;margin-top:2px">Saves ~50–70% for HTML/text</small>
+        </label>
+      </div>
+    </div>
+    <div class="row">
+      <div style="display:flex;align-items:flex-end;padding-bottom:6px">
+        <label style="margin:0">
+          <input type="checkbox" id="s-encrypt"> 🔒 Encrypt this content (AES-256-GCM)
+          <small style="display:block;color:#888;margin-top:2px">Generates a separate key code (SPEC §9) — print or share it apart from the content code</small>
         </label>
       </div>
     </div>
@@ -255,6 +270,7 @@ function cfloat(v) { return { __float64: true, value: v }; }
 function cborValue(out, v) {
   if (v === null || v === undefined) return;
   if (v && v.__float64) { cborFloat64(out, v.value); }
+  else if (typeof v === 'boolean') { out.push(v ? 0xF5 : 0xF4); } // true (0xf5) / false (0xf4)
   else if (typeof v === 'number') { writeHead(out, 0, v); }
   else if (v instanceof Uint8Array) { writeHead(out, 2, v.length); v.forEach(b => out.push(b)); }
   else if (typeof v === 'string') {
@@ -330,12 +346,40 @@ async function zlibCompress(bytes) {
 // CBOR payload-map keys (key 1 "version" is retired — it lives in the envelope)
 const K = { CACHE_ID:2, HINT:3, MIME:4, CONTENT:5,
              FILENAME:11, COMPRESSION:12, SET:13, SLUG:14, FILES:15, RELATED:16,
-             FILE_SLUG:20, FILE_MIME:21, FILE_ID:22, PAPER_ID:23, LAT:26, LNG:27 };
+             FILE_SLUG:20, FILE_MIME:21, FILE_ID:22, PAPER_ID:23, LAT:26, LNG:27,
+             ENCRYPTION:28, NONCE:29, KEY_MATERIAL:30, RETAIN_KEY:31 };
 
-async function encodeSingle({ hint, filename, mimeType, rawBytes, compress }) {
+// ── Encryption (SPEC §9) ────────────────────────────────────────────────────
+function generateKeyMaterial() { return crypto.getRandomValues(new Uint8Array(32)); }
+function generateNonce() { return crypto.getRandomValues(new Uint8Array(12)); }
+
+// 8 random bytes — cache_id for encrypted content (SPEC §9): random rather than
+// content-addressed, so the ID itself can't be used as a content-equality oracle.
+function randomCacheId() { return crypto.getRandomValues(new Uint8Array(8)); }
+
+// AES-256-GCM encrypt; returns ciphertext || 16-byte tag (SPEC §9).
+async function encryptAesGcm(plaintext, key, nonce) {
+  const cryptoKey = await crypto.subtle.importKey('raw', key, 'AES-GCM', false, ['encrypt']);
+  return new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv: nonce }, cryptoKey, plaintext));
+}
+
+/**
+ * If encryptionKey is given (32 bytes), the (possibly-compressed) content is
+ * AES-256-GCM encrypted under a fresh nonce, encryption/nonce are set, and
+ * cache_id is random rather than content-addressed (SPEC §9).
+ */
+async function encodeSingle({ hint, filename, mimeType, rawBytes, compress, encryptionKey }) {
   let content = rawBytes, compression = null;
   if (compress) { content = await zlibCompress(rawBytes); compression = 1; }
-  const cacheId = await sha256first8(rawBytes);
+  let cacheId, encryption = null, nonce = null;
+  if (encryptionKey) {
+    nonce = generateNonce();
+    content = await encryptAesGcm(content, encryptionKey, nonce);
+    encryption = 1;
+    cacheId = randomCacheId();
+  } else {
+    cacheId = await sha256first8(rawBytes);
+  }
   const payload = cborMap([
     [K.CACHE_ID,    cacheId],
     [K.HINT,        hint || null],
@@ -343,6 +387,25 @@ async function encodeSingle({ hint, filename, mimeType, rawBytes, compress }) {
     [K.MIME,        mimeType],
     [K.COMPRESSION, compression],
     [K.CONTENT,     content],
+    [K.ENCRYPTION,  encryption],
+    [K.NONCE,       nonce],
+  ]);
+  return { uri: 'tagdrop:' + base45Encode(cborSequence(TYPE_SINGLE, payload)), cacheId, encryption, nonce };
+}
+
+/**
+ * Builds a "key-only" Single payload (SPEC §9): carries keyMaterial for other
+ * content, with no content/mime_type of its own. cache_id is random — there's
+ * no content to address. Per SPEC §9's "discovery, not declaration", no field
+ * says which content this key unlocks — a reader tries it against any encrypted
+ * content it has cached.
+ */
+function encodeKeyCode({ keyMaterial, hint }) {
+  const cacheId = randomCacheId();
+  const payload = cborMap([
+    [K.CACHE_ID,     cacheId],
+    [K.HINT,         hint || null],
+    [K.KEY_MATERIAL, keyMaterial],
   ]);
   return { uri: 'tagdrop:' + base45Encode(cborSequence(TYPE_SINGLE, payload)), cacheId };
 }
@@ -400,6 +463,30 @@ async function renderQr(container, uri) {
   });
 }
 
+// Builds one QR card (canvas + label/sub/id + print/copy actions) and appends it to grid.
+// `label` is inserted as-is (escape before calling); `sub`/`id` are escaped here.
+async function addGeneratorQrCard(grid, { label, sub, badge, badgeClass, id, uri, itemClass }) {
+  const item = document.createElement('div');
+  item.className = 'qr-item' + (itemClass ? ' ' + itemClass : '');
+  const qrDiv = document.createElement('div');
+  item.appendChild(qrDiv);
+  const badgeHtml = badge ? ` <span class="qr-badge ${badgeClass || ''}">${escHtml(badge)}</span>` : '';
+  item.insertAdjacentHTML('beforeend', `
+    <div class="qr-label">${label}</div>
+    <div class="qr-sub">${escHtml(sub)}${badgeHtml}</div>
+    <div class="qr-id">ID: ${escHtml(id)}</div>`);
+  grid.appendChild(item);
+
+  await renderQr(qrDiv, uri); // throws on failure — caller handles
+
+  const actionRow = document.createElement('div');
+  actionRow.className = 'action-row';
+  actionRow.innerHTML = `
+    <button class="secondary" onclick="window.print()">🖨 Print</button>
+    <button class="secondary" onclick="copyToClipboard('${uri.replace(/'/g,"\\'")}')">Copy URI</button>`;
+  item.appendChild(actionRow);
+}
+
 // ── Single-file generator ─────────────────────────────────────────────────
 async function generateSingle() {
   const msgs   = document.getElementById('s-messages');
@@ -411,41 +498,58 @@ async function generateSingle() {
   const mimeType = document.getElementById('s-mime').value;
   const text     = document.getElementById('s-content').value;
   const compress = document.getElementById('s-compress').checked;
+  const encrypt  = document.getElementById('s-encrypt').checked;
 
   if (!text.trim()) { msgs.innerHTML = '<div class="err">Content cannot be empty.</div>'; return; }
 
   const rawBytes = new TextEncoder().encode(text);
+  const encryptionKey = encrypt ? generateKeyMaterial() : null;
   let encoded;
-  try { encoded = await encodeSingle({ hint, filename, mimeType, rawBytes, compress }); }
+  try { encoded = await encodeSingle({ hint, filename, mimeType, rawBytes, compress, encryptionKey }); }
   catch (e) { msgs.innerHTML = `<div class="err">Encoding failed: ${e.message}</div>`; return; }
 
   if (encoded.uri.length > 2000)
-    msgs.innerHTML = `<div class="warn">URI is ${encoded.uri.length} chars — may not fit in one QR.
+    msgs.innerHTML += `<div class="warn">URI is ${encoded.uri.length} chars — may not fit in one QR.
       Enable compression or reduce content size.</div>`;
+  if (encrypt)
+    msgs.innerHTML += `<div class="warn">🔒 Two QR codes generated: the <strong>content</strong> code and a
+      separate <strong>key</strong> code (SPEC §9). Keep them apart — print or share on different paper —
+      since anyone with both can decrypt the content.</div>`;
 
-  const item = document.createElement('div');
-  item.className = 'qr-item';
-  const qrDiv = document.createElement('div');
-  item.appendChild(qrDiv);
-  item.innerHTML += `<div class="qr-label">${hint ? escHtml(hint) : (filename ? escHtml(filename) : 'TagDrop')}</div>
-    <div class="qr-sub">${mimeType}${compress ? ' · deflate' : ''}</div>
-    <div class="qr-id">ID: ${toHex(encoded.cacheId)}</div>`;
   result.innerHTML = '<div class="qr-grid"></div>';
-  result.querySelector('.qr-grid').appendChild(item);
-  item.insertBefore(qrDiv, item.firstChild);
+  const grid = result.querySelector('.qr-grid');
+
   try {
-    await renderQr(qrDiv, encoded.uri);
-  } catch(e) {
+    await addGeneratorQrCard(grid, {
+      label: hint ? escHtml(hint) : (filename ? escHtml(filename) : 'TagDrop'),
+      sub: `${mimeType}${compress ? ' · deflate' : ''}`,
+      badge: encrypt ? 'encrypted' : null,
+      badgeClass: 'encrypted',
+      id: toHex(encoded.cacheId),
+      uri: encoded.uri,
+    });
+  } catch (e) {
     msgs.innerHTML += `<div class="err">QR rendering failed. Is the qrcode library loaded? (requires internet on first use)</div>`;
     return;
   }
 
-  const actionRow = document.createElement('div');
-  actionRow.className = 'action-row';
-  actionRow.innerHTML = `
-    <button class="secondary" onclick="window.print()">🖨 Print</button>
-    <button class="secondary" onclick="copyToClipboard('${encoded.uri.replace(/'/g,"\\'")}')">Copy URI</button>`;
-  result.appendChild(actionRow);
+  if (encrypt) {
+    const keyHint = hint ? `Key for: ${hint}` : (filename ? `Key for: ${filename}` : 'TagDrop key');
+    const keyEncoded = encodeKeyCode({ keyMaterial: encryptionKey, hint: keyHint });
+    try {
+      await addGeneratorQrCard(grid, {
+        label: escHtml(keyHint),
+        sub: 'key_material (AES-256-GCM)',
+        badge: 'key',
+        badgeClass: 'key',
+        id: toHex(keyEncoded.cacheId),
+        uri: keyEncoded.uri,
+        itemClass: 'key-item',
+      });
+    } catch (e) {
+      msgs.innerHTML += `<div class="err">QR rendering failed for the key code.</div>`;
+    }
+  }
 }
 
 // ── Paper layout generator ─────────────────────────────────────────────────

--- a/tools/reader/index.html
+++ b/tools/reader/index.html
@@ -229,6 +229,8 @@ function cborDecodeSequence(bytes) {
       }
       case 7:
         if (b === 0xF6) return null;
+        if (b === 0xF4) return false;
+        if (b === 0xF5) return true;
         if ((b & 0x1F) === 27) return new DataView(a.buffer, a.byteOffset, 8).getFloat64(0);
         throw new Error('Unsupported CBOR simple value: 0x' + b.toString(16));
       default: throw new Error('Unsupported CBOR major type: ' + major);
@@ -263,6 +265,17 @@ async function zlibDecompress(bytes) {
   return out;
 }
 
+// ── Encryption (SPEC §9) ──────────────────────────────────────────────────
+// AES-256-GCM decrypt; returns null on authentication failure (wrong key/nonce).
+async function decryptAesGcm(ciphertextAndTag, key, nonce) {
+  try {
+    const cryptoKey = await crypto.subtle.importKey('raw', key, 'AES-GCM', false, ['decrypt']);
+    return new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv: nonce }, cryptoKey, ciphertextAndTag));
+  } catch (e) {
+    return null;
+  }
+}
+
 // ── Utilities ─────────────────────────────────────────────────────────────
 function toHex(u8) {
   return Array.from(u8).map(b => b.toString(16).padStart(2, '0')).join('');
@@ -280,7 +293,8 @@ const K = {
   FILENAME:11, COMPRESSION:12,
   SET:13, SLUG:14, FILES:15, RELATED:16,
   FILE_SLUG:20, FILE_MIME:21, FILE_ID:22, PAPER_ID:23,
-  LAT:26, LNG:27
+  LAT:26, LNG:27,
+  ENCRYPTION:28, NONCE:29, KEY_MATERIAL:30, RETAIN_KEY:31
 };
 
 // CBOR-sequence envelope (SPEC §2): tagdrop:<base45( CBOR(version) || CBOR(type) || CBOR(payload) )>
@@ -297,7 +311,8 @@ const KEY_NAMES = {
   11: 'filename', 12: 'compression', 13: 'set', 14: 'slug', 15: 'files', 16: 'related',
   17: 'collection_id', 18: 'collection_label', 19: 'collection_tag',
   20: 'slug', 21: 'mime_type', 22: 'file_id', 23: 'paper_id', 24: 'icon',
-  26: 'lat', 27: 'lng'
+  26: 'lat', 27: 'lng',
+  28: 'encryption', 29: 'nonce', 30: 'key_material', 31: 'retain_key'
 };
 
 function toHexDump(bytes) {
@@ -379,15 +394,29 @@ async function parseUri(uri) {
   if (version !== ENVELOPE_VERSION) return { type: 'invalid' };
 
   if (kind === TYPE_SINGLE) {
-    let content = m[K.CONTENT];
-    if (m[K.COMPRESSION] === 1) content = await zlibDecompress(content);
+    // Key-only code (SPEC §9): carries key_material for other content, no content/mime
+    // of its own. Per "discovery, not declaration", nothing says which content it unlocks.
+    const keyMaterial = m[K.KEY_MATERIAL];
+    if (keyMaterial) {
+      return {
+        type: 'key',
+        cacheId:    toHex(m[K.CACHE_ID]),
+        hint:       m[K.HINT] || null,
+        keyMaterial,
+        retainKey:  m[K.RETAIN_KEY] !== false,
+        cbor: seq,
+      };
+    }
     return {
       type: 'single',
-      cacheId:  toHex(m[K.CACHE_ID]),
-      hint:     m[K.HINT]     || null,
-      filename: m[K.FILENAME] || null,
-      mimeType: m[K.MIME],
-      content,
+      cacheId:     toHex(m[K.CACHE_ID]),
+      hint:        m[K.HINT]     || null,
+      filename:    m[K.FILENAME] || null,
+      mimeType:    m[K.MIME],
+      content:     m[K.CONTENT],
+      compression: m[K.COMPRESSION] || 0,
+      encryption:  m[K.ENCRYPTION]  || 0,
+      nonce:       m[K.NONCE] || null,
       cbor: seq,
     };
   }
@@ -423,6 +452,8 @@ async function parseUri(uri) {
       filename:    m[K.FILENAME] || null,
       mimeType:    m[K.MIME],
       compression: m[K.COMPRESSION] || 0,
+      encryption:  m[K.ENCRYPTION]  || 0,
+      nonce:       m[K.NONCE] || null,
       chunkCount:  m[K.CHUNK_COUNT],
       sha256:      m[K.SHA256],
       cbor: seq,
@@ -445,13 +476,15 @@ let _db;
 async function getDb() {
   if (_db) return _db;
   return new Promise((res, rej) => {
-    const req = indexedDB.open('tagdrop-reader', 1);
+    const req = indexedDB.open('tagdrop-reader', 2);
     req.onupgradeneeded = e => {
       const d = e.target.result;
       if (!d.objectStoreNames.contains('caches'))
         d.createObjectStore('caches', { keyPath: 'cacheId' });
       if (!d.objectStoreNames.contains('papers'))
         d.createObjectStore('papers', { keyPath: 'rootHash' });
+      if (!d.objectStoreNames.contains('keys'))
+        d.createObjectStore('keys', { keyPath: 'id' });
     };
     req.onsuccess = e => { _db = e.target.result; res(_db); };
     req.onerror = () => rej(req.error);
@@ -485,18 +518,49 @@ async function dbGetAll(store) {
 }
 async function dbClear() {
   const d = await getDb();
-  return new Promise((res, rej) => {
-    const tx = d.transaction(['caches', 'papers'], 'readwrite');
+  await new Promise((res, rej) => {
+    const tx = d.transaction(['caches', 'papers', 'keys'], 'readwrite');
     tx.objectStore('caches').clear();
     tx.objectStore('papers').clear();
+    tx.objectStore('keys').clear();
     tx.oncomplete = res;
     tx.onerror = () => rej(tx.error);
   });
+  for (const id of Object.keys(pendingEncrypted)) delete pendingEncrypted[id];
 }
 
 // ── Chunk assembly ────────────────────────────────────────────────────────
 // In-memory only — multi-code sets must be scanned in one session.
 const assemblies = {};
+
+// ── Encrypted content awaiting a key (SPEC §9) ───────────────────────────
+// In-memory only, keyed by cacheId hex: hash-verified ciphertext that has no
+// matching key_material yet. Resolved when a 'key' code is scanned (or was
+// already retained from a previous scan).
+const pendingEncrypted = {};
+
+/**
+ * Decrypts (if encrypted) and decompresses verified bytes, storing the result in
+ * the 'caches' store. If encrypted and no retained key matches, stashes the
+ * ciphertext in pendingEncrypted and returns null — resolved later by a 'key' scan.
+ */
+async function resolveAndStore(cacheId, bytes, { encryption, nonce, compression, mimeType, hint, filename }) {
+  if (encryption === 1) { // AES-256-GCM (SPEC §9)
+    for (const k of await dbGetAll('keys')) {
+      const plain = await decryptAesGcm(bytes, k.keyMaterial, nonce);
+      if (plain !== null) {
+        const content = compression === 1 ? await zlibDecompress(plain) : plain;
+        await dbPut('caches', { cacheId, mimeType, content, hint, filename });
+        return content;
+      }
+    }
+    pendingEncrypted[cacheId] = { ciphertext: bytes, nonce, compression, mimeType, hint, filename };
+    return null;
+  }
+  const content = compression === 1 ? await zlibDecompress(bytes) : bytes;
+  await dbPut('caches', { cacheId, mimeType, content, hint, filename });
+  return content;
+}
 
 // ── Camera / QR scanner ───────────────────────────────────────────────────
 let scanning = false;
@@ -564,19 +628,47 @@ async function handleScanned(raw) {
 
   switch (parsed.type) {
 
-    case 'single':
-      await dbPut('caches', {
-        cacheId: parsed.cacheId, mimeType: parsed.mimeType,
-        content: parsed.content, hint: parsed.hint, filename: parsed.filename,
-      });
+    case 'single': {
       lastScannedCbor = parsed.cbor;
       lastScannedTitle = parsed.cacheId;
       updateCborButton();
+      const content = await resolveAndStore(parsed.cacheId, parsed.content, parsed);
+      if (content === null) {
+        showMsg('🔒 Encrypted content received — scan its key code to unlock.', 'info');
+        if (activePaperHash) await renderPaper(activePaperHash);
+        return;
+      }
       showMsg('Loaded: ' + (parsed.filename || parsed.hint || parsed.mimeType), 'ok');
-      await showContent(parsed.mimeType, parsed.content, parsed.filename || parsed.hint || parsed.mimeType, parsed.cacheId);
+      await showContent(parsed.mimeType, content, parsed.filename || parsed.hint || parsed.mimeType, parsed.cacheId);
       // Refresh directory if this file belongs to the active paper
       if (activePaperHash) await renderPaper(activePaperHash);
       break;
+    }
+
+    case 'key': {
+      lastScannedCbor = parsed.cbor;
+      lastScannedTitle = parsed.cacheId;
+      updateCborButton();
+      if (parsed.retainKey) {
+        await dbPut('keys', { id: toHex(parsed.keyMaterial), keyMaterial: parsed.keyMaterial, hint: parsed.hint });
+      }
+      let unlockedAny = false;
+      for (const [cacheId, entry] of Object.entries(pendingEncrypted)) {
+        const plain = await decryptAesGcm(entry.ciphertext, parsed.keyMaterial, entry.nonce);
+        if (plain === null) continue;
+        const content = entry.compression === 1 ? await zlibDecompress(plain) : plain;
+        await dbPut('caches', { cacheId, mimeType: entry.mimeType, content, hint: entry.hint, filename: entry.filename });
+        delete pendingEncrypted[cacheId];
+        unlockedAny = true;
+        showMsg('Decrypted: ' + (entry.filename || entry.hint || entry.mimeType), 'ok');
+        await showContent(entry.mimeType, content, entry.filename || entry.hint || entry.mimeType, cacheId);
+      }
+      if (!unlockedAny) {
+        showMsg('Key code scanned' + (parsed.retainKey ? ' and stored' : '') + ' — scan its content code to unlock.', 'info');
+      }
+      if (activePaperHash) await renderPaper(activePaperHash);
+      break;
+    }
 
     case 'paper':
       await dbPut('papers', parsed);
@@ -630,13 +722,14 @@ async function handleScanned(raw) {
       let ok = expected && hashBytes.length === expected.length;
       if (ok) for (let i = 0; i < hashBytes.length; i++) if (hashBytes[i] !== expected[i]) { ok = false; break; }
       if (!ok) { showMsg('Integrity check failed — try rescanning all chunks.', 'err'); return; }
-      const content = a.manifest.compression === 1 ? await zlibDecompress(raw) : raw;
-      await dbPut('caches', {
-        cacheId: a.manifest.cacheId, mimeType: a.manifest.mimeType,
-        content, hint: a.manifest.hint, filename: a.manifest.filename,
-      });
+      const content = await resolveAndStore(a.manifest.cacheId, raw, a.manifest);
       delete assemblies[a.manifest.cacheId];
       hideAssemblyProgress();
+      if (content === null) {
+        showMsg('🔒 All chunks assembled and verified — scan the key code to unlock.', 'info');
+        if (activePaperHash) await renderPaper(activePaperHash);
+        break;
+      }
       showMsg('All chunks assembled!', 'ok');
       await showContent(a.manifest.mimeType, content, a.manifest.filename || a.manifest.hint || a.manifest.mimeType, a.manifest.cacheId);
       if (activePaperHash) await renderPaper(activePaperHash);
@@ -708,10 +801,11 @@ async function renderPaper(rootHash) {
         '<span class="mime">' + escHtml(f.mimeType) + '</span>' +
         '<button class="secondary open-file" data-id="' + escHtml(f.fileId) + '" data-slug="' + escHtml(f.slug) + '">Open</button>';
     } else {
+      const label = pendingEncrypted[f.fileId] ? '🔒 needs key' : 'not scanned';
       li.innerHTML =
         '<span class="slug">' + escHtml(f.slug) + '</span>' +
         '<span class="mime">' + escHtml(f.mimeType) + '</span>' +
-        '<span class="missing-label">not scanned</span>';
+        '<span class="missing-label">' + label + '</span>';
     }
     list.appendChild(li);
   }

--- a/tools/reader/index.html
+++ b/tools/reader/index.html
@@ -33,6 +33,7 @@ button.secondary { padding: 7px 14px; background: #fff; border: 1px solid #ccc;
 button.secondary:hover { background: #f0f0f0; }
 button.ghost { background: none; border: 1px solid rgba(255,255,255,0.3); color: #fff;
                padding: 5px 12px; border-radius: 6px; cursor: pointer; font-size: 0.8rem; }
+button.ghost:disabled { opacity: 0.35; cursor: default; }
 
 /* Scanner overlay */
 .overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.85);
@@ -88,6 +89,16 @@ main { max-width: 720px; margin: 0 auto; padding: 20px 16px; }
 
 .paper-actions { margin-top: 12px; display: flex; gap: 8px; flex-wrap: wrap; }
 
+/* CBOR debug dialog */
+.cbor-box { background: #fff; border-radius: 10px; padding: 16px;
+            width: min(640px, 96vw); max-height: 80vh;
+            display: flex; flex-direction: column; gap: 12px; }
+.cbor-box h2 { margin: 0; font-size: 0.95rem; font-family: monospace;
+               color: #333; word-break: break-all; }
+#cborDump { margin: 0; overflow: auto; font-size: 0.78rem; line-height: 1.4;
+            white-space: pre-wrap; word-break: break-all;
+            background: #f5f5f5; border-radius: 6px; padding: 12px; flex: 1; }
+
 /* Content viewer */
 #contentSection { background: #fff; border-radius: 10px;
                   box-shadow: 0 1px 4px rgba(0,0,0,0.08); overflow: hidden; }
@@ -104,8 +115,19 @@ main { max-width: 720px; margin: 0 auto; padding: 20px 16px; }
 
 <header>
   <h1>TagDrop Reader</h1>
-  <button id="btnClear" class="ghost">Clear cache</button>
+  <div style="display:flex; gap:8px;">
+    <button id="btnCbor" class="ghost" disabled>🔍 CBOR</button>
+    <button id="btnClear" class="ghost">Clear cache</button>
+  </div>
 </header>
+
+<div id="cborOverlay" class="overlay hidden">
+  <div class="cbor-box">
+    <h2 id="cborTitle"></h2>
+    <pre id="cborDump"></pre>
+    <button id="btnCloseCbor" class="secondary">Close</button>
+  </div>
+</div>
 
 <div id="scanOverlay" class="overlay hidden">
   <div class="scan-box">
@@ -265,6 +287,67 @@ const K = {
 const ENVELOPE_VERSION = 1;
 const TYPE_SINGLE = 0, TYPE_MANIFEST = 1, TYPE_CHUNK = 2, TYPE_PAPER_MANIFEST = 3;
 
+// ── CBOR debug ────────────────────────────────────────────────────────────
+// Mirrors TagDropCodec.describeCbor/describeMap (Kotlin) for the "View raw CBOR"
+// debug view: hex dump, version/type envelope, key-by-key payload breakdown.
+const TYPE_NAMES = { 0: 'Single', 1: 'Manifest', 2: 'Chunk', 3: 'PaperManifest' };
+const KEY_NAMES = {
+  2: 'cache_id/root_hash', 3: 'hint/label', 4: 'mime_type', 5: 'content',
+  6: 'chunk_count', 7: 'total_bytes', 8: 'sha256', 9: 'chunk_index', 10: 'chunk_data',
+  11: 'filename', 12: 'compression', 13: 'set', 14: 'slug', 15: 'files', 16: 'related',
+  17: 'collection_id', 18: 'collection_label', 19: 'collection_tag',
+  20: 'slug', 21: 'mime_type', 22: 'file_id', 23: 'paper_id', 24: 'icon',
+  26: 'lat', 27: 'lng'
+};
+
+function toHexDump(bytes) {
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join(' ');
+}
+
+/** Pretty-prints a raw TagDrop CBOR sequence: hex dump, version/type envelope, and a
+ *  key-by-key breakdown of the payload map annotated with KEY_NAMES. */
+function describeCbor(bytes) {
+  let out = bytes.length + ' bytes\n' + toHexDump(bytes) + '\n\n';
+  try {
+    const items = cborDecodeSequence(bytes);
+    if (items.length < 3) throw new Error('Expected version, type, payload — got ' + items.length + ' item(s)');
+    const [version, type, payload] = items;
+    out += 'version: ' + version + '\n';
+    out += 'type: ' + type + ' (' + (TYPE_NAMES[type] || 'unknown') + ')\n\n';
+    out += describeMap(payload, 0);
+  } catch (e) {
+    out += 'Failed to decode as CBOR sequence: ' + e.message;
+  }
+  return out;
+}
+
+function describeMap(map, indent) {
+  const pad = '  '.repeat(indent);
+  let out = '';
+  for (const key of Object.keys(map).map(Number).sort((a, b) => a - b)) {
+    const value = map[key];
+    const label = KEY_NAMES[key] ? key + ' (' + KEY_NAMES[key] + ')' : String(key);
+    if (value instanceof Uint8Array) {
+      out += pad + label + ': ' + toHexDump(value) + ' (' + value.length + ' bytes)\n';
+    } else if (typeof value === 'string') {
+      out += pad + label + ': "' + value + '"\n';
+    } else if (Array.isArray(value)) {
+      out += pad + label + ': [\n';
+      for (const item of value) {
+        if (item !== null && typeof item === 'object' && !(item instanceof Uint8Array) && !Array.isArray(item)) {
+          out += pad + '  {\n' + describeMap(item, indent + 2) + pad + '  }\n';
+        } else {
+          out += pad + '  ' + item + '\n';
+        }
+      }
+      out += pad + ']\n';
+    } else {
+      out += pad + label + ': ' + value + '\n';
+    }
+  }
+  return out;
+}
+
 // ── TagDrop URI parser ────────────────────────────────────────────────────
 async function parseUri(uri) {
   if (!uri.startsWith('tagdrop:')) return null;
@@ -305,6 +388,7 @@ async function parseUri(uri) {
       filename: m[K.FILENAME] || null,
       mimeType: m[K.MIME],
       content,
+      cbor: seq,
     };
   }
   if (kind === TYPE_PAPER_MANIFEST) {
@@ -315,6 +399,7 @@ async function parseUri(uri) {
       set:      m[K.SET]  || null,
       slug:     m[K.SLUG] || null,
       scannedAt: Date.now(),
+      cbor: seq,
       files: (m[K.FILES] || []).map(f => ({
         slug:     f[K.FILE_SLUG],
         mimeType: f[K.FILE_MIME],
@@ -340,6 +425,7 @@ async function parseUri(uri) {
       compression: m[K.COMPRESSION] || 0,
       chunkCount:  m[K.CHUNK_COUNT],
       sha256:      m[K.SHA256],
+      cbor: seq,
     };
   }
   if (kind === TYPE_CHUNK) {
@@ -348,6 +434,7 @@ async function parseUri(uri) {
       cacheId: toHex(m[K.CACHE_ID]),
       index:   m[K.CHUNK_IDX],
       data:    m[K.CHUNK_DATA],
+      cbor: seq,
     };
   }
   return null;
@@ -462,6 +549,12 @@ function tickScan(video, canvas, stream) {
 
 // ── Main scan handler ─────────────────────────────────────────────────────
 let activePaperHash = null;
+let lastScannedCbor = null;
+let lastScannedTitle = null;
+
+function updateCborButton() {
+  document.getElementById('btnCbor').disabled = !lastScannedCbor;
+}
 
 async function handleScanned(raw) {
   let parsed;
@@ -476,6 +569,9 @@ async function handleScanned(raw) {
         cacheId: parsed.cacheId, mimeType: parsed.mimeType,
         content: parsed.content, hint: parsed.hint, filename: parsed.filename,
       });
+      lastScannedCbor = parsed.cbor;
+      lastScannedTitle = parsed.cacheId;
+      updateCborButton();
       showMsg('Loaded: ' + (parsed.filename || parsed.hint || parsed.mimeType), 'ok');
       await showContent(parsed.mimeType, parsed.content, parsed.filename || parsed.hint || parsed.mimeType, parsed.cacheId);
       // Refresh directory if this file belongs to the active paper
@@ -485,12 +581,18 @@ async function handleScanned(raw) {
     case 'paper':
       await dbPut('papers', parsed);
       activePaperHash = parsed.rootHash;
+      lastScannedCbor = parsed.cbor;
+      lastScannedTitle = parsed.rootHash;
+      updateCborButton();
       showMsg('Paper: ' + (parsed.label || 'untitled') + ' — ' + parsed.files.length + ' file(s)', 'ok');
       await renderPaper(parsed.rootHash);
       break;
 
     case 'manifest':
       assemblies[parsed.cacheId] = { manifest: parsed, chunks: new Map() };
+      lastScannedCbor = parsed.cbor;
+      lastScannedTitle = parsed.cacheId;
+      updateCborButton();
       showMsg('Manifest scanned — need ' + parsed.chunkCount + ' chunk(s). Scan them now.', 'info');
       showAssemblyProgress(parsed.cacheId, 0, parsed.chunkCount);
       break;
@@ -501,6 +603,9 @@ async function handleScanned(raw) {
         showMsg('Chunk received but no manifest yet — scan the manifest QR first.', 'warn');
         return;
       }
+      lastScannedCbor = parsed.cbor;
+      lastScannedTitle = parsed.cacheId + ' #' + parsed.index;
+      updateCborButton();
       a.chunks.set(parsed.index, parsed.data);
       const got = a.chunks.size, need = a.manifest.chunkCount;
       if (got < need) {
@@ -773,6 +878,17 @@ document.getElementById('fileList').addEventListener('click', async e => {
   else showMsg('Not cached yet — scan its QR code.', 'warn');
 });
 
+document.getElementById('btnCbor').onclick = () => {
+  if (!lastScannedCbor) return;
+  document.getElementById('cborTitle').textContent = 'Raw CBOR — ' + lastScannedTitle;
+  document.getElementById('cborDump').textContent = describeCbor(lastScannedCbor);
+  document.getElementById('cborOverlay').classList.remove('hidden');
+};
+
+document.getElementById('btnCloseCbor').onclick = () => {
+  document.getElementById('cborOverlay').classList.add('hidden');
+};
+
 document.getElementById('btnClear').onclick = async () => {
   if (!confirm('Clear all cached TagDrop content from this browser?')) return;
   await dbClear();
@@ -789,6 +905,11 @@ document.getElementById('btnClear').onclick = async () => {
   // Show the most recently scanned paper
   const latest = papers.reduce((a, b) => ((b.scannedAt || 0) > (a.scannedAt || 0) ? b : a));
   activePaperHash = latest.rootHash;
+  if (latest.cbor) {
+    lastScannedCbor = latest.cbor;
+    lastScannedTitle = latest.rootHash;
+    updateCborButton();
+  }
   await renderPaper(latest.rootHash);
 })();
 </script>


### PR DESCRIPTION
## Summary

- **SPEC §9 Encryption**: AES-256-GCM, implemented in both reference
  implementations — the Kotlin canonical codec (`TagDropCodec.kt`,
  `ChunkAssembler.kt`, `TagDropPayload.kt`) and all three browser tools
  (`tools/generator`, `tools/reader`, `tools/examples`). Content + a
  separate "key code" (CBOR keys 28–31: `encryption`, `nonce`,
  `key_material`, `retain_key`), random `cache_id` for encrypted content
  (avoids a content-equality oracle), and order-independent
  "discovery, not declaration" key/content scanning.
- **SPEC §10 Verified Authorship (signatures)**: ML-DSA-44 spec added for
  forward-compatibility — explicitly **not implemented** in this PR (needs
  new crypto deps on both sides; readers ignore unrecognised keys 32–36
  per §3).
- Adds a raw CBOR debug view to the web reader.
- Fixes a few stale claims in SPEC.md found during pre-release review.
- readme: credits Geocaching (original inspiration) and Dead Drops
  (Aram Bartholl, 2010 — offline/anonymous spirit).

## Test plan

- [x] Kotlin: `ChunkAssemblerTest` / `TagDropCodecTest` cover encrypted
      Single + Manifest/Chunk payloads, key-before/after-chunks ordering,
      wrong-key and hash-mismatch cases.
- [x] Browser tools: Node-based extraction round-trip tests — encode with
      `tools/generator`, decode with `tools/reader`, including encrypted
      single + key code, wrong-key rejection, and interop with the Kotlin
      `createManifestAndChunks(encryptionKey=...)` output.
- [ ] Manual: generate an encrypted code + key code in
      `tools/generator/index.html`, scan both (either order) in
      `tools/reader/index.html` and the Android app.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ANzFmmDsoaRewQTwZb5Rbi)_