### PR TITLE
Add optional created_at field to spec, app, and web tools

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -155,6 +155,7 @@ TagDrop's wire format has four internal CBOR structures, all integer-keyed maps 
 | 49 | `prefer_declared_location` | bool (opt, default `false`) | `core_meta_item` only |
 | 50 | `in_reply_to` | bytes (8, opt) | `core_meta_item` — `cache_id`/`root_hash` of the single parent this is replying to (§7) |
 | 51 | `title` | text (opt) | `core_meta_item` |
+| 52 | `created_at` | uint (opt) | `core_meta_item` — author-declared Unix timestamp (seconds since epoch) this payload was authored; reflects the authoring device's clock, not independently verified |
 
 Keys **1**, **6**, **9**, **10** are retired (formerly `version`-inside-payload,
 `chunk_count`, `chunk_index`, `chunk_data` — superseded by the envelope's
@@ -1417,7 +1418,7 @@ Version history:
   `sector_bytes` in order, is `core_meta_item || bulky_meta_item || content`
   — small/plain identity and declaration fields, then whatever's bulky or
   worth compressing, then raw content bytes with no declared length.
-- Payload map integer keys 2–19, 20–24, 26–28, 30–40, 42–51. Keys 1, 6, 9, 10
+- Payload map integer keys 2–19, 20–24, 26–28, 30–40, 42–52. Keys 1, 6, 9, 10
   retired (superseded by the envelope and by `part_meta`'s sector fields —
   §3). Key 25 reserved for a future binary image icon; key 29 reserved,
   unused (§9).
@@ -1446,6 +1447,7 @@ Version history:
 - Content-teaser `description` (key 40, both payload kinds) and per-file `description` (key 41, in `files[]` entries) — distinct from `label`/`hint` and from the short-caption `title` (key 51, both payload kinds) (§4.3).
 - AES-256-GCM hidden override maps (§9), Content payloads only: self-contained `nonce||ciphertext||tag` blob carried in the reassembled stream's `content` slot, applied after compression. Optional non-binding `encryption` hint (key 28). `key_material`/`retain_key` (keys 30/31) matched by trial decryption ("discovery, not declaration"). PBKDF2-HMAC-SHA256 passphrase derivation via `kdf_alg`/`kdf_salt`/`kdf_iters` (keys 37–39).
 - ML-DSA-44 post-quantum signatures (§10): `signature_algorithm`/`signature`/`signer_pubkey`/`signer_id`/`signer_label` (keys 32–36), additive and not affecting `cache_id`/`root_hash`/`content_sha256`/`bulky_meta_sha256`. Specified for forward-compatibility; not yet implemented in reference implementations.
+- Author-declared `created_at` (key 52, both payload kinds): optional Unix timestamp (seconds) recording when the payload was authored, taken from the authoring device's clock at encode time — self-declared like `lat`/`lng`, not a verified/trusted timestamp.
 
 ---
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/CreateActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/CreateActivity.kt
@@ -63,7 +63,8 @@ class CreateActivity : AppCompatActivity() {
 
         val rawContent = content.toByteArray(Charsets.UTF_8)
         val sector = TagDropCodec.createContentSectors(hint, filename, mimeType,
-                          rawContent, compress, icon = icon).first()
+                          rawContent, compress, icon = icon,
+                          createdAt = System.currentTimeMillis() / 1000).first()
         val uri = TagDropCodec.encode(sector)
         lastUri = uri
         lastPayloadHint = hint ?: filename

--- a/app/src/main/java/com/github/mofosyne/tagdrop/CreatePaperActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/CreatePaperActivity.kt
@@ -147,6 +147,7 @@ class CreatePaperActivity : AppCompatActivity() {
         val files = mutableListOf<TagDropPayload.FileEntry>()
         val fileEntries = mutableListOf<QrEntry>()
         val fileContents = mutableListOf<FileContent>()
+        val createdAt = System.currentTimeMillis() / 1000
 
         for (i in 0 until binding.containerFiles.childCount) {
             val entry = ItemPaperFileEntryBinding.bind(binding.containerFiles.getChildAt(i))
@@ -158,7 +159,7 @@ class CreatePaperActivity : AppCompatActivity() {
             val mimeType = mimeTypes[entry.spinnerFileMime.selectedItemPosition]
             val compress = entry.checkFileCompress.isChecked
             val rawContent = content.toByteArray(Charsets.UTF_8)
-            val sectors = TagDropCodec.createContentSectorsAutoSized(null, fileSlug, mimeType, rawContent, compress)
+            val sectors = TagDropCodec.createContentSectorsAutoSized(null, fileSlug, mimeType, rawContent, compress, createdAt = createdAt)
             val fileId = sectors.first().partMeta.cacheId ?: ByteArray(0)
             val fileIdHex = hex(fileId)
             files.add(TagDropPayload.FileEntry(fileSlug, mimeType, fileId))
@@ -166,7 +167,7 @@ class CreatePaperActivity : AppCompatActivity() {
             fileEntries.addAll(sectorQrEntries(sectors, fileSlug, mimeType, fileIdHex, addParity))
         }
 
-        val (paper, paperSectors) = TagDropCodec.createPaperAutoSized(label, set, slug, files)
+        val (paper, paperSectors) = TagDropCodec.createPaperAutoSized(label, set, slug, files, createdAt = createdAt)
         val rootHashHex = hex(paper.rootHash)
         val manifestLabel = label ?: getString(R.string.paper_manifest_label)
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
@@ -456,7 +456,8 @@ class ReceiveActivity : AppCompatActivity() {
         kdfAlg: Int = 0, kdfSalt: ByteArray? = null,
         lat: Double? = null, lng: Double? = null, radiusM: Double? = null,
         preferDeclaredLocation: Boolean = false,
-        inReplyTo: ByteArray? = null, title: String? = null, description: String? = null
+        inReplyTo: ByteArray? = null, title: String? = null, description: String? = null,
+        createdAt: Long? = null
     ) {
         val location = getLastKnownLocation()
         val resolved = LocationUtils.resolveLocation(lat, lng, radiusM, preferDeclaredLocation, location?.first, location?.second)
@@ -486,7 +487,8 @@ class ReceiveActivity : AppCompatActivity() {
                     kdfSalt             = kdfSalt,
                     inReplyTo           = inReplyTo?.toHex(),
                     title               = title,
-                    description         = description
+                    description         = description,
+                    createdAt           = createdAt
                 )
             )
             if (paper != null) {
@@ -535,7 +537,8 @@ class ReceiveActivity : AppCompatActivity() {
                 wasEncrypted = true,
                 lat = state.lat, lng = state.lng, radiusM = state.radiusM,
                 preferDeclaredLocation = state.preferDeclaredLocation,
-                inReplyTo = state.inReplyTo, title = state.title, description = state.description
+                inReplyTo = state.inReplyTo, title = state.title, description = state.description,
+                createdAt = state.createdAt
             )
             return
         }
@@ -549,7 +552,8 @@ class ReceiveActivity : AppCompatActivity() {
                 collectionTag = state.collectionTag, icon = state.icon, kdfAlg = state.kdfAlg,
                 lat = state.lat, lng = state.lng, radiusM = state.radiusM,
                 preferDeclaredLocation = state.preferDeclaredLocation,
-                inReplyTo = state.inReplyTo, title = state.title, description = state.description
+                inReplyTo = state.inReplyTo, title = state.title, description = state.description,
+                createdAt = state.createdAt
             )
             return
         }
@@ -561,7 +565,8 @@ class ReceiveActivity : AppCompatActivity() {
             wasEncrypted = state.wasEncrypted,
             lat = state.lat, lng = state.lng, radiusM = state.radiusM,
             preferDeclaredLocation = state.preferDeclaredLocation,
-            inReplyTo = state.inReplyTo, title = state.title, description = state.description
+            inReplyTo = state.inReplyTo, title = state.title, description = state.description,
+            createdAt = state.createdAt
         )
     }
 
@@ -600,7 +605,8 @@ class ReceiveActivity : AppCompatActivity() {
         collectionId: String?, collectionLabel: String?, collectionTag: String?, icon: String?, kdfAlg: Int,
         lat: Double? = null, lng: Double? = null, radiusM: Double? = null,
         preferDeclaredLocation: Boolean = false,
-        inReplyTo: ByteArray? = null, title: String? = null, description: String? = null
+        inReplyTo: ByteArray? = null, title: String? = null, description: String? = null,
+        createdAt: Long? = null
     ) {
         val result = askPassphrase(hint)
         if (result != null) {
@@ -619,7 +625,8 @@ class ReceiveActivity : AppCompatActivity() {
                     override.mimeType ?: mimeType, override.content ?: ByteArray(0),
                     collectionId, collectionLabel, collectionTag, icon, wasEncrypted = true,
                     lat = lat, lng = lng, radiusM = radiusM, preferDeclaredLocation = preferDeclaredLocation,
-                    inReplyTo = inReplyTo, title = title, description = description
+                    inReplyTo = inReplyTo, title = title, description = description,
+                    createdAt = createdAt
                 )
                 return
             }
@@ -632,7 +639,8 @@ class ReceiveActivity : AppCompatActivity() {
                 pendingOverrideBlob = blob, pendingCompression = compression,
                 wasEncrypted = true, kdfAlg = kdfAlg, kdfSalt = kdfSalt,
                 lat = lat, lng = lng, radiusM = radiusM, preferDeclaredLocation = preferDeclaredLocation,
-                inReplyTo = inReplyTo, title = title, description = description
+                inReplyTo = inReplyTo, title = title, description = description,
+                createdAt = createdAt
             )
         } else {
             toast(getString(R.string.awaiting_key))
@@ -698,7 +706,8 @@ class ReceiveActivity : AppCompatActivity() {
             wasEncrypted = state.wasEncrypted,
             lat = state.lat, lng = state.lng, radiusM = state.radiusM,
             preferDeclaredLocation = state.preferDeclaredLocation,
-            inReplyTo = state.inReplyTo, title = state.title, description = state.description
+            inReplyTo = state.inReplyTo, title = state.title, description = state.description,
+            createdAt = state.createdAt
         )
     }
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/ShareQrActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/ShareQrActivity.kt
@@ -92,7 +92,8 @@ class ShareQrActivity : AppCompatActivity() {
         return TagDropCodec.createContentSectorsAutoSized(
             cache.hint, cache.filename, cache.mimeType, rawContent, compress,
             collectionId, cache.collectionLabel, cache.collectionTag, cache.icon,
-            inReplyTo = cache.inReplyTo?.hexToBytes(), title = cache.title, description = cache.description
+            inReplyTo = cache.inReplyTo?.hexToBytes(), title = cache.title, description = cache.description,
+            createdAt = cache.createdAt
         )
     }
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/WriteNfcTagActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/WriteNfcTagActivity.kt
@@ -156,6 +156,7 @@ class WriteNfcTagActivity : AppCompatActivity() {
             cache.hint, cache.filename, cache.mimeType, rawContent, compress,
             collectionId, cache.collectionLabel, cache.collectionTag, cache.icon,
             inReplyTo = cache.inReplyTo?.hexToBytes(), title = cache.title, description = cache.description,
+            createdAt = cache.createdAt,
             maxSectorDataBytes = maxSectorDataBytes
         )
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [FoundCache::class, ScannedPaper::class, RetainedKey::class], version = 14, exportSchema = false)
+@Database(entities = [FoundCache::class, ScannedPaper::class, RetainedKey::class], version = 15, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun cacheDao(): CacheDao
     abstract fun paperDao(): PaperDao
@@ -15,7 +15,7 @@ abstract class AppDatabase : RoomDatabase() {
 
     companion object {
         const val DB_NAME = "tagdrop.db"
-        const val SCHEMA_VERSION = 14
+        const val SCHEMA_VERSION = 15
 
         @Volatile private var INSTANCE: AppDatabase? = null
 
@@ -162,13 +162,19 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_14_15 = object : Migration(14, 15) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE found_caches ADD COLUMN createdAt INTEGER")
+            }
+        }
+
         fun get(context: Context): AppDatabase = INSTANCE ?: synchronized(this) {
             INSTANCE ?: Room.databaseBuilder(
                 context.applicationContext,
                 AppDatabase::class.java,
                 DB_NAME
             )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15)
             .build().also { INSTANCE = it }
         }
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/FoundCache.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/FoundCache.kt
@@ -26,7 +26,8 @@ data class FoundCache(
     val kdfSalt: ByteArray? = null,              // 16-byte random salt for PBKDF2; present whenever kdfAlg != 0
     val inReplyTo: String? = null,               // hex-encoded cache_id/root_hash of the single parent this is replying to (SPEC §7)
     val title: String? = null,                   // optional short subject/caption, distinct from hint (SPEC §4.3, issue #35)
-    val description: String? = null              // optional content teaser / message body (SPEC §4.3, issue #35)
+    val description: String? = null,             // optional content teaser / message body (SPEC §4.3, issue #35)
+    val createdAt: Long? = null                  // author-declared Unix timestamp (seconds) this payload was authored, unverified (SPEC §3); distinct from discoveredAt
 ) {
     override fun equals(other: Any?) = other is FoundCache && cacheId == other.cacheId
     override fun hashCode() = cacheId.hashCode()

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/SectorAssembler.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/SectorAssembler.kt
@@ -76,7 +76,8 @@ class SectorAssembler {
             val preferDeclaredLocation: Boolean = false,
             val inReplyTo: ByteArray? = null,
             val title: String? = null,
-            val description: String? = null
+            val description: String? = null,
+            val createdAt: Long? = null
         ) : State()
 
         /** A Paper payload fully reassembled. [streamBytes] is the reassembled stream, stored as `ScannedPaper.cborBytes`. */
@@ -252,7 +253,8 @@ class SectorAssembler {
         preferDeclaredLocation = content.preferDeclaredLocation,
         inReplyTo = content.inReplyTo,
         title = content.title,
-        description = content.description
+        description = content.description,
+        createdAt = content.createdAt
     )
 
     /** Concatenates `sector_bytes` for indices `0..count-1` in order, or null if any is missing. */

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
@@ -45,7 +45,7 @@ import javax.crypto.spec.SecretKeySpec
  *                     24 icon, 28 encryption, 30 key_material, 31 retain_key,
  *                     37/38/39 kdf_*, 40 description, 45 bulky_meta_compression,
  *                     46 bulky_meta_compressed_bytes, 47 bulky_meta_sha256, 50 in_reply_to,
- *                     51 title
+ *                     51 title, 52 created_at
  *   bulky_meta_item:  15 files, 16 related (Paper); large fixed fields
  *   override map (§9, inside the content slot once decrypted): 3 hint, 4 mime_type,
  *                     5 content, 11 filename
@@ -154,6 +154,7 @@ object TagDropCodec {
     private const val K_PREFER_DECLARED_LOCATION = 49  // core_meta_item only — lat/lng wins over live GPS when true
     private const val K_IN_REPLY_TO = 50  // core_meta_item only — cache_id/root_hash of the single parent being replied to (SPEC §7)
     private const val K_TITLE       = 51  // short subject/caption, distinct from hint/label — valid for both Content and Paper
+    private const val K_CREATED_AT  = 52  // author-declared Unix timestamp (seconds since epoch) this payload was authored — valid for both Content and Paper
 
     const val KDF_NONE          = 0
     const val KDF_PBKDF2_SHA256 = 1
@@ -289,6 +290,10 @@ object TagDropCodec {
      * [title] is an optional short subject/caption, kept separate from [hint]'s existing role.
      * [description] is an optional content teaser or message body — e.g. a postcard's message
      * when [rawContent] is spoken for by an attachment instead (SPEC §7, "Postcards").
+     *
+     * [createdAt] is an optional author-declared Unix timestamp (seconds since epoch) recording
+     * when this payload was authored — the authoring device's clock at encode time, not an
+     * independently verified timestamp (SPEC §3).
      */
     fun createContentSectors(
         hint: String?, filename: String?, mimeType: String,
@@ -302,6 +307,7 @@ object TagDropCodec {
         preferDeclaredLocation: Boolean = false,
         inReplyTo: ByteArray? = null,
         title: String? = null, description: String? = null,
+        createdAt: Long? = null,
         maxSectorDataBytes: Int = Int.MAX_VALUE
     ): List<Sector> {
         val (compressedContent, compression) =
@@ -340,7 +346,8 @@ object TagDropCodec {
             K_LNG     to lng,
             K_RADIUS_M to radiusM,
             K_PREFER_DECLARED_LOCATION to true.takeIf { preferDeclaredLocation },
-            K_IN_REPLY_TO to inReplyTo
+            K_IN_REPLY_TO to inReplyTo,
+            K_CREATED_AT to createdAt
         )
 
         // Single-sector when the stream fits; otherwise re-build with content_sha256 added.
@@ -368,13 +375,15 @@ object TagDropCodec {
         lat: Double? = null, lng: Double? = null, radiusM: Double? = null,
         preferDeclaredLocation: Boolean = false,
         inReplyTo: ByteArray? = null,
-        title: String? = null, description: String? = null
+        title: String? = null, description: String? = null,
+        createdAt: Long? = null
     ): List<Sector> {
         val first = createContentSectors(
             hint, filename, mimeType, rawContent, compress,
             collectionId, collectionLabel, collectionTag, icon,
             keyMaterial, retainKey, override, encryptionKey, declareEncryption,
             lat, lng, radiusM, preferDeclaredLocation, inReplyTo, title, description,
+            createdAt,
             maxSectorDataBytes = Int.MAX_VALUE
         )
         if (encode(first.first()).length <= DEFAULT_URI_LENGTH) return first
@@ -383,6 +392,7 @@ object TagDropCodec {
             collectionId, collectionLabel, collectionTag, icon,
             keyMaterial, retainKey, override, encryptionKey, declareEncryption,
             lat, lng, radiusM, preferDeclaredLocation, inReplyTo, title, description,
+            createdAt,
             maxSectorDataBytes = DEFAULT_SECTOR_DATA_BYTES
         )
     }
@@ -422,6 +432,7 @@ object TagDropCodec {
         preferDeclaredLocation: Boolean = false,
         inReplyTo: ByteArray? = null,
         title: String? = null,
+        createdAt: Long? = null,
         maxSectorDataBytes: Int = Int.MAX_VALUE
     ): Pair<TagDropPayload.Paper, List<Sector>> {
         val draft = TagDropPayload.Paper(
@@ -431,7 +442,7 @@ object TagDropCodec {
             collectionTag = collectionTag, icon = icon,
             keyMaterial = keyMaterial, retainKey = retainKey,
             lat = lat, lng = lng, radiusM = radiusM, preferDeclaredLocation = preferDeclaredLocation,
-            inReplyTo = inReplyTo, title = title
+            inReplyTo = inReplyTo, title = title, createdAt = createdAt
         )
         val stream = buildPaperStream(draft)
         val rootHash = sha256(stream).copyOf(8)
@@ -450,13 +461,15 @@ object TagDropCodec {
         lat: Double? = null, lng: Double? = null, radiusM: Double? = null,
         preferDeclaredLocation: Boolean = false,
         inReplyTo: ByteArray? = null,
-        title: String? = null
+        title: String? = null,
+        createdAt: Long? = null
     ): Pair<TagDropPayload.Paper, List<Sector>> {
         val first = createPaper(
             label, set, slug, files, related, description,
             collectionId, collectionLabel, collectionTag, icon,
             keyMaterial, retainKey,
             lat, lng, radiusM, preferDeclaredLocation, inReplyTo, title,
+            createdAt,
             maxSectorDataBytes = Int.MAX_VALUE
         )
         if (encode(first.second.first()).length <= DEFAULT_URI_LENGTH) return first
@@ -465,6 +478,7 @@ object TagDropCodec {
             collectionId, collectionLabel, collectionTag, icon,
             keyMaterial, retainKey,
             lat, lng, radiusM, preferDeclaredLocation, inReplyTo, title,
+            createdAt,
             maxSectorDataBytes = DEFAULT_SECTOR_DATA_BYTES
         )
     }
@@ -524,6 +538,7 @@ object TagDropCodec {
             K_RADIUS_M to paper.radiusM,
             K_PREFER_DECLARED_LOCATION to true.takeIf { paper.preferDeclaredLocation },
             K_IN_REPLY_TO to paper.inReplyTo,
+            K_CREATED_AT to paper.createdAt,
             K_BULKY_SHA to sha256(bulkyBytes)
         )
         val out = ByteArrayOutputStream()
@@ -765,7 +780,8 @@ object TagDropCodec {
                 preferDeclaredLocation = core.boolOrNull(K_PREFER_DECLARED_LOCATION) ?: false,
                 inReplyTo       = core.bytesOrNull(K_IN_REPLY_TO),
                 title           = core.text(K_TITLE),
-                description     = core.text(K_DESCRIPTION)
+                description     = core.text(K_DESCRIPTION),
+                createdAt       = core.uint(K_CREATED_AT)
             )
         )
     }
@@ -857,7 +873,8 @@ object TagDropCodec {
             radiusM         = parts.core.doubleOrNull(K_RADIUS_M),
             preferDeclaredLocation = parts.core.boolOrNull(K_PREFER_DECLARED_LOCATION) ?: false,
             inReplyTo       = parts.core.bytesOrNull(K_IN_REPLY_TO),
-            title           = parts.core.text(K_TITLE)
+            title           = parts.core.text(K_TITLE),
+            createdAt       = parts.core.uint(K_CREATED_AT)
         )
     }
 
@@ -905,7 +922,7 @@ object TagDropCodec {
         K_BULKY_COMPRESSION to "bulky_meta_compression",
         K_BULKY_COMPRESSED_BYTES to "bulky_meta_compressed_bytes", K_BULKY_SHA to "bulky_meta_sha256",
         K_RADIUS_M to "radius_m", K_PREFER_DECLARED_LOCATION to "prefer_declared_location",
-        K_IN_REPLY_TO to "in_reply_to", K_TITLE to "title"
+        K_IN_REPLY_TO to "in_reply_to", K_TITLE to "title", K_CREATED_AT to "created_at"
     )
 
     private val TYPE_NAMES = mapOf(TYPE_CONTENT to "Content", TYPE_PAPER to "Paper")

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
@@ -42,7 +42,8 @@ sealed class TagDropPayload {
         val preferDeclaredLocation: Boolean = false, // if true, lat/lng wins over live GPS even when a fix is available
         val inReplyTo: ByteArray? = null,       // optional — cache_id/root_hash of the single parent this is replying to (SPEC §7)
         val title: String? = null,              // optional — short subject/caption, distinct from hint (SPEC §4.3, issue #35)
-        val description: String? = null         // optional — content teaser / message body, e.g. when an attachment occupies content (SPEC §4.3, issue #35)
+        val description: String? = null,        // optional — content teaser / message body, e.g. when an attachment occupies content (SPEC §4.3, issue #35)
+        val createdAt: Long? = null             // optional — author-declared Unix timestamp (seconds) this payload was authored; the authoring device's clock, not independently verified (SPEC §3)
     ) : TagDropPayload() {
         override fun equals(other: Any?) = other is Content && cacheId.contentEquals(other.cacheId)
         override fun hashCode() = cacheId?.contentHashCode() ?: 0
@@ -123,7 +124,8 @@ sealed class TagDropPayload {
         val radiusM: Double? = null,            // optional — circle-of-uncertainty radius in meters around lat/lng
         val preferDeclaredLocation: Boolean = false, // if true, lat/lng wins over live GPS even when a fix is available
         val inReplyTo: ByteArray? = null,       // optional — cache_id/root_hash of the single parent this is replying to (SPEC §7)
-        val title: String? = null               // optional — short subject/caption, distinct from label (SPEC §4.3, issue #35)
+        val title: String? = null,              // optional — short subject/caption, distinct from label (SPEC §4.3, issue #35)
+        val createdAt: Long? = null             // optional — author-declared Unix timestamp (seconds) this payload was authored; the authoring device's clock, not independently verified (SPEC §3)
     ) : TagDropPayload() {
         override fun equals(other: Any?) = other is Paper && rootHash.contentEquals(other.rootHash)
         override fun hashCode() = rootHash.contentHashCode()

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropCodecTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropCodecTest.kt
@@ -57,6 +57,7 @@ class TagDropCodecTest {
         assertNull(state.collectionLabel)
         assertNull(state.collectionTag)
         assertNull(state.icon)
+        assertNull(state.createdAt)
     }
 
     @Test fun contentWithCollectionAndIcon() {
@@ -83,6 +84,15 @@ class TagDropCodecTest {
         assertEquals("Greetings from the coast", state.title)
         assertEquals("Wish you were here", state.description)
         assertArrayEquals(parentId, state.inReplyTo)
+    }
+
+    @Test fun contentWithCreatedAt() {
+        val sectors = TagDropCodec.createContentSectors(
+            "hint text", null, "text/plain", "postcard message".toByteArray(),
+            createdAt = 1_750_000_000L
+        )
+        val state = assemble(roundTrip(sectors)) as SectorAssembler.State.ContentReady
+        assertEquals(1_750_000_000L, state.createdAt)
     }
 
     @Test fun contentWithCompressionDecompressedOnAssembly() {
@@ -325,6 +335,16 @@ class TagDropCodecTest {
         val state = assemble(roundTrip(sectors)) as SectorAssembler.State.PaperReady
         assertEquals("Reply to Stop 3", state.paper.title)
         assertArrayEquals(parentId, state.paper.inReplyTo)
+    }
+
+    @Test fun paperWithCreatedAt() {
+        val files = listOf(TagDropPayload.FileEntry("index", "text/html", byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)))
+        val (_, sectors) = TagDropCodec.createPaper(
+            "Trail Stop 4", "sunset-trail", "stop-4", files,
+            createdAt = 1_750_000_000L
+        )
+        val state = assemble(roundTrip(sectors)) as SectorAssembler.State.PaperReady
+        assertEquals(1_750_000_000L, state.paper.createdAt)
     }
 
     @Test fun paperRootHashIsContentAddressed() {

--- a/tools/generator/index.html
+++ b/tools/generator/index.html
@@ -233,6 +233,12 @@
     </div>
     <div class="row">
       <div>
+        <label>Created at <small>(optional — self-declared authoring time, taken from this device's clock; not verified)</small></label>
+        <input type="datetime-local" id="s-created-at">
+      </div>
+    </div>
+    <div class="row">
+      <div>
         <label>Latitude <small>(optional — this code's own declared location, see §4.2)</small></label>
         <input type="text" id="s-lat" placeholder="e.g. -33.8688">
       </div>
@@ -395,6 +401,12 @@
       <div>
         <label>Replying to <small>(optional, hex — cache_id/root_hash of the code this replies to, see §7)</small></label>
         <input type="text" id="p-in-reply-to" placeholder="e.g. a1b2c3d4e5f60718" style="font-family:monospace">
+      </div>
+    </div>
+    <div class="row">
+      <div>
+        <label>Created at <small>(optional — self-declared authoring time, taken from this device's clock; not verified)</small></label>
+        <input type="datetime-local" id="p-created-at">
       </div>
     </div>
     <div class="row">
@@ -752,7 +764,7 @@ const KEY_NAMES = {
   42: 'sector_index', 43: 'sector_count', 44: 'parity_scheme',
   45: 'bulky_meta_compression', 46: 'bulky_meta_compressed_bytes', 47: 'bulky_meta_sha256',
   48: 'radius_m', 49: 'prefer_declared_location',
-  50: 'in_reply_to', 51: 'title',
+  50: 'in_reply_to', 51: 'title', 52: 'created_at',
 };
 
 function toHexDump(bytes) {
@@ -938,7 +950,7 @@ const K = { CACHE_ID:2, HINT:3, MIME:4, CONTENT:5,
              SECTOR_INDEX:42, SECTOR_COUNT:43, PARITY:44,
              BULKY_COMPRESSION:45, BULKY_COMPRESSED_BYTES:46, BULKY_SHA:47,
              RADIUS_M:48, PREFER_DECLARED_LOCATION:49,
-             IN_REPLY_TO:50, TITLE:51 };
+             IN_REPLY_TO:50, TITLE:51, CREATED_AT:52 };
 
 // Sector sizing (mirrors Kotlin TagDropCodec.MAX_URI_LENGTH / MAX_SECTOR_DATA_BYTES):
 // MAX_URI_LENGTH/MAX_SECTOR_DATA_BYTES are the hard ceiling beyond which a sector's
@@ -1028,7 +1040,7 @@ async function createContentSectors({
   keyMaterial, retainKey = true,
   override, encryptionKey, kdfPassphrase, declareEncryption = true,
   lat, lng, radiusM, preferDeclaredLocation = false,
-  inReplyTo, title,
+  inReplyTo, title, createdAt,
   maxSectorDataBytes = Infinity,
 }) {
   let compression = null, compressedContent = rawBytes;
@@ -1074,6 +1086,7 @@ async function createContentSectors({
       [K.PREFER_DECLARED_LOCATION, preferDeclaredLocation ? true : null],
       [K.IN_REPLY_TO, inReplyTo || null],
       [K.TITLE, title || null],
+      [K.CREATED_AT, createdAt || null],
     ];
   }
 
@@ -1134,7 +1147,7 @@ function createKeyCodeSector({ keyMaterial, retainKey = true, hint }) {
  * structures where a constant ~36-byte cost is negligible next to the cost of an unverified
  * directory.
  */
-async function buildPaperStream({ label, set, slug, files, related, description, collectionId, collectionLabel, collectionTag, icon, keyMaterial, retainKey = true, lat, lng, radiusM, preferDeclaredLocation = false, inReplyTo, title }) {
+async function buildPaperStream({ label, set, slug, files, related, description, collectionId, collectionLabel, collectionTag, icon, keyMaterial, retainKey = true, lat, lng, radiusM, preferDeclaredLocation = false, inReplyTo, title, createdAt }) {
   const bulky = [
     [K.FILES, files.map(f => subMap([
       [K.FILE_SLUG, f.slug], [K.FILE_MIME, f.mimeType], [K.FILE_ID, f.fileId],
@@ -1165,6 +1178,7 @@ async function buildPaperStream({ label, set, slug, files, related, description,
     [K.PREFER_DECLARED_LOCATION, preferDeclaredLocation ? true : null],
     [K.IN_REPLY_TO, inReplyTo || null],
     [K.TITLE, title || null],
+    [K.CREATED_AT, createdAt || null],
     [K.BULKY_SHA, await sha256(bulkyBytes)],
   ];
   return concatBytes(cborMap(core), bulkyBytes);
@@ -1193,6 +1207,21 @@ async function createPaperAutoSized(args, targetSectorBytes = DEFAULT_SECTOR_DAT
 }
 
 function toHex(u8) { return Array.from(u8).map(b => b.toString(16).padStart(2,'0')).join(''); }
+
+// `created_at` (SPEC §3, key 52) round-trips through an <input type="datetime-local">,
+// which reads/writes local time with no timezone suffix — Date treats that string as
+// local time on the way in, and these helpers mirror that on the way out so the field
+// always reflects the browser's local clock, matching the Kotlin app's auto-stamp.
+function nowAsDatetimeLocal() {
+  const d = new Date();
+  const pad = n => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+function datetimeLocalToEpochSeconds(value) {
+  if (!value) return null;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? Math.floor(ms / 1000) : null;
+}
 
 // Turns a human-readable label (a file slug, hint, or caption fragment) into a
 // safe filename component — keeps ZIP entries self-describing instead of
@@ -1843,6 +1872,7 @@ function buildSingleEncodeArgs() {
   let inReplyTo;
   try { inReplyTo = hexToBytes(document.getElementById('s-in-reply-to').value); }
   catch (e) { throw new Error('Replying to must be hex (e.g. a1b2c3d4e5f60718).'); }
+  const createdAt = datetimeLocalToEpochSeconds(document.getElementById('s-created-at').value);
 
   // Declared location (SPEC §4.2) — also never secret, carried through encryption the
   // same way as collection/icon above.
@@ -1883,7 +1913,7 @@ function buildSingleEncodeArgs() {
         kdfPassphrase,
         collectionId, collectionLabel, collectionTag, icon,
         lat, lng, radiusM, preferDeclaredLocation,
-        inReplyTo, title,
+        inReplyTo, title, createdAt,
       };
     } else {
       encryptionKey = generateKeyMaterial();
@@ -1897,14 +1927,14 @@ function buildSingleEncodeArgs() {
         encryptionKey,
         collectionId, collectionLabel, collectionTag, icon,
         lat, lng, radiusM, preferDeclaredLocation,
-        inReplyTo, title,
+        inReplyTo, title, createdAt,
       };
     }
   } else {
     encodeArgs = {
       hint, filename, mimeType, rawBytes, compress, collectionId, collectionLabel, collectionTag, icon,
       lat, lng, radiusM, preferDeclaredLocation,
-      inReplyTo, title,
+      inReplyTo, title, createdAt,
     };
   }
 
@@ -2118,6 +2148,7 @@ async function computePaperSectorPlan() {
   let inReplyTo;
   try { inReplyTo = hexToBytes(document.getElementById('p-in-reply-to').value); }
   catch (e) { throw new Error('Replying to must be hex (e.g. a1b2c3d4e5f60718).'); }
+  const createdAt = datetimeLocalToEpochSeconds(document.getElementById('p-created-at').value);
 
   // Declared location (SPEC §4.2) — this paper's own placement, distinct from a related
   // entry's hint-location use of the same lat/lng/radius_m fields.
@@ -2192,7 +2223,7 @@ async function computePaperSectorPlan() {
       label, set, slug, files: manifestFiles, related, description,
       collectionId, collectionLabel, collectionTag, icon,
       lat, lng, radiusM, preferDeclaredLocation,
-      inReplyTo, title,
+      inReplyTo, title, createdAt,
     }, targetSectorBytes);
   }
   catch(e) { throw new Error(`Paper encoding failed: ${e.message}`); }
@@ -2566,6 +2597,12 @@ setupDropzone(document.getElementById('p-dropzone'), async files => {
   if (zipCount)  parts.push(`${zipCount} file(s) from ZIP archive(s)`);
   if (parts.length) msgs.innerHTML += `<div class="ok">Added ${parts.join(' and ')}.</div>`;
 });
+
+// `created_at` defaults to "now" on load, mirroring the Kotlin app's silent auto-stamp,
+// but stays an editable field here since the web generator is the primary authoring tool
+// (CLAUDE.md) and already exposes every other optional field — clear it to omit created_at.
+document.getElementById('s-created-at').value = nowAsDatetimeLocal();
+document.getElementById('p-created-at').value = nowAsDatetimeLocal();
 
 // ── Live QR-count estimates ─────────────────────────────────────────────────
 // Delegated listeners catch direct user edits anywhere in each tab (including

--- a/tools/reader/index.html
+++ b/tools/reader/index.html
@@ -540,7 +540,7 @@ const K = {
   SECTOR_INDEX:42, SECTOR_COUNT:43, PARITY:44,
   BULKY_COMPRESSION:45, BULKY_COMPRESSED_BYTES:46, BULKY_SHA:47,
   RADIUS_M:48, PREFER_DECLARED_LOCATION:49,
-  IN_REPLY_TO:50, TITLE:51
+  IN_REPLY_TO:50, TITLE:51, CREATED_AT:52
 };
 
 // CBOR-sequence envelope (SPEC §2):
@@ -607,7 +607,7 @@ const KEY_NAMES = {
   42: 'sector_index', 43: 'sector_count', 44: 'parity_scheme',
   45: 'bulky_meta_compression', 46: 'bulky_meta_compressed_bytes', 47: 'bulky_meta_sha256',
   48: 'radius_m', 49: 'prefer_declared_location',
-  50: 'in_reply_to', 51: 'title',
+  50: 'in_reply_to', 51: 'title', 52: 'created_at',
 };
 
 function toHexDump(bytes) {
@@ -812,6 +812,7 @@ async function parseContentStream(stream, partMeta) {
       preferDeclaredLocation: core[K.PREFER_DECLARED_LOCATION] === true,
       inReplyTo:       core[K.IN_REPLY_TO] ? toHex(core[K.IN_REPLY_TO]) : null,
       title:           core[K.TITLE] ?? null,
+      createdAt:       core[K.CREATED_AT] ?? null,
     },
   };
 }
@@ -887,6 +888,7 @@ function paperFromParts(parts, rootHash) {
     preferDeclaredLocation: parts.core[K.PREFER_DECLARED_LOCATION] === true,
     inReplyTo:       parts.core[K.IN_REPLY_TO] ? toHex(parts.core[K.IN_REPLY_TO]) : null,
     title:           parts.core[K.TITLE] ?? null,
+    createdAt:       parts.core[K.CREATED_AT] ?? null,
   };
 }
 
@@ -1078,7 +1080,7 @@ function readyContentState(content, hint, filename, mimeType, resolved, pendingB
     wasEncrypted,
     lat: content.lat, lng: content.lng, radiusM: content.radiusM,
     preferDeclaredLocation: content.preferDeclaredLocation,
-    inReplyTo: content.inReplyTo, title: content.title,
+    inReplyTo: content.inReplyTo, title: content.title, createdAt: content.createdAt,
   };
 }
 
@@ -1215,12 +1217,12 @@ async function completeSingle(cacheId, hint, filename, mimeType, content, opts =
     collectionId = null, collectionLabel = null, collectionTag = null, icon = null,
     pendingOverrideBlob = null, pendingCompression = 0, wasEncrypted = false,
     kdfAlg = 0, kdfSalt = null, kdfIters = 100000,
-    inReplyTo = null, title = null,
+    inReplyTo = null, title = null, createdAt = null,
   } = opts;
   await dbPut('caches', {
     cacheId, hint, filename, mimeType, content,
     pendingOverrideBlob, pendingCompression, wasEncrypted, kdfAlg, kdfSalt, kdfIters,
-    inReplyTo, title,
+    inReplyTo, title, createdAt,
   });
   const label = filename || hint || mimeType;
   await showContent(mimeType, content, label, cacheId, { icon, collectionLabel, collectionTag, collectionId });
@@ -1268,7 +1270,7 @@ async function handleContentReady(state) {
       override.mimeType ?? state.mimeType, override.content ?? new Uint8Array(0),
       { collectionId: state.collectionId, collectionLabel: state.collectionLabel,
         collectionTag: state.collectionTag, icon: state.icon, wasEncrypted: true,
-        inReplyTo: state.inReplyTo, title: state.title }
+        inReplyTo: state.inReplyTo, title: state.title, createdAt: state.createdAt }
     );
     showMsg('🔓 Decrypted: ' + label, 'ok');
     return;
@@ -1281,7 +1283,7 @@ async function handleContentReady(state) {
       filename: state.filename, mimeType: state.mimeType,
       collectionId: state.collectionId, collectionLabel: state.collectionLabel,
       collectionTag: state.collectionTag, icon: state.icon,
-      inReplyTo: state.inReplyTo, title: state.title,
+      inReplyTo: state.inReplyTo, title: state.title, createdAt: state.createdAt,
     });
     return;
   }
@@ -1292,7 +1294,7 @@ async function handleContentReady(state) {
       collectionTag: state.collectionTag, icon: state.icon,
       pendingOverrideBlob: blob, pendingCompression: state.pendingOverrideCompression,
       wasEncrypted: state.wasEncrypted, kdfAlg: state.kdfAlg, kdfSalt: state.kdfSalt, kdfIters: state.kdfIters,
-      inReplyTo: state.inReplyTo, title: state.title }
+      inReplyTo: state.inReplyTo, title: state.title, createdAt: state.createdAt }
   );
   showMsg(blob ? 'Loaded: ' + label + ' (🔒 hidden content not yet unlocked)' : 'Loaded: ' + label, 'ok');
 }
@@ -1317,7 +1319,7 @@ async function handleAwaitingKey(state) {
       compression: state.compression, kdfSalt: state.kdfSalt, kdfIters: state.kdfIters,
       fallbackContent: null, filename: null, mimeType: '',
       collectionId: null, collectionLabel: null, collectionTag: null, icon: null,
-      inReplyTo: null, title: null,
+      inReplyTo: null, title: null, createdAt: null,
     });
     return;
   }
@@ -1335,7 +1337,7 @@ async function handleAwaitingKey(state) {
  */
 async function unlockWithPassphrase({
   hint, cacheId, blob, compression, kdfSalt, kdfIters, fallbackContent, filename, mimeType,
-  collectionId, collectionLabel, collectionTag, icon, inReplyTo, title
+  collectionId, collectionLabel, collectionTag, icon, inReplyTo, title, createdAt
 }) {
   const saltHex = toHex(kdfSalt);
   const info = hint
@@ -1357,7 +1359,7 @@ async function unlockWithPassphrase({
       const label = await completeSingle(
         cacheId, override.hint ?? hint, override.filename ?? filename, override.mimeType ?? mimeType,
         override.content ?? new Uint8Array(0),
-        { collectionId, collectionLabel, collectionTag, icon, wasEncrypted: true, inReplyTo, title }
+        { collectionId, collectionLabel, collectionTag, icon, wasEncrypted: true, inReplyTo, title, createdAt }
       );
       await unlockPending(derived);
       for (const r of await assembler.tryKey(derived)) await completeContentReady(r);
@@ -1371,7 +1373,7 @@ async function unlockWithPassphrase({
       cacheId, hint, filename, mimeType, fallbackContent,
       { collectionId, collectionLabel, collectionTag, icon,
         pendingOverrideBlob: blob, pendingCompression: compression, wasEncrypted: true,
-        kdfAlg: 1, kdfSalt, kdfIters, inReplyTo, title }
+        kdfAlg: 1, kdfSalt, kdfIters, inReplyTo, title, createdAt }
     );
     showMsg(wrongPassphrase
       ? 'Wrong passphrase. Loaded: ' + label + ' (🔒 still locked)'
@@ -1408,7 +1410,7 @@ async function completeContentReady(state) {
     { collectionId: state.collectionId, collectionLabel: state.collectionLabel,
       collectionTag: state.collectionTag, icon: state.icon,
       pendingOverrideBlob: state.pendingOverrideBlob, pendingCompression: state.pendingOverrideCompression,
-      wasEncrypted: state.wasEncrypted, inReplyTo: state.inReplyTo, title: state.title }
+      wasEncrypted: state.wasEncrypted, inReplyTo: state.inReplyTo, title: state.title, createdAt: state.createdAt }
   );
   showMsg('🔓 Unlocked: ' + label, 'ok');
 }
@@ -1664,13 +1666,18 @@ async function findRepliesTo(parentId) {
   ];
 }
 
-/** Renders a postcard's short subject (title, SPEC §7), an "↩ Replying to" link (resolved
- *  if the parent is already cached, an inert chip otherwise), and a "💬" button per reply
- *  found pointing back at [selfId] — into [el]. Shared by renderPaper and showContent;
- *  hides [el] entirely when there's nothing to show. */
-async function renderReplyInfo(el, { title, inReplyTo, selfId } = {}) {
+/** Renders a postcard's short subject (title, SPEC §7), an author-declared timestamp
+ *  (created_at, SPEC §3 key 52 — self-declared, not verified), an "↩ Replying to" link
+ *  (resolved if the parent is already cached, an inert chip otherwise), and a "💬" button
+ *  per reply found pointing back at [selfId] — into [el]. Shared by renderPaper and
+ *  showContent; hides [el] entirely when there's nothing to show. */
+async function renderReplyInfo(el, { title, inReplyTo, selfId, createdAt } = {}) {
   const parts = [];
   if (title) parts.push('<strong>' + escHtml(title) + '</strong>');
+  if (createdAt) {
+    parts.push('<span class="chip" title="Self-declared by the author\'s device clock; not verified">🕐 ' +
+      escHtml(new Date(createdAt * 1000).toLocaleString()) + '</span>');
+  }
   if (inReplyTo) {
     const parent = await resolveReplyParent(inReplyTo);
     parts.push(parent
@@ -1739,7 +1746,7 @@ async function renderPaper(rootHash) {
   document.getElementById('paperHeader').innerHTML = hdr;
 
   await renderReplyInfo(document.getElementById('paperReplyInfo'),
-    { title: paper.title, inReplyTo: paper.inReplyTo, selfId: paper.rootHash });
+    { title: paper.title, inReplyTo: paper.inReplyTo, selfId: paper.rootHash, createdAt: paper.createdAt });
 
   const descEl = document.getElementById('paperDescription');
   if (paper.description) {
@@ -1855,7 +1862,8 @@ async function showContent(mimeType, content, title, cacheId, meta) {
   // keeps this independent of which caller/path reached showContent.
   const cached = cacheId ? await dbGet('caches', cacheId) : null;
   await renderReplyInfo(document.getElementById('contentReplyInfo'),
-    { title: cached && cached.title, inReplyTo: cached && cached.inReplyTo, selfId: cacheId });
+    { title: cached && cached.title, inReplyTo: cached && cached.inReplyTo, selfId: cacheId,
+      createdAt: cached && cached.createdAt });
 
   if (mimeType.startsWith('text/html')) {
     renderHtmlInIframe(area, new TextDecoder().decode(content));


### PR DESCRIPTION
## Summary
- Adds a new optional `created_at` field (CBOR key 52, Unix epoch seconds) to both Content and Paper payloads — a self-declared, unverified timestamp based on the authoring device's clock (SPEC §3). Unknown-keys-ignored forward compatibility means this needs no version bump.
- **Kotlin app** (canonical implementation): threaded through `TagDropCodec` encode/decode, `TagDropPayload`/`SectorAssembler` state, a new Room migration (`AppDatabase` v14→v15, `FoundCache.createdAt` column), auto-stamped on creation in `CreateActivity`/`CreatePaperActivity`, and round-tripped through `ReceiveActivity`/`ShareQrActivity`/`WriteNfcTagActivity`. `ScannedPaper` needs no schema change — it re-derives fields from stored raw CBOR.
- **Web tools**: `tools/generator/index.html` gains a `created_at` datetime-local input (defaulting to "now") on both the Single File and Paper Layout tabs; `tools/reader/index.html` decodes it and renders a 🕐 chip with the formatted local time on both Content and Paper views.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — full suite passes, including new `contentWithCreatedAt()`/`paperWithCreatedAt()` round-trip tests in `TagDropCodecTest`
- [x] `cd tools && npm test` (independent Node QR round-trip suite) — 8 passed, 0 failed
- [x] Playwright end-to-end check: generator → reader round-trip verified for both Content and Paper flows, confirming the 🕐 chip renders the correct local-time string

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013gTYNpLGKzRhaPMSXSZnXC)_