### PR TITLE
Replace box-drawing characters with ASCII in SPEC.md diagrams

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,10 +40,10 @@ CBOR(version) || CBOR(type) || CBOR(part_meta) || CBOR(sector_bytes)
 Laid out as a sequence of four concatenated items:
 
 ```
-┌──────────┬──────────┬────────────┬───────────────┐
-│ version  │ type     │ part_meta  │ sector_bytes  │
-│ (1 byte) │ (1 byte) │ (CBOR map) │ (byte string) │
-└──────────┴──────────┴────────────┴───────────────┘
++----------+----------+------------+---------------+
+| version  | type     | part_meta  | sector_bytes  |
+| (1 byte) | (1 byte) | (CBOR map) | (byte string) |
++----------+----------+------------+---------------+
 ```
 
 | Item | Type | Meaning |
@@ -295,11 +295,11 @@ CBOR(core_meta_item) || CBOR(bulky_meta_item) || content
 Laid out as a sequence of three concatenated parts:
 
 ```
-┌────────────────┬─────────────────────┬─────────────────────────┐
-│ core_meta_item │ bulky_meta_item     │ content                 │
-│ plain CBOR map │ CBOR map            │ raw or compressed bytes │
-│ (always small) │ (may be compressed) │ (empty for Paper)       │
-└────────────────┴─────────────────────┴─────────────────────────┘
++----------------+---------------------+-------------------------+
+| core_meta_item | bulky_meta_item     | content                 |
+| plain CBOR map | CBOR map            | raw or compressed bytes |
+| (always small) | (may be compressed) | (empty for Paper)       |
++----------------+---------------------+-------------------------+
 ```
 
 **`core_meta_item`** is always plain CBOR (never compressed) and always
@@ -680,13 +680,13 @@ Each A4 sheet is analogous to a floppy disk:
 A recommended layout for an A4 paper:
 
 ```
-┌─────────────────────────────────────────────┐
-│  [ Paper QR ]      Trail Stop 3 — Oak Tree  │
-│                                             │
-│  [ index.html ]    [ map.svg ]              │
-│                                             │
-│  Next: letterbox 200m north                 │
-└─────────────────────────────────────────────┘
++-------------------------------------------+
+| [ Paper QR ]      Trail Stop 3 — Oak Tree |
+|                                           |
+| [ index.html ]    [ map.svg ]             |
+|                                           |
+| Next: letterbox 200m north                |
++-------------------------------------------+
 ```
 
 Scan the Paper code first to get the directory, then scan whichever file you want — you don't have to scan everything.


### PR DESCRIPTION
## Summary
Replace Unicode box-drawing characters (┌, ─, ┬, ┐, │, ├, ┼, ┤, └, ┴, ┘) with ASCII equivalents (+, -, |) in three data structure diagrams in SPEC.md for improved compatibility and readability.

## Changes
- **Sector format diagram** (line 40–46): Converted from Unicode box-drawing to ASCII table format
- **Content stream layout diagram** (line 295–301): Converted from Unicode box-drawing to ASCII table format  
- **Paper A4 layout example** (line 680–690): Converted from Unicode box-drawing to ASCII box format

All three diagrams maintain their original semantic meaning and visual structure while using only standard ASCII characters (+, -, |, and spaces). This improves rendering consistency across different text editors, terminals, and documentation viewers that may not handle Unicode box-drawing characters uniformly.

https://claude.ai/code/session_01QGZv8zpdtbbc3NBVpdmsVM