### PR TITLE
Fix tagdrop:// domain/hash collision (#51) + add in-app spec viewer

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -64,17 +64,30 @@ For values 0–23, a CBOR unsigned integer is exactly **one byte** (RFC 8949 maj
 
 ### Navigation links (not QR payloads)
 
-HTML pages embedded in TagDrop caches can link to other files and papers using:
+HTML pages embedded in TagDrop caches can link to other files and papers using one of three forms:
 
 ```
-tagdrop://<rootHash-hex>/<slug>
+tagdrop://<domain>/<slug>
+tagdrop://@<rootHash-hex>/<slug>
+tagdrop://<domain>@<rootHash-hex>/<slug>
 ```
 
-`rootHash` is the Paper's `root_hash` (§4.4) — the 8-byte SHA-256 of its reassembled stream (`core_meta_item || bulky_meta_item || content`, §4.2) — lowercase-hex-encoded (16 characters). `slug` is the file's identifier within that paper. The TagDrop app intercepts these links in its WebView and resolves them against the local scanned-paper database — no network needed. A human-readable **domain name** may be used in place of `<rootHash-hex>` — see "Domains" in §7.
+- `tagdrop://<domain>/<slug>` — **floating**: resolved by name (§7 "Domains"); the paper behind a domain can change over time.
+- `tagdrop://@<rootHash-hex>/<slug>` — **pinned**: resolved to one exact, immutable paper.
+- `tagdrop://<domain>@<rootHash-hex>/<slug>` — both: the hash is authoritative for resolution, `domain` is a decorative label only.
 
-**Why hex, not Base41, here?** Base41's alphabet includes `:`, which is fine inside the *path* of an opaque URI like `tagdrop:<base41-cbor-sequence>` but not inside a URL's *authority* (host[:port]) component — a `:` there starts the port subcomponent per the WHATWG URL Standard, and anything after it that isn't a bare port number is a hard parse failure for the whole URL. Since the root hash sits in the authority position of a `tagdrop://` link, a Base41-encoded root hash containing `:` (roughly 1 in 4, since `:` is 1 of 41 alphabet characters) would make the link unparseable. Plain lowercase hex has no such character, at the cost of 4 extra characters (16 hex vs 12 Base41 for 8 bytes) — cheap, since navigation links are clicked/typed, not scanned from a QR code.
+`rootHash` is the Paper's `root_hash` (§4.4) — the 8-byte SHA-256 of its reassembled stream (`core_meta_item || bulky_meta_item || content`, §4.2) — lowercase-hex-encoded (16 characters). `domain` is a human-readable name a paper claims for itself (§7 "Domains") — unlike `rootHash`, it is never unique, and is resolved by lookup rather than exact match. `slug` is the file's identifier within the resolved paper. The TagDrop app intercepts these links in its WebView and resolves them against the local scanned-paper database — no network needed.
 
-**Disambiguation:** encoding payloads never contain `//` — `tagdrop:<base41-cbor-sequence>` has no authority component. Navigation links always do — the root hash serves as the link's authority. Base41's alphabet has no `/` character at all, so it can never appear anywhere in a Base41-encoded string, let alone right after the scheme. Encoding URIs and navigation links are therefore unambiguously distinguishable by whether `//` follows the scheme.
+These three forms reuse standard URI **authority** syntax (`[userinfo "@"] host`, RFC 3986 §3.2.1) instead of inventing TagDrop-specific punctuation: `domain` occupies the userinfo slot, `rootHash` the host slot. The `@` is what decides resolution, never the shape of the text around it:
+
+- No `@` → the entire host is `domain`, looked up by name — **never** attempted as a hash, even if it happens to be the same length and shape as one.
+- `@` present → whatever follows it is always `rootHash`, looked up by exact match; whatever precedes it (possibly nothing) is an optional, purely cosmetic label, never used for resolution.
+
+See "Resolving a domain link" in §7 for why this needed to be a syntactic split rather than a lookup-order rule, and §16 for other markers considered.
+
+**Why hex, not Base41, for `rootHash`?** Base41's alphabet includes `:`, which is fine inside the *path* of an opaque URI like `tagdrop:<base41-cbor-sequence>` but not inside a URL's *authority* (host[:port]) component — a `:` there starts the port subcomponent per the WHATWG URL Standard, and anything after it that isn't a bare port number is a hard parse failure for the whole URL. Since `rootHash` sits in the authority position of a `tagdrop://` link, a Base41-encoded root hash containing `:` (roughly 1 in 4, since `:` is 1 of 41 alphabet characters) would make the link unparseable. Plain lowercase hex has no such character, at the cost of 4 extra characters (16 hex vs 12 Base41 for 8 bytes) — cheap, since navigation links are clicked/typed, not scanned from a QR code. This is the same hazard that ruled out `:` as the `domain`/`rootHash` marker (§16) — just relocated from inside the hash to between domain and hash.
+
+**Disambiguation from encoding URIs:** encoding payloads never contain `//` — `tagdrop:<base41-cbor-sequence>` has no authority component. Navigation links always do — `domain`/`rootHash` serve as the link's authority. Base41's alphabet has no `/` character at all, so it can never appear anywhere in a Base41-encoded string, let alone right after the scheme. Encoding URIs and navigation links are therefore unambiguously distinguishable by whether `//` follows the scheme, independent of the `@` marker.
 
 **Why Base41?** QR codes have an alphanumeric mode (charset 0–9, A–Z, space, `$%*+-./:`, 45 characters) that stores 5.5 bits per character vs 8 bits per character in binary mode. RFC 9285's Base45 uses that full 45-character set, encoding 2 bytes → 3 alphanumeric characters (~3% overhead over QR's alphanumeric capacity) — far better than Base64 (33% overhead, and forces binary mode since Base64 needs lowercase letters). TagDrop uses **Base41**: the same 2-bytes-to-3-characters packing as Base45, but over a 41-character subset of the QR alphanumeric set — `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ$*-.:` — that drops the 4 characters which cause trouble outside QR codes: space and `%` aren't valid unescaped in a URI (RFC 3986), and `+`/`/` carry special meaning in URLs (`+` as a space in query strings, `/` as a path separator). 41 is the smallest alphabet for which 3 characters can still represent every 16-bit value (41³ = 68921 ≥ 65536; 40³ = 64000 does not), so this costs nothing — Base41 output is exactly the same length as Base45 output would be for the same bytes. The result is a string that's always a strictly valid, unescaped URI component, with no percent-encoding step needed on either side. This alphabet is also a safe (if non-optimal) subset of Data Matrix's C40 mode and Aztec's Upper/Digit modes, so the same encoded string stays reasonably dense on those carriers too (§13).
 
@@ -470,7 +483,7 @@ location, per §4.2's priority rule) replaces the placeholder.
 
 **Navigation:** HTML files on the paper can link to other files using:
 ```html
-<a href="tagdrop://<paper-root-hash-hex>/map">See the map</a>
+<a href="tagdrop://@<paper-root-hash-hex>/map">See the map</a>
 ```
 The TagDrop app intercepts these links and resolves them from the local database.
 
@@ -680,18 +693,20 @@ Scan the Paper code first to get the directory, then scan whichever file you wan
 
 ### Navigation links
 
-HTML files can link across the TagDropNet using:
+HTML files can link across the TagDropNet using one of three forms (§2):
 ```
-tagdrop://<rootHash-hex>/<slug>
+tagdrop://<domain>/<slug>
+tagdrop://@<rootHash-hex>/<slug>
+tagdrop://<domain>@<rootHash-hex>/<slug>
 ```
 
 When the TagDrop WebView encounters such a link, it:
-1. Looks up `rootHash` in the local scanned-papers database.
+1. Resolves the host to a single paper — an exact `root_hash` lookup for the `@<rootHash-hex>` forms, or a domain lookup for the bare `<domain>` form (see "Domains" below).
 2. Finds the `slug` in that paper's file directory.
 3. Looks up the file's `cache_id` in the found-caches database.
 4. If found: loads the file. If not: shows a "not yet scanned" message with the location hint.
 
-This gives the experience of browsing a website, but entirely offline and made of physical paper. `rootHash` may instead be a human-readable **domain name** — see "Domains" below.
+This gives the experience of browsing a website, but entirely offline and made of physical paper.
 
 ### Relative links (same-paper)
 
@@ -723,10 +738,10 @@ This works because of how slugs and page-loading combine:
   with the root hash gone. The app's `WebViewClient` recognises any
   `*.paper.tagdrop.invalid` host (alongside the `tagdrop://` scheme) and
   resolves the resulting `<rootHash-hex>`/`<slug>` pair through
-  `TagDropLinkResolver`, exactly like a `tagdrop://<rootHash>/<slug>` link.
+  `TagDropLinkResolver`, exactly like a `tagdrop://@<rootHash>/<slug>` link.
 
 To reference a file on a **different** paper (a different root hash), use an
-explicit `tagdrop://<rootHash-hex>/<slug>` link — this can't be relative,
+explicit `tagdrop://@<rootHash-hex>/<slug>` link — this can't be relative,
 since it's a different content-addressed directory.
 
 Practical effect: a normal static-site folder (HTML + CSS + images with
@@ -762,8 +777,9 @@ links to another paper with slug="letterbox" in the same set.
 
 The full navigation URI for the letterbox paper's index file would be:
 ```
-tagdrop://<letterbox-paper-root-hash-hex>/index
+tagdrop://@<letterbox-paper-root-hash-hex>/index
 ```
+(or, with a decorative label, `tagdrop://letterbox@<letterbox-paper-root-hash-hex>/index` — see "Domains" below.)
 
 Root hashes are permanent because paper is immutable. If a paper is updated, it gets a new hash — the old one continues to work as long as the old paper exists physically.
 
@@ -779,44 +795,68 @@ free with no extra field.
 Like `collection_id` ("Collections" below), a domain is **unilateral, not
 coordinated**: any author can claim any name, there's no registry, and
 nothing stops two unrelated papers from claiming the same one. This is a
-deliberate trade-off — useful names stay short — and is resolved at lookup
-time rather than prevented at authoring time (see "Resolving a domain
-link" below).
+deliberate trade-off — useful names stay short, and a domain can be
+**floating**: re-pointed to a new paper just by printing a fresh one that
+claims the same name, the same way updating a website means pointing a DNS
+name at new content, or moving a `latest`-tagged container image to a new
+build. A `root_hash`, by contrast, is always **pinned** — content-addressed
+and immutable; the only way to "change" what it points to is to scan a
+different hash. Navigation links can ask for either property — see "Domain
+and pinned links" below.
 
-#### Domain links
+#### Domain and pinned links
 
-A navigation link may use a domain name in place of the root hash:
+§2 splits `tagdrop://` links into three syntactic forms so that "look this
+name up" and "use this exact hash" are never ambiguous:
 
 ```
-tagdrop://<domain-name>/<slug>
+tagdrop://<domain>/<slug>
+tagdrop://@<rootHash-hex>/<slug>
+tagdrop://<domain>@<rootHash-hex>/<slug>
 ```
 
-The TagDrop app intercepts this exactly like a `tagdrop://<rootHash-hex>/<slug>`
-link, finds the file's `cache_id` in the resolved paper's directory, and
-loads it from the found-caches database.
+- `tagdrop://<domain>/<slug>` — a **floating** reference: resolved by domain
+  lookup (below), tracking whichever paper currently claims that name.
+- `tagdrop://@<rootHash-hex>/<slug>` — a **pinned** reference: resolved by
+  exact `root_hash` lookup, always the same paper.
+- `tagdrop://<domain>@<rootHash-hex>/<slug>` — pinned, with `domain` carried
+  along purely as a decorative label (e.g. for display in a UI or a printed
+  caption). Resolution uses `rootHash` only — `domain` here is never checked
+  against the resolved paper's actual declared domain, validated, or used as
+  a fallback if the hash lookup misses. It's exactly as unverified as
+  `label`/`hint`, or the `domain` field itself, always are. An author who
+  wants this label to be *trustworthy*, not just descriptive, needs §10
+  signatures, not this field.
+
+The TagDrop app intercepts all three forms exactly alike, finds the file's
+`cache_id` in the resolved paper's directory, and loads it from the
+found-caches database.
 
 #### Resolving a domain link
 
-A domain name and a root hash occupy the same position in the link, and a
-domain name made only of hex digits is indistinguishable from a root hash
-by shape alone. Resolvers MUST therefore:
+Whether a link is a domain lookup or a pinned hash lookup is decided by
+syntax alone — the presence of `@` — never by the shape of the host text:
 
-1. Try an exact `root_hash` lookup first (the database's primary key for
-   papers, so this is cheap regardless of whether the host turns out to be
-   hex-shaped).
-2. Only if that lookup misses — whether because the host isn't hex-shaped at
-   all, or because it is but no paper with that exact hash is known — fall
-   back to a domain lookup: scan known papers for `domain` (or, absent that,
-   `slug`) case-insensitively matching the host.
+- No `@`: the whole host is `domain`. Resolvers MUST scan known papers for
+  `domain` (or, absent that, `slug`) case-insensitively matching it —
+  **never** as a `root_hash` lookup, even if the text happens to be 16 hex
+  characters.
+- `@` present: whatever follows it is `rootHash`, resolved by an exact
+  `root_hash` lookup only. Whatever precedes the `@` (possibly nothing) is
+  discarded for resolution purposes — see "Domain and pinned links" above.
 
-This "exact match wins" order means a real root hash can never be shadowed
-by a same-looking domain name, while a hex-shaped domain name (e.g.
-`deadbeef`) still resolves normally on any device that hasn't *also* scanned
-a paper with that literal root hash.
+This syntactic split exists specifically so a same-looking `domain` can
+never be confused with, or shadow, a real `root_hash`, regardless of which
+one a device happens to have scanned first. An earlier draft tried to get
+the same guarantee from lookup order instead (try `root_hash` first, fall
+back to a domain scan only on a miss) — see §16 for why that's
+order-dependent and insufficient on its own, and for other markers
+considered before `@`.
 
 **Picking the closest match.** Because domains are uncoordinated, more than
 one known paper can match the same name — this is expected, not an error.
-When it happens, the app resolves to a single candidate using:
+When a bare `tagdrop://<domain>/<slug>` link resolves to more than one
+candidate, the app picks a single one using:
 
 1. If the device has a current position fix, and at least one candidate has
    a known location (declared, or resolved from a live GPS fix when it was
@@ -830,7 +870,12 @@ This favours "the one you're standing next to" when that's knowable, and
 arbitrary pick. If no known paper matches the name under either field, the
 app reports the domain as not found (with the requested `slug`, so the UI
 can still show what was being looked for) rather than treating it as
-invalid input — the name may simply not have been scanned yet.
+invalid input — the name may simply not have been scanned yet. A future,
+backward-compatible refinement could prefer, among several candidates, the
+one whose §10 `signer_id` the device has already trusted under this domain
+— pinning *authority* over a name without giving up the name's
+human-readable convenience — but no such tie-break exists yet, and nothing
+here requires signatures today.
 
 **Searchability:** since `domain` (and its `slug` fallback) is meant to be
 memorable, it's included alongside `label`/`set`/`slug` in the app's
@@ -1597,7 +1642,7 @@ Version history:
   - `Base41.kt` — TagDrop's own alphabet, packed like RFC 9285 Base45 (§2)
   - `MiniCbor.kt` — minimal CBOR encoder/decoder; supports arrays (major 4), nested maps, float64 (major 7), and top-level CBOR sequences (RFC 8742) for the version/type envelope
   - `SectorAssembler.kt` — multi-sector assembly with SHA-256 verification; tracks any number of in-flight `(type, cache_id)` groups concurrently
-  - `TagDropLinkResolver.kt` — resolves `tagdrop://<rootHash>/<slug>` navigation links; also locates the `style.css` sibling for `text/markdown` content (§7)
+  - `TagDropLinkResolver.kt` — resolves `tagdrop://<domain>/<slug>` and `tagdrop://[<domain>]@<rootHash>/<slug>` navigation links; also locates the `style.css` sibling for `text/markdown` content (§7)
   - `MarkdownRenderer.kt` — renders `text/markdown` content to HTML (§7) via CommonMark
 
 - **Android database:** `app/src/main/java/com/github/mofosyne/tagdrop/data/db/`
@@ -1612,6 +1657,51 @@ Version history:
 **Why not extend `data:` URI syntax?** (issues #2, #4, #13) Adding parameters like `;seq-id=`, `;seq-total=`, `;crc=` to the data URI was the original approach. It fails because data: URIs are opaque to QR readers — there's no way to route them to the app by scheme. The `tagdrop:` scheme gives us OS-level routing and a clean separation between the envelope and payload.
 
 **Why a version/type envelope instead of URI path segments or per-map keys?** An earlier draft put `v1/<type>/` in the URI path and a `version` key inside each payload map. That works for QR, but raw-byte carriers (NFC NDEF, JABCode raw — §12/§13) have no URI wrapper, so type/version information would either be lost or have to be guessed from which map keys happen to be present — fragile, and ambiguous for future payload types. Prefixing every sector with a CBOR Sequence (RFC 8742) led by `CBOR(version) || CBOR(type)`, 1 byte each for the foreseeable range of values — makes the same bytes self-describing on every carrier: Base41-encode them for `tagdrop:<base41>`, or store them raw in an NDEF record, with identical decode logic either way. It also lets the URI collapse to `tagdrop:<base41>` (no `//`, no `/<type>/` segment), gives a clean disambiguation rule against `tagdrop://<rootHash>/<slug>` navigation links (§2), and — being a sequence rather than a CBOR array — costs one less byte than an equivalent `[version, type, part_meta, sector_bytes]` array and doesn't require everything after `version`/`type` to be CBOR-wrapped, leaving room for raw non-CBOR bytes in a future version. `version` lives *only* in the envelope, not redundantly inside `part_meta` too: two fields claiming to describe the same fact can disagree, forcing a reader to pick which one to trust — the same class of ambiguity RFC 9112 §6.3 closes off by forbidding conflicting `Content-Length`/`Transfer-Encoding` framing in HTTP/1.1. CBOR's own self-describing-data convention (the tag-55799 "magic number", RFC 8949 §3.4.5.3) is likewise an external prefix rather than a duplicated internal field, reinforcing that self-description belongs in the envelope.
+
+**Why `@` to mark a pinned hash, not `:` or triple-slash?** (issue #51) An
+earlier draft resolved `domain`/`root_hash` collisions purely by *lookup
+order* — try an exact `root_hash` lookup first, fall back to a domain scan
+only on a miss. That closes the obvious case but is order-dependent: if a
+device scans an attacker-authored paper whose self-declared `domain` is
+crafted to exactly match a real paper's `root_hash` hex string *before* it
+ever scans the real paper, there's no real `root_hash` registered yet for
+the lookup to find first, so the domain claim wins silently — the device
+has no way to tell it apart from the genuine paper. Splitting `domain` and
+`root_hash` into syntactically distinct positions (rather than relying on
+order) needed a marker; alternatives considered and rejected:
+
+- `:` (`tagdrop://hash:<hex>/<slug>`) — rejected outright: `:` is the
+  host:port delimiter in URI authority syntax (WHATWG URL Standard), so
+  anything after it that isn't a bare port number is a hard parse failure.
+  This is the *exact* hazard §2 already documents for why root hashes use
+  hex instead of Base41 in this position — reusing `:` as a marker would
+  reintroduce it deliberately.
+- Triple-slash / empty authority (`tagdrop:///<hash>/<slug>`,
+  RFC 3986-idiomatic, like `file:///`) — not adopted: these links are
+  clicked inside a real Android WebView, where Chromium's URL canonicalizer
+  parses the href before the app's own resolver ever sees it, and whether
+  an empty authority survives that pass unmangled wasn't verified.
+- Requiring a literal `.` in domain names — rejected as strictly weaker: it
+  closes the bare-vs-bare ambiguity but has no way to express "named *and*
+  pinned" at once, which the combined form below gets for free.
+- Separate sub-schemes (`tagdrop-hash://`, `tagdrop-domain://`) — workable,
+  but doubles WebView interception surface and is the most verbose option.
+
+`@` was chosen instead, reusing standard URI authority syntax
+(`[userinfo "@"] host`, RFC 3986 §3.2.1) rather than inventing new
+TagDrop-specific punctuation: `domain` occupies the userinfo slot,
+`rootHash` the host slot. The marker sits on the hash side (`@<hash>`), not
+the domain side, because hash strings are always scanned, copy-pasted, or
+tool-generated — never hand-typed or memorized — so the punctuation costs a
+human nothing there, whereas `domain` exists specifically so links can be
+typed/spoken/memorized, and forcing extra punctuation onto it would
+undercut that purpose. The two non-bare forms map cleanly onto a
+distinction worth keeping on its own merits (§7 "Domains"): a bare
+`<domain>` is a **floating** reference that can be silently re-pointed by a
+later paper claiming the same name, while `@<rootHash-hex>` is a
+**pinned**, immutable one; `<domain>@<rootHash-hex>` gets both at once, with
+the leading label purely decorative and the hash always authoritative for
+resolution.
 
 **Why not NDEF as the primary format?** (issue #16) NDEF is a memory-layout format for NFC chips with a specific capability container. Adapting it for QR codes adds complexity without benefit — the QR code already handles error correction and binary framing. We use NDEF only as a transport option for NFC tags (§12).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,16 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
+// Copies the repo-root SPEC.md into a generated raw resource on every build, so the in-app
+// "Wire Format Spec" screen (SpecActivity) always shows the exact same text as SPEC.md —
+// never a manually-maintained copy that can silently drift out of sync.
+def specRawResDir = layout.buildDirectory.dir("generated/specRawRes")
+tasks.register("copySpecToRawRes", Copy) {
+    from(rootProject.file("SPEC.md"))
+    into(specRawResDir.map { it.dir("raw") })
+    rename { "spec.md" }
+}
+
 android {
     namespace = 'com.github.mofosyne.tagdrop'
     compileSdk = 35
@@ -17,6 +27,12 @@ android {
 
     buildFeatures {
         viewBinding = true
+    }
+
+    sourceSets {
+        main {
+            res.srcDirs += specRawResDir
+        }
     }
 
     compileOptions {
@@ -36,6 +52,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+}
+
+tasks.named("preBuild").configure {
+    dependsOn("copySpecToRawRes")
 }
 
 dependencies {
@@ -64,6 +84,8 @@ dependencies {
 
     // Markdown rendering for text/markdown content (pure Kotlin/Java, no native deps)
     implementation libs.commonmark
+    // GFM pipe-table support — SPEC.md (rendered in-app by SpecActivity) relies on tables
+    implementation libs.commonmark.ext.gfm.tables
 
     // SVG rendering for image/svg+xml thumbnails (BitmapFactory can't decode XML)
     implementation libs.androidsvg

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -101,6 +101,13 @@
             android:exported="false"
             android:parentActivityName=".MainActivity" />
 
+        <!-- In-app wire-format spec viewer (SPEC.md, synced at build time — see app/build.gradle) -->
+        <activity
+            android:name=".SpecActivity"
+            android:label="@string/title_activity_spec"
+            android:exported="false"
+            android:parentActivityName=".MainActivity" />
+
         <!-- Retained AES key management (SPEC §9) -->
         <activity
             android:name=".RetainedKeysActivity"

--- a/app/src/main/java/com/github/mofosyne/tagdrop/MainActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/MainActivity.kt
@@ -142,6 +142,7 @@ class MainActivity : AppCompatActivity() {
             R.id.action_backup -> { startBackup(); true }
             R.id.action_restore -> { triggerRestore(); true }
             R.id.action_readme -> { startActivity(Intent(this, ReadMeActivity::class.java)); true }
+            R.id.action_spec -> { startActivity(Intent(this, SpecActivity::class.java)); true }
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/SpecActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/SpecActivity.kt
@@ -1,0 +1,108 @@
+package com.github.mofosyne.tagdrop
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import com.github.mofosyne.tagdrop.data.format.MarkdownRenderer
+import com.github.mofosyne.tagdrop.databinding.ActivitySpecBinding
+
+/**
+ * Renders SPEC.md in-app, read from `R.raw.spec` — a copy synced from the repo-root SPEC.md
+ * at build time (see the `copySpecToRawRes` task in app/build.gradle), never a
+ * manually-maintained duplicate that could drift out of sync.
+ */
+class SpecActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivitySpecBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+        binding = ActivitySpecBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updatePadding(
+                left = systemBars.left,
+                top = systemBars.top,
+                right = systemBars.right,
+                bottom = systemBars.bottom
+            )
+            insets
+        }
+
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        title = getString(R.string.title_activity_spec)
+
+        // Matches the system "Font size" accessibility setting, since a WebView's text
+        // otherwise ignores it (unlike a TextView, which used to scale automatically).
+        binding.specWebView.settings.textZoom = (resources.configuration.fontScale * 100).toInt()
+        binding.specWebView.webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+                if (request.url.scheme != "http" && request.url.scheme != "https") return false
+                runCatching { startActivity(Intent(Intent.ACTION_VIEW, request.url)) }
+                return true
+            }
+        }
+
+        val html = MarkdownRenderer.toHtmlDocument(readRaw(), SPEC_CSS)
+        binding.specWebView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null)
+    }
+
+    override fun onSupportNavigateUp(): Boolean { finish(); return true }
+
+    private fun readRaw(): String {
+        return try {
+            resources.openRawResource(R.raw.spec).bufferedReader().use { it.readText() }
+        } catch (e: Exception) {
+            ""
+        }
+    }
+
+    companion object {
+        /** Same brand palette as ReadMeActivity's README_CSS, plus tables/code blocks for SPEC.md. */
+        private const val SPEC_CSS = """
+            body { margin: 16px; font-family: sans-serif; font-size: 15px; line-height: 1.5;
+                   color: #1a1a1a; background: #ffffff; }
+            h1, h2, h3, h4 { color: #D9652B; }
+            h1 { font-size: 1.6em; margin-top: 0; }
+            h2 { font-size: 1.25em; margin-top: 1.4em; border-bottom: 1px solid #e0d7c8; padding-bottom: 4px; }
+            h3 { font-size: 1.1em; margin-top: 1.2em; }
+            a { color: #2A3941; }
+            blockquote { margin: 0.8em 0; padding: 0.4em 0.8em; border-left: 4px solid #D9652B;
+                         background: #F3EDE1; color: #333333; }
+            hr { border: none; border-top: 1px solid #dddddd; margin: 1.5em 0; }
+            strong { color: #2A3941; }
+            code { font-family: monospace; background: #F3EDE1; padding: 0.1em 0.3em; border-radius: 3px; }
+            pre { background: #F3EDE1; padding: 0.8em; border-radius: 4px; overflow-x: auto; }
+            pre code { background: none; padding: 0; }
+            li { margin-bottom: 0.4em; }
+            table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.92em; }
+            th, td { border: 1px solid #dddddd; padding: 0.4em 0.6em; text-align: left; vertical-align: top; }
+            th { background: #F3EDE1; }
+            @media (prefers-color-scheme: dark) {
+                body { color: #e8e8e8; background: #121212; }
+                h1, h2, h3, h4 { color: #f08a4b; }
+                h2 { border-bottom-color: #333333; }
+                a { color: #8fb8c9; }
+                blockquote { background: #1e1e1e; color: #cccccc; border-left-color: #f08a4b; }
+                hr { border-top-color: #333333; }
+                strong { color: #cfe3ea; }
+                code { background: #1e1e1e; }
+                pre { background: #1e1e1e; }
+                th, td { border-color: #333333; }
+                th { background: #1e1e1e; }
+            }
+        """
+    }
+}

--- a/app/src/main/java/com/github/mofosyne/tagdrop/ViewDataUriActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/ViewDataUriActivity.kt
@@ -230,7 +230,7 @@ class ViewDataUriActivity : AppCompatActivity() {
 
     /**
      * True for both navigation-link forms TagDropLinkResolver understands:
-     *   tagdrop://<rootHash-hex>/<slug>
+     *   tagdrop://<host>/<slug>  (host is a domain, @<rootHash-hex>, or <domain>@<rootHash-hex>)
      *   https://<rootHash-hex>.paper.tagdrop.invalid/<slug>  (same-paper relative links)
      */
     private fun isTagDropUrl(uri: Uri): Boolean =

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/MarkdownRenderer.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/MarkdownRenderer.kt
@@ -1,5 +1,6 @@
 package com.github.mofosyne.tagdrop.data.format
 
+import org.commonmark.ext.gfm.tables.TablesExtension
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
 
@@ -7,10 +8,14 @@ import org.commonmark.renderer.html.HtmlRenderer
  * Renders `text/markdown` content (SPEC §7) to a standalone HTML document, for display
  * via the same WebView path as `text/html` content (relative links, tagdrop:// resolution,
  * subresource interception all keep working).
+ *
+ * Includes the GFM tables extension — needed for SPEC.md's pipe tables (rendered in-app by
+ * SpecActivity), not just author-supplied `text/markdown` content.
  */
 object MarkdownRenderer {
-    private val parser: Parser = Parser.builder().build()
-    private val renderer: HtmlRenderer = HtmlRenderer.builder().build()
+    private val extensions = listOf(TablesExtension.create())
+    private val parser: Parser = Parser.builder().extensions(extensions).build()
+    private val renderer: HtmlRenderer = HtmlRenderer.builder().extensions(extensions).build()
 
     /**
      * Converts [markdown] to a full HTML document. If [css] is non-null, it's inlined as a

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
@@ -33,7 +33,7 @@ import javax.crypto.spec.SecretKeySpec
  *   - content: raw cache bytes (Content), empty (Paper), or a hidden override map (§9)
  *
  * Navigation links (NOT encoding URIs, NOT put in QR codes):
- *   tagdrop://<rootHash-hex>/<slug>
+ *   tagdrop://<domain-or-@rootHash-hex>/<slug>  — see TagDropLinkResolver for the grammar
  *   Disambiguated by "//": Base41's alphabet has no '/' at all, so an encoding
  *   URI can never have "//" right after the scheme.
  *

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolver.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolver.kt
@@ -11,15 +11,32 @@ import kotlin.math.sqrt
 /**
  * Resolves TagDrop navigation links. Two URL forms are recognised:
  *
- *   tagdrop://<rootHash-hex-or-domain>/<slug>
- *     The portable form carried in QR-encoded content. The host is either plain
- *     lowercase hex -- NOT Base41, unlike the QR-payload encoding, because Base41's
- *     alphabet includes ':', which breaks URL authority parsing if it lands in the
- *     host (SPEC.md §2) -- or a human-readable domain name (SPEC §7 "Domains").
- *     An exact root-hash lookup is always tried first; only on a miss does
- *     resolution fall back to a domain lookup (`ScannedPaper.domain`, falling back
- *     to `ScannedPaper.slug`), so a real root hash can never be shadowed by a
- *     same-looking domain name.
+ *   tagdrop://<host>/<slug>
+ *     The portable form carried in QR-encoded content. Whether [host] is treated as
+ *     a root hash or a domain name is decided purely by the presence of an `@`
+ *     marker (SPEC §7 "Domain and pinned links") -- never by whether the text
+ *     happens to look hex-shaped, and never by trying one lookup and falling back
+ *     to the other. Three forms:
+ *
+ *       tagdrop://<domain>/<slug>           floating: domain/slug lookup only,
+ *                                           never attempted as a root hash.
+ *       tagdrop://@<rootHash-hex>/<slug>    pinned: exact root-hash lookup only.
+ *       tagdrop://<domain>@<rootHash-hex>/<slug>
+ *                                           both: the hash is authoritative; the
+ *                                           domain is a decorative label that is
+ *                                           never validated against it.
+ *
+ *     The hash half is plain lowercase hex -- NOT Base41, unlike the QR-payload
+ *     encoding, because Base41's alphabet includes ':', which breaks URL authority
+ *     parsing if it lands in the host (SPEC.md §2). `@` was chosen as the separator
+ *     because it reuses standard URI authority syntax (`[userinfo "@"] host`, RFC
+ *     3986 §3.2.1) -- see SPEC §16 for alternatives considered.
+ *
+ *     This split exists because a domain name is a self-declared, uncoordinated
+ *     claim (SPEC §7) -- anyone can craft a paper whose `domain` field happens to
+ *     match another paper's real root-hash hex string. Deciding hash-vs-domain by
+ *     shape or by lookup order would let whichever paper got scanned first shadow
+ *     the other; deciding by syntax instead makes that impossible (issue #51).
  *
  *   https://<rootHash-hex>.paper.tagdrop.invalid/<slug>
  *     A synthetic same-paper form. rootHash is a subdomain *label*, not a path
@@ -31,7 +48,7 @@ import kotlin.math.sqrt
  *     via standard URL resolution. `.invalid` is an IANA-reserved TLD (RFC 2606)
  *     that never resolves over the network. This form is always a real root hash --
  *     it's derived from an already-scanned paper, never user-typed -- so it has no
- *     domain-name fallback.
+ *     domain-name fallback and the `@` grammar doesn't apply to it.
  *
  * In both forms, the root hash identifies which physical paper to look up; the slug
  * selects a file within that paper's directory. Both are resolved from the local
@@ -86,22 +103,27 @@ class TagDropLinkResolver(private val db: AppDatabase) {
     }
 
     /**
-     * `tagdrop://<host>/<slug>` where `host` may be a root hash or a domain name. Tries the
-     * exact root-hash lookup first (cheap, primary-keyed); only on a miss does it fall back to
-     * a domain lookup, so a real root hash can never be shadowed by a same-looking domain name
-     * (SPEC §7 "Resolving a domain link"). A hex-shaped host that matches neither stays
-     * PaperNotFound (same as before this field existed); a non-hex-shaped host that matches
-     * neither is DomainNotFound.
+     * `tagdrop://<host>/<slug>` where whether `host` is a root hash or a domain name is decided
+     * purely by the presence of an `@` marker (SPEC §7 "Domain and pinned links") -- never by
+     * whether the text looks hex-shaped, and never by trying one lookup and falling back to the
+     * other. No `@` means `host` is a domain/slug claim and is only ever looked up as one --
+     * never attempted as a root hash, even if it happens to look hex-shaped. An `@` splits
+     * `host` into `<domain>@<rootHash-hex>`; everything after the first `@` is the hash and is
+     * the only thing looked up (the domain half, if present, is a decorative label that is never
+     * validated against it). This keeps a real root hash from ever being shadowed by a
+     * same-looking domain claim, and vice versa (issue #51).
      */
     private suspend fun resolveSchemeLink(rest: String, deviceLat: Double?, deviceLng: Double?): Resolution {
         val (host, slug) = splitFirstSlash(rest)
-        val hex = host.lowercase()
-        val hexShaped = HEX_ROOT_HASH.matches(hex)
-        if (hexShaped) {
-            db.paperDao().getByRootHash(hex)?.let { return resolveWithinPaper(it, slug) }
+        val at = host.indexOf('@')
+        if (at < 0) {
+            pickClosestDomainMatch(host, deviceLat, deviceLng)?.let { return resolveWithinPaper(it, slug) }
+            return Resolution.DomainNotFound(host, slug)
         }
-        pickClosestDomainMatch(host, deviceLat, deviceLng)?.let { return resolveWithinPaper(it, slug) }
-        return if (hexShaped) Resolution.PaperNotFound(hex, slug) else Resolution.DomainNotFound(host, slug)
+        val hex = host.substring(at + 1).lowercase()
+        if (!HEX_ROOT_HASH.matches(hex)) return Resolution.Invalid
+        val paper = db.paperDao().getByRootHash(hex) ?: return Resolution.PaperNotFound(hex, slug)
+        return resolveWithinPaper(paper, slug)
     }
 
     /** `https://<rootHash-hex>.paper.tagdrop.invalid/<slug>` — always a real root hash, never a domain name. */

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
@@ -13,7 +13,7 @@ import com.github.mofosyne.tagdrop.data.db.ScannedPaper
  *     CBOR(core_meta_item) || CBOR(bulky_meta_item) || content
  *
  * Navigation links (not QR payloads):
- *   tagdrop://<rootHash-hex>/<slug>  resolved by TagDropLinkResolver
+ *   tagdrop://<domain-or-@rootHash-hex>/<slug>  resolved by TagDropLinkResolver
  */
 sealed class TagDropPayload {
 
@@ -105,7 +105,9 @@ sealed class TagDropPayload {
      * there's no placeholder/re-encode pass needed — compute once, done.
      *
      * Navigation links embedded in HTML pages:
-     *   tagdrop://<rootHash-hex>/<slug>  — resolved by TagDropLinkResolver
+     *   tagdrop://@<rootHash-hex>/<slug>  — pinned to this exact paper, resolved by
+     *   TagDropLinkResolver (the `@` marker rules out an unrelated paper's `domain`
+     *   claim ever being mistaken for this root hash, SPEC §7).
      */
     data class Paper(
         val rootHash: ByteArray,           // SHA-256(CBOR)[0:8]; paper's permanent address

--- a/app/src/main/res/layout/activity_spec.xml
+++ b/app/src/main/res/layout/activity_spec.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <WebView
+        android:id="@+id/specWebView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -27,4 +27,9 @@
         android:title="@string/button_readme"
         app:showAsAction="never" />
 
+    <item
+        android:id="@+id/action_spec"
+        android:title="@string/button_spec"
+        app:showAsAction="never" />
+
 </menu>

--- a/app/src/main/res/raw/readme.md
+++ b/app/src/main/res/raw/readme.md
@@ -59,6 +59,8 @@ Already-scanned content can be re-shared as a fresh QR code, or written straight
 
 ## Extra
 
+The full technical wire-format spec is also available in-app — see **Wire Format Spec** in the menu, next to this page.
+
 Source: [github.com/mofosyne/tagdrop](https://github.com/mofosyne/tagdrop)
 
 Licence: GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">tagdrop</string>
     <string name="title_activity_read_me">Read Me</string>
+    <string name="title_activity_spec">Wire Format Spec</string>
     <string name="title_scan">Scan Tag</string>
 
     <!-- Bottom navigation tabs -->
@@ -45,6 +46,7 @@
     <string name="button_launch">Launch Content (legacy)</string>
     <string name="button_clear">Clear</string>
     <string name="button_readme">About / Read Me</string>
+    <string name="button_spec">Wire Format Spec</string>
     <string name="status_ready">Point the camera at a TagDrop code to begin.</string>
     <string name="status_collecting">Collecting chunks: %1$d / %2$d\nHint: %3$s\n\nStill need: %4$s</string>
     <string name="status_legacy">Legacy mode: %1$d fragment(s) accumulated.\n\nTap \'Launch Content\' when done.</string>

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/MarkdownRendererTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/MarkdownRendererTest.kt
@@ -29,4 +29,13 @@ class MarkdownRendererTest {
         val html = MarkdownRenderer.toHtmlDocument("[map](tagdrop://abc123/map)")
         assertTrue(html.contains("href=\"tagdrop://abc123/map\""))
     }
+
+    @Test fun rendersGfmPipeTables() {
+        val html = MarkdownRenderer.toHtmlDocument(
+            "| Key | Type |\n|---|---|\n| 1 | uint |\n"
+        )
+        assertTrue(html.contains("<table>"))
+        assertTrue(html.contains("<th>Key</th>"))
+        assertTrue(html.contains("<td>uint</td>"))
+    }
 }

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolverTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolverTest.kt
@@ -152,13 +152,13 @@ class TagDropLinkResolverTest {
         // 24 hex chars = 12 bytes, longer than today's 8-byte truncation. Should reach the
         // DB lookup (and miss) rather than being rejected by the parser itself.
         val longHex = "001122334455667788990011"
-        val result = resolver.resolve("tagdrop://$longHex/index")
+        val result = resolver.resolve("tagdrop://@$longHex/index")
         assertEquals(TagDropLinkResolver.Resolution.PaperNotFound(longHex, "index"), result)
     }
 
     @Test fun navLinkAcceptsShorterThanTodaysRootHashLength() = runBlocking {
         val shortHex = "00ff" // 2 bytes
-        val result = resolver.resolve("tagdrop://$shortHex/index")
+        val result = resolver.resolve("tagdrop://@$shortHex/index")
         assertEquals(TagDropLinkResolver.Resolution.PaperNotFound(shortHex, "index"), result)
     }
 
@@ -166,13 +166,13 @@ class TagDropLinkResolverTest {
 
     @Test fun navLinkRootHashIsLowercasedBeforeLookup() = runBlocking {
         val paper = storePaper()
-        val result = resolver.resolve("tagdrop://${paper.rootHash.uppercase()}")
+        val result = resolver.resolve("tagdrop://@${paper.rootHash.uppercase()}")
         assertEquals(TagDropLinkResolver.Resolution.PaperFound(paper, null), result)
     }
 
     @Test fun unknownRootHashIsPaperNotFound() = runBlocking {
         val hex = "0011223344556677"
-        val result = resolver.resolve("tagdrop://$hex/index")
+        val result = resolver.resolve("tagdrop://@$hex/index")
         assertEquals(TagDropLinkResolver.Resolution.PaperNotFound(hex, "index"), result)
     }
 
@@ -180,18 +180,18 @@ class TagDropLinkResolverTest {
 
     @Test fun navLinkWithNoSlugIsPaperFoundWithNullSlug() = runBlocking {
         val paper = storePaper()
-        assertEquals(TagDropLinkResolver.Resolution.PaperFound(paper, null), resolver.resolve("tagdrop://${paper.rootHash}"))
+        assertEquals(TagDropLinkResolver.Resolution.PaperFound(paper, null), resolver.resolve("tagdrop://@${paper.rootHash}"))
     }
 
     @Test fun navLinkWithTrailingSlashIsPaperFoundWithNullSlug() = runBlocking {
         val paper = storePaper()
-        assertEquals(TagDropLinkResolver.Resolution.PaperFound(paper, null), resolver.resolve("tagdrop://${paper.rootHash}/"))
+        assertEquals(TagDropLinkResolver.Resolution.PaperFound(paper, null), resolver.resolve("tagdrop://@${paper.rootHash}/"))
     }
 
     @Test fun navLinkSlugKeepsOnlyFirstSlashAsSeparator() = runBlocking {
         val paper = storePaper()
         // Only the first '/' separates rootHash from slug -- the rest is part of the slug itself.
-        val result = resolver.resolve("tagdrop://${paper.rootHash}/sub/page.html")
+        val result = resolver.resolve("tagdrop://@${paper.rootHash}/sub/page.html")
         assertEquals(TagDropLinkResolver.Resolution.FileNotFound(paper, "sub/page.html"), result)
     }
 
@@ -203,13 +203,13 @@ class TagDropLinkResolverTest {
             cborBytes = byteArrayOf(1, 2, 3) // garbage, not a valid CBOR sequence
         )
         paperDao.papers[paper.rootHash] = paper
-        val result = resolver.resolve("tagdrop://${paper.rootHash}/index")
+        val result = resolver.resolve("tagdrop://@${paper.rootHash}/index")
         assertEquals(TagDropLinkResolver.Resolution.PaperFound(paper, "index"), result)
     }
 
     @Test fun slugNotInManifestIsFileNotFound() = runBlocking {
         val paper = storePaper()
-        val result = resolver.resolve("tagdrop://${paper.rootHash}/missing.html")
+        val result = resolver.resolve("tagdrop://@${paper.rootHash}/missing.html")
         assertEquals(TagDropLinkResolver.Resolution.FileNotFound(paper, "missing.html"), result)
     }
 
@@ -217,7 +217,7 @@ class TagDropLinkResolverTest {
         val fileId = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
         val file = TagDropPayload.FileEntry(slug = "doc.html", mimeType = "text/html", fileId = fileId)
         val paper = storePaper(files = listOf(file))
-        val result = resolver.resolve("tagdrop://${paper.rootHash}/doc.html")
+        val result = resolver.resolve("tagdrop://@${paper.rootHash}/doc.html")
         assertEquals(TagDropLinkResolver.Resolution.FileNotCached(paper, file), result)
     }
 
@@ -226,7 +226,7 @@ class TagDropLinkResolverTest {
         val file = TagDropPayload.FileEntry(slug = "doc.html", mimeType = "text/html", fileId = fileId)
         val paper = storePaper(files = listOf(file))
         val cache = storeCache(fileId, "text/html", "<p>hi</p>".toByteArray())
-        val result = resolver.resolve("tagdrop://${paper.rootHash}/doc.html")
+        val result = resolver.resolve("tagdrop://@${paper.rootHash}/doc.html")
         assertEquals(TagDropLinkResolver.Resolution.FileFound(cache, paper, "doc.html"), result)
     }
 
@@ -302,13 +302,50 @@ class TagDropLinkResolverTest {
         assertEquals(TagDropLinkResolver.Resolution.DomainNotFound("nowhere", "index"), result)
     }
 
-    @Test fun exactRootHashMatchWinsOverSameLookingDomainClaim() = runBlocking {
+    // ── @ marker: syntax alone decides hash vs. domain (issue #51) ───────────
+
+    @Test fun bareHashShapedDomainNeverFallsBackToRootHashLookup() = runBlocking {
+        // No `@` means the host is only ever looked up as a domain/slug claim -- never
+        // attempted as a root hash, even though it's hex-shaped and a real paper exists
+        // under that root hash. (SPEC §7 "Domain and pinned links".)
         val real = storePaper(label = "Real Paper")
-        // A second paper claims the first paper's root hash as its own domain name -- the
-        // exact-hash lookup must still win (SPEC §7 "Resolving a domain link").
-        storePaper(label = "Impostor", domain = real.rootHash)
         val result = resolver.resolve("tagdrop://${real.rootHash}")
+        assertEquals(TagDropLinkResolver.Resolution.DomainNotFound(real.rootHash, null), result)
+    }
+
+    @Test fun pinnedHashLinkIsNeverShadowedByMatchingDomainClaim() = runBlocking {
+        // A second paper claims the first paper's root hash as its own domain name. With the
+        // `@` marker present, only the hash is ever looked up, so the impostor's domain claim
+        // can't shadow the real paper -- the vulnerability this grammar exists to close.
+        val real = storePaper(label = "Real Paper")
+        storePaper(label = "Impostor", domain = real.rootHash)
+        val result = resolver.resolve("tagdrop://@${real.rootHash}")
         assertEquals(TagDropLinkResolver.Resolution.PaperFound(real, null), result)
+    }
+
+    @Test fun domainShapedLikeHashStillResolvesAsDomainWhenClaimed() = runBlocking {
+        // Flip side: a paper whose domain field happens to be hex-shaped still resolves
+        // through the domain path when referenced without `@`.
+        val impostor = storePaper(label = "Impostor", domain = "0011223344556677")
+        val result = resolver.resolve("tagdrop://0011223344556677")
+        assertEquals(TagDropLinkResolver.Resolution.PaperFound(impostor, null), result)
+    }
+
+    @Test fun combinedFormResolvesByHashIgnoringLabel() = runBlocking {
+        // `<domain>@<rootHash-hex>/<slug>` -- the domain half is a decorative label, never
+        // validated against the hash, so an unrelated/wrong label doesn't block resolution.
+        val real = storePaper(label = "Real Paper")
+        val result = resolver.resolve("tagdrop://totally-unrelated-label@${real.rootHash}")
+        assertEquals(TagDropLinkResolver.Resolution.PaperFound(real, null), result)
+    }
+
+    @Test fun multipleAtSignsInHostFailsSafelyAsInvalid() = runBlocking {
+        // Only the first '@' is treated as the marker; everything after it (including any
+        // further '@') must still be hex-shaped. A malformed host with a stray second '@'
+        // fails closed as Invalid rather than partially matching.
+        val real = storePaper(label = "Real Paper")
+        val result = resolver.resolve("tagdrop://label@stray@${real.rootHash}")
+        assertEquals(TagDropLinkResolver.Resolution.Invalid, result)
     }
 
     @Test fun multipleDomainClaimsPickClosestByDevicePosition() = runBlocking {

--- a/docs/index.html
+++ b/docs/index.html
@@ -128,8 +128,10 @@
         sector.</li>
       <li><strong>Paper manifests</strong> describe a directory of files — each
         with its own short description — on one physical sheet, linked by
-        ordinary relative links or <code>tagdrop://&lt;root-hash&gt;/&lt;slug&gt;</code>
-        links, so a small static site survives being printed and scanned back in.</li>
+        ordinary relative links, <code>tagdrop://@&lt;root-hash&gt;/&lt;slug&gt;</code>
+        (pinned to an exact paper), or <code>tagdrop://&lt;domain&gt;/&lt;slug&gt;</code>
+        (a human-readable name), so a small static site survives being printed
+        and scanned back in.</li>
       <li><strong>Trails, collections, and replies:</strong> link papers
         together with <code>related</code> hints, tag a loose set of stickers
         with a shared collection so they group into one card and map, or mark

--- a/fastlane/metadata/android/en-US/changelogs/7.txt
+++ b/fastlane/metadata/android/en-US/changelogs/7.txt
@@ -13,3 +13,4 @@
 - The Collections, History, and Map tabs now show TagDrop's icon mark in the toolbar for clearer branding.
 - The in-app Help page now renders proper formatting — headings, lists, bold/italic — instead of a plain approximation.
 - Printed and PDF paper sheets now show a title and useful details (file count, set/slug, domain, date) before you start scanning, and sector labels now match the "Sector N of M" numbering printed right next to them.
+- The full wire-format spec is now readable in-app from the menu, next to About / Read Me.

--- a/fastlane/metadata/android/en-US/changelogs/7.txt
+++ b/fastlane/metadata/android/en-US/changelogs/7.txt
@@ -1,4 +1,5 @@
 - Papers can now claim a short, human-readable domain name (e.g. "helloworld"), so finders can open tagdrop://helloworld instead of typing out a long root hash.
+- Fix: a paper's self-claimed domain name could be crafted to look exactly like another paper's root hash, letting a found code redirect a tagdrop://<hash>/<slug> link meant for that other paper. Root-hash links now use an explicit tagdrop://@<hash>/<slug> marker so a domain claim can never be confused with one.
 - Cached image files now show as a small picture preview instead of a generic icon, in your collection, history, and on the map — name a file "favicon" (or favicon.png, etc.) to pick which image is used.
 - Content with no fixed location can carry a short text description instead (like "🚋 Tram 40"), and no longer has a live GPS position silently substituted in once you've marked it that way.
 - Codes can now declare what time they were authored, shown as a clock-icon chip.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ zxing-android-embedded = { group = "com.journeyapps", name = "zxing-android-embe
 zxing-core = { group = "com.google.zxing", name = "core", version.ref = "zxingCore" }
 osmdroid-android = { group = "org.osmdroid", name = "osmdroid-android", version.ref = "osmdroid" }
 commonmark = { group = "org.commonmark", name = "commonmark", version.ref = "commonmark" }
+commonmark-ext-gfm-tables = { group = "org.commonmark", name = "commonmark-ext-gfm-tables", version.ref = "commonmark" }
 androidsvg = { group = "com.caverock", name = "androidsvg-aar", version.ref = "androidsvg" }
 
 [plugins]

--- a/readme.md
+++ b/readme.md
@@ -39,8 +39,9 @@ network, or account needed to read or write a drop.
 - **Drop a whole "paper"** — a printable sheet with a directory QR code (a
   *paper manifest*) plus one QR per file, built in-app (Create Paper) or with
   the web generator. Pages can link to each other with ordinary relative
-  links or `tagdrop://<root-hash>/<slug>` links, so a small static site
-  survives being printed and scanned back in.
+  links or `tagdrop://@<root-hash>/<slug>` links (or `tagdrop://<domain>/<slug>`
+  for a human-readable name), so a small static site survives being printed
+  and scanned back in.
 - **Spread large content across multiple codes** — split a payload too big
   for one QR into multiple sector codes placed along a trail. The app
   collects sectors in any order and reassembles and verifies them, with an

--- a/tools/examples/index.html
+++ b/tools/examples/index.html
@@ -1754,7 +1754,7 @@ async function main() {
     <strong>${escHtml(p.label)}</strong>
     — set: <code>${escHtml(p.set)}</code>, slug: <code>${escHtml(p.slug)}</code><br>
     Root hash: <code>${rootHashHex}</code><br>
-    Navigation link base: <code>tagdrop://${escHtml(rootHashHex)}/${escHtml(p.slug)}</code>
+    Navigation link base: <code>tagdrop://@${escHtml(rootHashHex)}/${escHtml(p.slug)}</code>
     <div class="step">① Scan the <strong>manifest</strong> first — it registers the paper and its file list.</div>
     <div class="step">② Scan each <strong>file</strong> QR in any order to cache its content.</div>
     <div class="step">③ Open <strong>readme</strong> — its relative links (<code>note</code>, <code>images/badge.svg</code>) resolve to the sibling files on this same paper.</div>`;
@@ -1785,7 +1785,7 @@ async function main() {
     <strong>${escHtml(book.label)}</strong>
     — set: <code>${escHtml(book.set)}</code>, slug: <code>${escHtml(book.slug)}</code><br>
     Root hash: <code>${bookRootHashHex}</code><br>
-    Navigation link base: <code>tagdrop://${escHtml(bookRootHashHex)}/${escHtml(book.slug)}</code>
+    Navigation link base: <code>tagdrop://@${escHtml(bookRootHashHex)}/${escHtml(book.slug)}</code>
     <div class="step">① Scan the <strong>manifest</strong>, then <code>style.css</code> and each markdown page.</div>
     <div class="step">② Open <strong>index.md</strong> — its table of contents links to each chapter.</div>
     <div class="step">③ Each chapter links back to the cover and to its neighbours, and every page

--- a/tools/generator/index.html
+++ b/tools/generator/index.html
@@ -386,7 +386,7 @@
       <input type="text" id="p-slug" placeholder="e.g. oak-tree  →  tagdrop://…/oak-tree">
     </div>
     <div>
-      <label>Domain <small>(optional — human-readable name finders can type instead of the root hash, e.g. "helloworld"  →  tagdrop://helloworld; falls back to Slug above when absent — SPEC §7 "Domains")</small></label>
+      <label>Domain <small>(optional — human-readable name finders can type instead of the root hash, e.g. "helloworld"  →  tagdrop://helloworld; falls back to Slug above when absent — SPEC §7 "Domains". Avoid '@' — it's reserved syntax for marking a pinned root hash, e.g. tagdrop://helloworld@&lt;hash&gt;)</small></label>
       <input type="text" id="p-domain" placeholder="e.g. helloworld  →  tagdrop://helloworld">
     </div>
     <div>
@@ -471,8 +471,8 @@
       <em>same or different</em> papers using absolute tagdrop:// links —
       the app intercepts these and serves the cached bytes inline, so images,
       audio, and SVGs load without a network connection:<br>
-      <code style="font-size:0.8rem">&lt;img src="tagdrop://ROOTHASH/photo.jpg"&gt;</code><br>
-      <code style="font-size:0.8rem">&lt;audio controls src="tagdrop://ROOTHASH/song.mid"&gt;</code><br>
+      <code style="font-size:0.8rem">&lt;img src="tagdrop://@ROOTHASH/photo.jpg"&gt;</code><br>
+      <code style="font-size:0.8rem">&lt;audio controls src="tagdrop://@ROOTHASH/song.mid"&gt;</code><br>
       Slugs can contain <code>/</code> to mimic folder paths
       (e.g. <code>images/photo.jpg</code>) — they are matched as plain strings.
       A file too large for one QR code is automatically split into multiple
@@ -2513,7 +2513,7 @@ async function generatePaper() {
       <strong>Root hash:</strong>
       <code style="display:block;margin:4px 0;font-size:0.85rem">${rootHashHex}</code>
       <small style="color:#555">Use in navigation links:
-        <code>tagdrop://${rootHashHex}/${slug || 'index'}</code></small>
+        <code>tagdrop://@${rootHashHex}/${slug || 'index'}</code></small>
     </div>`);
 
   const actionRow = document.createElement('div');

--- a/tools/reader/index.html
+++ b/tools/reader/index.html
@@ -726,17 +726,18 @@ function sectorScanResult(bytes) {
 async function parseUri(uri) {
   if (!uri.startsWith('tagdrop:')) return null;
 
-  // Navigation link: tagdrop://ROOTHASH_HEX[/slug] — disambiguated from encoding
-  // URIs by the "//" (SPEC §2): Base41's alphabet has no '/' at all. The root hash
-  // here is plain lowercase hex, NOT Base41 — Base41's alphabet includes ':', which
-  // breaks URL authority parsing if it lands in the host (SPEC.md §2).
+  // Navigation link: tagdrop://HOST[/slug] — disambiguated from encoding URIs by the
+  // "//" (SPEC §2): Base41's alphabet has no '/' at all. HOST's grammar is decided
+  // purely by the presence of an `@` marker (SPEC §7 "Domain and pinned links"),
+  // resolved in resolveNavLink:
+  //   <domain>                  floating: domain/slug lookup only, never a root hash
+  //   @<rootHash-hex>           pinned: exact root-hash lookup only
+  //   <domain>@<rootHash-hex>   both: hash authoritative, domain a decorative label
+  // The hash half, when present, is plain lowercase hex, NOT Base41 — Base41's alphabet
+  // includes ':', which breaks URL authority parsing if it lands in the host (SPEC.md §2).
   if (uri.startsWith('tagdrop://')) {
     const rest = uri.slice('tagdrop://'.length);
     const slash = rest.indexOf('/');
-    // host may be a root-hash hex string or a human-readable domain name (SPEC §7
-    // "Domains") -- resolveNavLink tries the exact hash first, falling back to a
-    // domain lookup only on a miss, so a real root hash can never be shadowed by a
-    // same-looking domain name.
     const host = slash < 0 ? rest : rest.slice(0, slash);
     const slug = slash < 0 ? null : (rest.slice(slash + 1) || null);
     if (!host) return { type: 'invalid' };
@@ -1657,19 +1658,37 @@ async function findDomainMatch(domainName) {
 }
 
 /**
- * `host` is either a root-hash hex string or a domain name (SPEC §7 "Domains"). The
- * exact-hash lookup is always tried first; only on a miss does resolution fall back to
- * a domain lookup, so a real root hash can never be shadowed by a same-looking domain
- * name. Mirrors Kotlin TagDropLinkResolver.resolveSchemeLink.
+ * Whether `host` is a root hash or a domain name is decided purely by the presence of an
+ * `@` marker (SPEC §7 "Domain and pinned links") -- never by whether the text looks
+ * hex-shaped, and never by trying one lookup and falling back to the other. No `@` means
+ * `host` is a domain/slug claim and is only ever looked up as one -- never attempted as a
+ * root hash, even if it happens to look hex-shaped. An `@` splits `host` into
+ * `<domain>@<rootHash-hex>`; everything after the first `@` is the hash and is the only
+ * thing looked up (the domain half, if present, is a decorative label, never validated
+ * against it). This keeps a real root hash from ever being shadowed by a same-looking
+ * domain claim, and vice versa (issue #51). Mirrors Kotlin
+ * TagDropLinkResolver.resolveSchemeLink.
  */
 async function resolveNavLink(host, slug) {
-  const hexShaped = /^([0-9a-f]{2})+$/.test(host.toLowerCase());
-  const paper = (hexShaped && await dbGet('papers', host.toLowerCase())) || await findDomainMatch(host);
-  if (!paper) {
-    showMsg(hexShaped
-      ? 'Paper not in collection — scan its manifest QR first.'
-      : "No scanned paper claims the domain '" + host + "'.", 'warn');
-    return;
+  const at = host.indexOf('@');
+  let paper;
+  if (at < 0) {
+    paper = await findDomainMatch(host);
+    if (!paper) {
+      showMsg("No scanned paper claims the domain '" + host + "'.", 'warn');
+      return;
+    }
+  } else {
+    const hex = host.slice(at + 1).toLowerCase();
+    if (!/^([0-9a-f]{2})+$/.test(hex)) {
+      showMsg('Malformed tagdrop:// link.', 'err');
+      return;
+    }
+    paper = await dbGet('papers', hex);
+    if (!paper) {
+      showMsg('Paper not in collection — scan its manifest QR first.', 'warn');
+      return;
+    }
   }
   if (!slug) {
     activePaperHash = paper.rootHash;


### PR DESCRIPTION
## Summary

- Fixes #51: `tagdrop://<host>/<slug>` navigation links now decide domain-vs-hash resolution purely by **syntax** (presence/absence of an `@` marker) instead of by lookup order/shape-sniffing, closing the collision where a paper's self-claimed `domain` could be crafted to match another paper's real `root_hash` and hijack resolution if scanned first.
  - New grammar: `tagdrop://<domain>/<slug>` (floating, domain-only), `tagdrop://@<rootHash-hex>/<slug>` (pinned, hash-only), `tagdrop://<domain>@<rootHash-hex>/<slug>` (both — hash authoritative, domain decorative).
  - Implemented independently in both reference implementations per CLAUDE.md: `TagDropLinkResolver.kt` (Kotlin/Android) and `tools/reader/index.html`'s `resolveNavLink` (browser JS), plus SPEC.md, `tools/generator/index.html`, docs, and stale doc comments updated to match.
  - `TagDropLinkResolverTest.kt`: existing tests updated to the pinned form; added 5 new tests covering the collision scenario directly (bare hash-shaped domain never falls back to hash lookup, pinned link is never shadowed by a matching domain claim, combined form resolves by hash ignoring the label, malformed multi-`@` hosts fail safely to `Invalid`).
- Adds an in-app "Wire Format Spec" viewer (`SpecActivity`), reachable from the menu next to "About / Read Me". Its raw resource is generated by a new Gradle task that copies the repo-root `SPEC.md` verbatim on every build, so it can never drift from the source of truth. `MarkdownRenderer` now includes the GFM tables extension since SPEC.md relies on pipe tables.

## Test plan

- [x] `./gradlew :app:assembleDebug :app:testDebugUnitTest` — `BUILD SUCCESSFUL`, all unit tests pass (including new `TagDropLinkResolverTest` and `MarkdownRendererTest` cases)
- [x] `cd tools && npm test` — JS QR round-trip tests pass (8/8), unaffected by the resolver-side changes
- [x] CI green on every commit on this branch (Gradle tests + `web-tools-roundtrip` job)
- [x] Verified generated `app/build/generated/specRawRes/raw/spec.md` is byte-identical to root `SPEC.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_01S2WhixUcRFyohEL81MJAim)_