### PR TITLE
Raw QR mode for paper files + SPEC key table cleanup (v2.3.0)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -127,28 +127,28 @@ TagDrop's wire format has four internal CBOR structures, all integer-keyed maps 
 - **`bulky_meta_item`** — the second item of the reassembled stream. Whatever doesn't need to be in the early preview but isn't raw content: directories, related-paper hints, large fixed-size fields. May be compressed.
 - **content** — the third and last item: the actual bytes (a Content payload's cache; empty for a Paper, which has no content of its own). May be compressed, and may be a hidden encrypted override map (§9).
 
-| Key | Field | Type | Lives in |
+| Key | Field | Type | Valid in |
 |---|---|---|---|
 | 2 | `cache_id` / `root_hash` | bytes (8, opt) | `part_meta` |
-| 3 | `hint` / `label` | text (opt) | `core_meta_item` |
+| 3 | `hint` / `label` | text (opt) | `core_meta_item`; `related[]` (as `hint`) |
 | 4 | `mime_type` | text (opt) | `core_meta_item`; Content only |
 | 7 | `total_bytes` | uint | `part_meta` |
 | 8 | `content_sha256` | bytes (32, required iff `sector_count > 1`) | `core_meta_item` |
 | 11 | `filename` | text (opt) | `core_meta_item`; Content only |
 | 12 | `content_compression` | uint (opt) | `core_meta_item` |
-| 13 | `set` | text (opt) | `core_meta_item`; Paper only |
-| 14 | `slug` | text (opt) | `core_meta_item`; Paper only |
-| 15 | `files` | array | `bulky_meta_item`; Paper only |
-| 16 | `related` | array | `bulky_meta_item`; Paper only |
+| 13 | `set` | text (opt) | `core_meta_item` (Paper only) |
+| 14 | `slug` | text (opt) | `core_meta_item` (Paper only) |
+| 15 | `files` | array of `files[]` sub-maps | `bulky_meta_item`; Paper only |
+| 16 | `related` | array of `related[]` sub-maps | `bulky_meta_item`; Paper only |
 | 17 | `collection_id` | bytes (8, opt) | `core_meta_item` |
 | 18 | `collection_label` | text (opt) | `core_meta_item` |
 | 19 | `collection_tag` | text (opt) | `core_meta_item` |
 | 24 | `icon` | text (opt) | `core_meta_item` |
-| 26 | `lat` | float64 (opt) | `core_meta_item` — author-declared latitude of this payload's own location |
-| 27 | `lng` | float64 (opt) | `core_meta_item` — author-declared longitude, same scope as `lat` |
+| 26 | `lat` | float64 (opt) | `core_meta_item` (author-declared location of this payload) |
+| 27 | `lng` | float64 (opt) | `core_meta_item` — longitude, same scope as `lat` |
 | 28 | `encryption` | uint (opt) | `core_meta_item`; Content only |
 | 30 | `key_material` | bytes (32, opt) | `core_meta_item` |
-| 31 | `retain_key` | bool (opt, default `true`) | wherever `key_material` appears |
+| 31 | `retain_key` | bool (opt, default `true`) | `core_meta_item` — see §9 |
 | 32 | `signature_algorithm` | uint (opt) | `core_meta_item` |
 | 33 | `signature` | bytes (2420, opt) | `bulky_meta_item` |
 | 34 | `signer_pubkey` | bytes (1312, opt) | `bulky_meta_item` |
@@ -164,27 +164,58 @@ TagDrop's wire format has four internal CBOR structures, all integer-keyed maps 
 | 45 | `bulky_meta_compression` | uint (opt) | `core_meta_item` |
 | 46 | `bulky_meta_compressed_bytes` | uint (required iff key 45 present) | `core_meta_item` |
 | 47 | `bulky_meta_sha256` | bytes (32, required iff `sector_count > 1`) | `core_meta_item` |
-| 48 | `radius_m` | float64 (opt) | wherever `lat`/`lng` appears — `core_meta_item` or a `related` entry |
+| 48 | `radius_m` | float64 (opt) | `core_meta_item` — circle-of-uncertainty radius in meters around `lat`/`lng` |
 | 49 | `prefer_declared_location` | bool (opt, default `false`) | `core_meta_item` only |
 | 50 | `in_reply_to` | bytes (8, opt) | `core_meta_item` — `cache_id`/`root_hash` of the single parent this is replying to (§7) |
 | 51 | `title` | text (opt) | `core_meta_item` |
 | 52 | `created_at` | uint (opt) | `core_meta_item` — author-declared Unix timestamp (seconds since epoch) this payload was authored; reflects the authoring device's clock, not independently verified |
 | 53 | `domain` | text (opt) | `core_meta_item`; Paper only — human-readable name for `tagdrop://<domain>/<slug>` links, see §7 "Domains" |
 | 54 | `location_label` | text (opt) | `core_meta_item` — human-readable, non-coordinate description of this payload's own location, e.g. "🚋 Tram 40"; see §4.2 |
-| 55 | `pixel_art` | bool (opt, default `false`) | `core_meta_item`; Content only — see §7 "Pixel art" |
+| 55 | `pixel_art` | bool (opt, default `false`) | `core_meta_item` (Content only) — render with nearest-neighbour scaling (no smoothing); see §7 "Pixel art" |
 
 Keys **1**, **6**, **9**, **10** are retired (formerly `version`-inside-payload,
 `chunk_count`, `chunk_index`, `chunk_data` — superseded by the envelope's
 `version` and by `part_meta`'s `sector_index`/`sector_count`; §14). Key **5**
 (`content`) no longer appears in `core_meta_item` or `bulky_meta_item`, but is
 reused with the same meaning inside the encrypted override map structure only
-(§9). Key 25 is reserved for a future small embedded image icon (raw bytes),
-as an alternative to the emoji `icon` field. Keys 28, 30, 31 are defined in §9
-(Encryption); keys 32–36 in §10 (Verified Authorship); keys 37–39 in §9
-(Passphrase-based key derivation); keys 26, 27, 48, 49, 54 in §4.2 (Declared
-location and priority); key 53 in §7 (Domains); key 55 in §7 (Pixel art). Key
-29 is reserved and unused — see §9 for why an encrypted override map's nonce
-doesn't need its own clear field.
+(§9). Keys **20–23** and **41** are retired as global keys — they formerly named
+`files[]`/`related[]` sub-map fields, but those sub-maps now use their own
+independent local key namespaces (see below). Key 25 is reserved for a future
+small embedded image icon (raw bytes), as an alternative to the emoji `icon`
+field. Keys 28, 30, 31 are defined in §9 (Encryption); keys 32–36 in §10
+(Verified Authorship); keys 37–39 in §9 (Passphrase-based key derivation); keys
+26, 27, 48, 49, 54 in §4.2 (Declared location and priority); key 53 in §7
+(Domains); key 55 in §7 (Pixel art). Key 29 is reserved and unused — see §9 for
+why an encrypted override map's nonce doesn't need its own clear field.
+
+**Sub-map local key namespaces:** `files[]` and `related[]` entries are CBOR
+maps with their own independent key ranges, separate from the top-level key
+space. The same integer may appear in both a top-level map and a sub-map without
+conflict, because CBOR map keys are scoped per-map.
+
+**`files[]` entry keys** (each element of the `files` array, key 15):
+
+| Key | Field | Type | Notes |
+|---|---|---|---|
+| 1 | `slug` | text | URL-safe name for this file within the paper |
+| 2 | `mime_type` | text | MIME type of the file |
+| 3 | `file_id` | bytes (8) | `cache_id` of the file's root QR |
+| 4 | `description` | text (opt) | Content teaser, e.g. "A poem to read" |
+| 5 | `pixel_art` | bool (opt, default `false`) | Render with nearest-neighbour scaling (no smoothing); see §7 "Pixel art" |
+
+**`related[]` entry keys** (each element of the `related` array, key 16):
+
+| Key | Field | Type | Notes |
+|---|---|---|---|
+| 1 | `hint` | text | Human-readable label for this related paper |
+| 2 | `set` | text (opt) | Collection set identifier |
+| 3 | `slug` | text (opt) | Slug of the related paper |
+| 4 | `paper_id` | bytes (8, opt) | Root hash of the related paper |
+| 5 | `lat` | float64 (opt) | Location of the related paper |
+| 6 | `lng` | float64 (opt) | Longitude, same scope as `lat` |
+| 7 | `radius_m` | float64 (opt) | Circle-of-uncertainty radius in meters |
+| 8 | `key_material` | bytes (32, opt) | Decryption key for that paper's content (§9) |
+| 9 | `retain_key` | bool (opt, default `true`) | See §9 |
 
 **`content_sha256`/`bulky_meta_sha256` are REQUIRED whenever `sector_count >
 1`.** Without it, an adversary who substitutes one sector of a multi-sector
@@ -217,30 +248,11 @@ serve as the values shown before (or without) a matching key. See §9.
 
 ### File entry sub-keys (elements of key 15)
 
-Each element is a CBOR map:
-
-| Key | Field | Type |
-|---|---|---|
-| 20 | `slug` | text |
-| 21 | `mime_type` | text |
-| 22 | `file_id` | bytes (8) — `cache_id` of the file's root QR |
-| 41 | `description` | text (opt) — what this file is, e.g. "A poem to read" |
+Each element is a CBOR map using local keys **1** (`slug`), **2** (`mime_type`), **3** (`file_id`), **4** (`description`), **5** (`pixel_art`). These keys are local to the sub-map and independent of the top-level key space — see the `files[]` entry key table in §3.
 
 ### Related paper sub-keys (elements of key 16)
 
-Each element is a CBOR map:
-
-| Key | Field | Type |
-|---|---|---|
-| 3 | `hint` | text — human-readable location description |
-| 13 | `set` | text (opt) |
-| 14 | `slug` | text (opt) |
-| 23 | `paper_id` | bytes (8, opt) — root hash of the related paper |
-| 26 | `lat` | float64 (opt) — latitude of the related paper |
-| 27 | `lng` | float64 (opt) — longitude of the related paper |
-| 48 | `radius_m` | float64 (opt) — circle-of-uncertainty radius in meters around `lat`/`lng` |
-| 30 | `key_material` | bytes (32, opt) — decryption key for the related paper's content, see §9 |
-| 31 | `retain_key` | bool (opt, default `true`) — see §9 |
+Each element is a CBOR map using local keys **1** (`hint`), **2** (`set`), **3** (`slug`), **4** (`paper_id`), **5** (`lat`), **6** (`lng`), **7** (`radius_m`), **8** (`key_material`), **9** (`retain_key`). These keys are local to the sub-map and independent of the top-level key space — see the `related[]` entry key table in §3.
 
 ---
 
@@ -460,7 +472,7 @@ already being browsed rather than as a "should I look for this" decision;
 for a Content payload, free text alongside the cache's own bytes, or —
 when the content slot is occupied by an attachment instead — standing in
 as the message itself (see Postcards below). A per-file `description`
-(key 41, optional, in each `files[]` entry alongside `slug`/`mime_type`)
+(local key 4, optional, in each `files[]` entry alongside `slug`/`mime_type`)
 plays the analogous role for an individual file, e.g. "A poem to read" or
 "A hand-drawn map" — letting a finder choose among files they can already
 see listed, before scanning each one's own code. `title` (key 51,
@@ -1628,7 +1640,7 @@ Version history:
   (`parity_scheme` 1) at `sector_index == sector_count` reconstructs exactly
   one lost data sector per payload (§5).
 - Ad-hoc collections via `collection_id`/`collection_label`/`collection_tag` (keys 17–19). Emoji `icon` (key 24).
-- Content-teaser `description` (key 40, both payload kinds) and per-file `description` (key 41, in `files[]` entries) — distinct from `label`/`hint` and from the short-caption `title` (key 51, both payload kinds) (§4.3).
+- Content-teaser `description` (key 40, both payload kinds) and per-file `description` (local key 4, in `files[]` entries) — distinct from `label`/`hint` and from the short-caption `title` (key 51, both payload kinds) (§4.3).
 - AES-256-GCM hidden override maps (§9), Content payloads only: self-contained `nonce||ciphertext||tag` blob carried in the reassembled stream's `content` slot, applied after compression. Optional non-binding `encryption` hint (key 28). `key_material`/`retain_key` (keys 30/31) matched by trial decryption ("discovery, not declaration"). PBKDF2-HMAC-SHA256 passphrase derivation via `kdf_alg`/`kdf_salt`/`kdf_iters` (keys 37–39).
 - ML-DSA-44 post-quantum signatures (§10): `signature_algorithm`/`signature`/`signer_pubkey`/`signer_id`/`signer_label` (keys 32–36), additive and not affecting `cache_id`/`root_hash`/`content_sha256`/`bulky_meta_sha256`. Specified for forward-compatibility; not yet implemented in reference implementations.
 - Author-declared `created_at` (key 52, both payload kinds): optional Unix timestamp (seconds) recording when the payload was authored, taken from the authoring device's clock at encode time — self-declared like `lat`/`lng`, not a verified/trusted timestamp.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,8 @@ android {
         applicationId = "com.github.mofosyne.tagdrop"
         minSdk = 23
         targetSdk = 35
-        versionCode = 7
-        versionName = "2.2.0"
+        versionCode = 8
+        versionName = "2.3.0"
     }
 
     buildFeatures {

--- a/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
@@ -811,10 +811,16 @@ class ReceiveActivity : AppCompatActivity() {
      * non-TagDrop content, so this is the only source of a human-readable title.
      */
     private fun completeRawScan(text: String, format: BarcodeFormat, rawBytes: ByteArray? = null) {
-        // Prefer raw bytes from the QR byte-mode segment (preserves binary content exactly);
-        // fall back to re-encoding the decoded text as UTF-8 (the common case for text QRs).
-        val bytes = rawBytes ?: text.toByteArray(Charsets.UTF_8)
-        val cacheId = TagDropCodec.contentId(bytes).toHex()
+        // cacheId is always derived from the text representation (UTF-8), matching how the paper
+        // manifest's file_id is computed by the generator (sha256 of UTF-8 bytes of the content
+        // string). rawBytes from ZXing BYTE_SEGMENTS may only cover byte-mode QR segments, not
+        // alphanumeric/numeric ones, so it can be a partial byte run for mixed-mode QR codes —
+        // using it for the cacheId would produce a hash mismatch against the manifest's file_id.
+        // We still prefer rawBytes as the stored content (preserves exact binary data) but always
+        // compute the cacheId from the full decoded text.
+        val textBytes = text.toByteArray(Charsets.UTF_8)
+        val bytes = rawBytes ?: textBytes
+        val cacheId = TagDropCodec.contentId(textBytes).toHex()
         val paperFile = lastPaper?.files?.find { it.fileId.toHex() == cacheId }
         val classification = QrContentClassifier.classify(text, format)
         val declaredMime = paperFile?.mimeType ?: classification?.mimeType

--- a/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
@@ -43,6 +43,7 @@ import com.github.mofosyne.tagdrop.databinding.ActivityReceiveBinding
 import com.github.mofosyne.tagdrop.ui.ScanBlock
 import com.github.mofosyne.tagdrop.ui.ScanBoardAdapter
 import com.github.mofosyne.tagdrop.util.LocationUtils
+import com.github.mofosyne.tagdrop.util.MimeTypeGuesser
 import com.github.mofosyne.tagdrop.util.QrContentClassifier
 import com.github.mofosyne.tagdrop.util.showCborDebugDialog
 import com.google.zxing.BarcodeFormat
@@ -127,7 +128,9 @@ class ReceiveActivity : AppCompatActivity() {
             if (text == lastDecodedText && (now - lastDecodedAt) < SCAN_COOLDOWN_MS) return
             lastDecodedText = text
             lastDecodedAt = now
-            processScanned(text, result.result.barcodeFormat)
+            // Pass rawBytes so completeRawScan can use them directly for non-TagDrop binary QRs
+            // (byte-mode content that didn't decode as TagDrop — e.g. a raw PNG stored in a code).
+            processScanned(text, result.result.barcodeFormat, rawBytes)
         }
         override fun possibleResultPoints(resultPoints: MutableList<ResultPoint>) {}
     }
@@ -342,7 +345,7 @@ class ReceiveActivity : AppCompatActivity() {
             .show()
     }
 
-    private fun processScanned(scanned: String, format: BarcodeFormat = BarcodeFormat.QR_CODE) {
+    private fun processScanned(scanned: String, format: BarcodeFormat = BarcodeFormat.QR_CODE, rawBytes: ByteArray? = null) {
         val scan = TagDropCodec.decode(scanned)
         if (scan != null) { processScan(scan); return }
         when {
@@ -364,7 +367,7 @@ class ReceiveActivity : AppCompatActivity() {
             // -- SPEC.md defines no multi-fragment scheme for these (§11 is data: URIs only), so
             // there's no "more fragments" to wait for. Cache it immediately as content-addressed
             // raw content instead of stranding it in legacyChunks with no way to complete.
-            else -> completeRawScan(scanned, format)
+            else -> completeRawScan(scanned, format, rawBytes)
         }
     }
 
@@ -467,7 +470,7 @@ class ReceiveActivity : AppCompatActivity() {
         lat: Double? = null, lng: Double? = null, radiusM: Double? = null,
         preferDeclaredLocation: Boolean = false, locationLabel: String? = null,
         inReplyTo: ByteArray? = null, title: String? = null, description: String? = null,
-        createdAt: Long? = null, pixelArt: Boolean = false
+        createdAt: Long? = null, pixelArt: Boolean = false, mimeTypeIsGuessed: Boolean = false
     ) {
         val location = getLastKnownLocation()
         val resolved = LocationUtils.resolveLocation(lat, lng, radiusM, preferDeclaredLocation, location?.first, location?.second, locationLabel)
@@ -501,7 +504,8 @@ class ReceiveActivity : AppCompatActivity() {
                     title               = title,
                     description         = description,
                     createdAt           = createdAt,
-                    pixelArt            = pixelArt
+                    pixelArt            = pixelArt,
+                    mimeTypeIsGuessed   = mimeTypeIsGuessed
                 )
             )
             if (paper != null) {
@@ -806,20 +810,29 @@ class ReceiveActivity : AppCompatActivity() {
      * display already falls back to "Untitled" without -- there's no author-declared hint for
      * non-TagDrop content, so this is the only source of a human-readable title.
      */
-    private fun completeRawScan(text: String, format: BarcodeFormat) {
-        val bytes = text.toByteArray(Charsets.UTF_8)
+    private fun completeRawScan(text: String, format: BarcodeFormat, rawBytes: ByteArray? = null) {
+        // Prefer raw bytes from the QR byte-mode segment (preserves binary content exactly);
+        // fall back to re-encoding the decoded text as UTF-8 (the common case for text QRs).
+        val bytes = rawBytes ?: text.toByteArray(Charsets.UTF_8)
         val cacheId = TagDropCodec.contentId(bytes).toHex()
         val paperFile = lastPaper?.files?.find { it.fileId.toHex() == cacheId }
         val classification = QrContentClassifier.classify(text, format)
+        val declaredMime = paperFile?.mimeType ?: classification?.mimeType
+        val (mimeType, isGuessed) = if (declaredMime != null) {
+            declaredMime to false
+        } else {
+            (MimeTypeGuesser.guess(bytes) ?: "text/plain") to true
+        }
         completeSingle(
-            cacheId       = cacheId,
-            hint          = classification?.title,
-            filename      = null,
-            mimeType      = paperFile?.mimeType ?: classification?.mimeType ?: "text/plain",
-            content       = bytes,
-            collectionTag = classification?.tag,
-            icon          = classification?.icon,
-            pixelArt      = paperFile?.pixelArt ?: false
+            cacheId          = cacheId,
+            hint             = classification?.title,
+            filename         = null,
+            mimeType         = mimeType,
+            content          = bytes,
+            collectionTag    = classification?.tag,
+            icon             = classification?.icon,
+            pixelArt         = paperFile?.pixelArt ?: false,
+            mimeTypeIsGuessed = isGuessed
         )
     }
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
@@ -440,7 +440,15 @@ class ReceiveActivity : AppCompatActivity() {
         }
         lastPaper = paper
         updateDisplay()
-        toast(getString(R.string.paper_scanned, paper.files.size))
+        val cachedIds = latestCaches.mapTo(HashSet()) { it.cacheId }
+        val alreadyFoundCount = paper.files.count { cachedIds.contains(it.fileId.toHex()) }
+        toast(
+            if (alreadyFoundCount > 0) {
+                getString(R.string.paper_scanned_with_found, paper.files.size, alreadyFoundCount)
+            } else {
+                getString(R.string.paper_scanned, paper.files.size)
+            }
+        )
     }
 
     /**
@@ -800,15 +808,18 @@ class ReceiveActivity : AppCompatActivity() {
      */
     private fun completeRawScan(text: String, format: BarcodeFormat) {
         val bytes = text.toByteArray(Charsets.UTF_8)
+        val cacheId = TagDropCodec.contentId(bytes).toHex()
+        val paperFile = lastPaper?.files?.find { it.fileId.toHex() == cacheId }
         val classification = QrContentClassifier.classify(text, format)
         completeSingle(
-            cacheId       = TagDropCodec.contentId(bytes).toHex(),
+            cacheId       = cacheId,
             hint          = classification?.title,
             filename      = null,
-            mimeType      = classification?.mimeType ?: "text/plain",
+            mimeType      = paperFile?.mimeType ?: classification?.mimeType ?: "text/plain",
             content       = bytes,
             collectionTag = classification?.tag,
-            icon          = classification?.icon
+            icon          = classification?.icon,
+            pixelArt      = paperFile?.pixelArt ?: false
         )
     }
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/ViewDataUriActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/ViewDataUriActivity.kt
@@ -55,6 +55,8 @@ class ViewDataUriActivity : AppCompatActivity() {
     /** Set by [showPreviewUnavailable]; re-read by [refreshPreviewPanel] once [exportCache] resolves asynchronously. */
     private var previewMimeType: String? = null
     private var previewSizeBytes: Int = 0
+    /** True while the preview-unavailable panel is showing (not the WebView). Used by [setViewMode] to restore the panel on RENDERED. */
+    private var isPreviewPanel = false
 
     /**
      * The content bytes currently on screen, tracked so the view-mode menu ([ViewMode]) can
@@ -151,6 +153,7 @@ class ViewDataUriActivity : AppCompatActivity() {
                 refreshPreviewPanel()
                 refreshReplyBar()
                 refreshActionChip()
+                refreshGuessedTypeBanner()
             }
         }
     }
@@ -165,7 +168,8 @@ class ViewDataUriActivity : AppCompatActivity() {
         menu.findItem(R.id.action_open_external)?.isEnabled = enabled
         menu.findItem(R.id.action_share)?.isEnabled = enabled
         menu.findItem(R.id.action_save)?.isEnabled = enabled
-        menu.findItem(R.id.action_view_as)?.isVisible = currentContent != null
+        menu.findItem(R.id.action_set_type)?.isVisible = enabled
+        menu.findItem(R.id.action_view_as)?.isVisible = enabled || currentContent != null
         val checkedId = when (viewMode) {
             ViewMode.RENDERED -> R.id.action_view_rendered
             ViewMode.TEXT -> R.id.action_view_text
@@ -181,6 +185,7 @@ class ViewDataUriActivity : AppCompatActivity() {
         R.id.action_open_external -> { openExternally(); true }
         R.id.action_share -> { shareContent(); true }
         R.id.action_save -> { saveToDevice(); true }
+        R.id.action_set_type -> { showSetTypeDialog(); true }
         R.id.action_view_rendered -> { setViewMode(ViewMode.RENDERED); true }
         R.id.action_view_text -> { setViewMode(ViewMode.TEXT); true }
         R.id.action_view_hex -> { setViewMode(ViewMode.HEX); true }
@@ -189,11 +194,74 @@ class ViewDataUriActivity : AppCompatActivity() {
         else -> super.onOptionsItemSelected(item)
     }
 
-    /** Switches [viewMode] and re-renders [currentContent]'s bytes the new way, without re-fetching them. */
+    /** Switches [viewMode] and re-renders content the new way, without re-fetching from DB. */
     private fun setViewMode(mode: ViewMode) {
-        val content = currentContent ?: return
         viewMode = mode
+        invalidateOptionsMenu()
+        // RENDERED on a non-renderable file: go back to the preview panel.
+        if (mode == ViewMode.RENDERED && isPreviewPanel) {
+            showPreviewUnavailable(previewMimeType ?: return, previewSizeBytes)
+            return
+        }
+        // For raw dump modes, build ContentInfo from exportCache if not already set.
+        val content = currentContent ?: run {
+            val cache = exportCache ?: return
+            val bytes = cache.contentBytes ?: return
+            ContentInfo(cache.mimeType, bytes, null, cache.pixelArt)
+        }
+        showWebView()
         renderContent(content)
+    }
+
+    /** Shows a warning banner when the cached MIME type was guessed; tapping it opens [showSetTypeDialog]. */
+    private fun refreshGuessedTypeBanner() {
+        val cache = exportCache
+        if (cache == null || !cache.mimeTypeIsGuessed) {
+            binding.guessedTypeBanner.visibility = View.GONE
+            return
+        }
+        binding.guessedTypeBanner.text = getString(R.string.guessed_type_banner, cache.mimeType)
+        binding.guessedTypeBanner.setOnClickListener { showSetTypeDialog() }
+        binding.guessedTypeBanner.visibility = View.VISIBLE
+    }
+
+    /** Dialog letting the user override the stored MIME type for the current cache entry. */
+    private fun showSetTypeDialog() {
+        val cache = exportCache ?: return
+        val input = android.widget.EditText(this).apply {
+            hint = getString(R.string.set_type_hint)
+            setText(cache.mimeType)
+            setSelection(text.length)
+        }
+        AlertDialog.Builder(this)
+            .setTitle(R.string.set_type_dialog_title)
+            .setView(input)
+            .setPositiveButton(R.string.set_type_apply) { _, _ ->
+                val newMime = input.text.toString().trim().takeIf { it.isNotEmpty() } ?: return@setPositiveButton
+                lifecycleScope.launch {
+                    AppDatabase.get(this@ViewDataUriActivity).cacheDao().updateMimeType(cache.cacheId, newMime)
+                    exportCache = AppDatabase.get(this@ViewDataUriActivity).cacheDao().getById(cache.cacheId)
+                    invalidateOptionsMenu()
+                    refreshPreviewPanel()
+                    refreshGuessedTypeBanner()
+                    // If showing a raw dump, re-render with the new MIME type in ContentInfo
+                    currentContent?.let { old ->
+                        currentContent = old.copy(mimeType = newMime)
+                        if (viewMode == ViewMode.RENDERED) {
+                            // Re-render in case the new MIME changes how we display it
+                            val bytes = exportCache?.contentBytes ?: return@let
+                            if (isWebViewRenderable(newMime)) {
+                                showWebView()
+                                renderContent(ContentInfo(newMime, bytes, old.context, old.pixelArt))
+                            } else {
+                                showPreviewUnavailable(newMime, bytes.size)
+                            }
+                        }
+                    }
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
     }
 
     /** Shows or hides the contextual action chip based on the current [exportCache]'s content type. */
@@ -490,6 +558,7 @@ class ViewDataUriActivity : AppCompatActivity() {
 
     /** Hides the preview-unavailable panel and shows the WebView, e.g. when navigating to a renderable file. */
     private fun showWebView() {
+        isPreviewPanel = false
         binding.previewPanel.visibility = View.GONE
         binding.htmldisp.visibility = View.VISIBLE
     }
@@ -497,6 +566,7 @@ class ViewDataUriActivity : AppCompatActivity() {
     /** Shows the "can't preview" panel for [mimeType] content instead of a blank WebView. */
     private fun showPreviewUnavailable(mimeType: String, sizeBytes: Int) {
         currentContent = null
+        isPreviewPanel = true
         previewMimeType = mimeType
         previewSizeBytes = sizeBytes
         binding.htmldisp.visibility = View.GONE

--- a/app/src/main/java/com/github/mofosyne/tagdrop/ViewDataUriActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/ViewDataUriActivity.kt
@@ -139,6 +139,7 @@ class ViewDataUriActivity : AppCompatActivity() {
 
         binding.previewButtonOpen.setOnClickListener { openExternally() }
         binding.previewButtonSave.setOnClickListener { saveToDevice() }
+        binding.actionChip.setOnClickListener { launchContextualAction() }
 
         val cacheId = intent.getStringExtra(EXTRA_CACHE_ID)
         loadInitial(dataUri, cacheId)
@@ -149,6 +150,7 @@ class ViewDataUriActivity : AppCompatActivity() {
                 invalidateOptionsMenu()
                 refreshPreviewPanel()
                 refreshReplyBar()
+                refreshActionChip()
             }
         }
     }
@@ -192,6 +194,95 @@ class ViewDataUriActivity : AppCompatActivity() {
         val content = currentContent ?: return
         viewMode = mode
         renderContent(content)
+    }
+
+    /** Shows or hides the contextual action chip based on the current [exportCache]'s content type. */
+    private fun refreshActionChip() {
+        val (label, _) = contextualAction() ?: run {
+            binding.actionChip.visibility = View.GONE
+            return
+        }
+        binding.actionChip.text = label
+        binding.actionChip.visibility = View.VISIBLE
+    }
+
+    /**
+     * Returns a (label, intent) pair for a direct system action appropriate to this content,
+     * or null if no contextual action applies.
+     *
+     * Covers: URL → open in browser, vCard → add contact, iCal → add to calendar,
+     * WiFi → connect (API 29+), geo → open in maps, tel → dial, sms → compose, email → compose.
+     */
+    @Suppress("DEPRECATION")
+    private fun contextualAction(): Pair<String, Intent>? {
+        val cache = exportCache ?: return null
+        val bytes = cache.contentBytes ?: return null
+        val text = bytes.toString(Charsets.UTF_8)
+        return when (cache.collectionTag) {
+            "url" -> {
+                val uri = Uri.parse(text.trim())
+                "🔗 Open URL" to Intent(Intent.ACTION_VIEW, uri)
+            }
+            "vcard" -> {
+                val uri = ContentExporter.writeTempFile(this, cache) ?: return null
+                "👤 Add Contact" to Intent(Intent.ACTION_VIEW).apply { setDataAndType(uri, "text/vcard") }
+            }
+            "calendar" -> {
+                val uri = ContentExporter.writeTempFile(this, cache) ?: return null
+                "📅 Add to Calendar" to Intent(Intent.ACTION_VIEW).apply { setDataAndType(uri, "text/calendar") }
+            }
+            "wifi" -> buildWifiIntent(text)
+            "geo" -> {
+                val uri = Uri.parse(text.trim())
+                "📍 Open in Maps" to Intent(Intent.ACTION_VIEW, uri)
+            }
+            "tel" -> {
+                val uri = Uri.parse(text.trim())
+                "📞 Dial" to Intent(Intent.ACTION_DIAL, uri)
+            }
+            "sms" -> {
+                val uri = Uri.parse(text.trim())
+                "💬 Send SMS" to Intent(Intent.ACTION_SENDTO, uri)
+            }
+            "email" -> {
+                val uri = Uri.parse(text.trim())
+                "📧 Compose Email" to Intent(Intent.ACTION_SENDTO, uri)
+            }
+            else -> null
+        }
+    }
+
+    /** Parses a WiFi QR string (WIFI:T:WPA;S:ssid;P:pass;;) and returns a connect intent, or null. */
+    @android.annotation.SuppressLint("NewApi")
+    private fun buildWifiIntent(wifiString: String): Pair<String, Intent>? {
+        if (android.os.Build.VERSION.SDK_INT < 29) return null
+        val fields = wifiString.removePrefix("WIFI:").removeSuffix(";").split(";")
+            .mapNotNull { it.split(":").takeIf { p -> p.size >= 2 }?.let { p -> p[0] to p.drop(1).joinToString(":") } }
+            .toMap()
+        val ssid = fields["S"]?.takeIf { it.isNotBlank() } ?: return null
+        val type = fields["T"] ?: "nopass"
+        val pass = fields["P"]
+        val suggestion = when (type.uppercase()) {
+            "WPA", "WPA2" -> android.net.wifi.WifiNetworkSuggestion.Builder()
+                .setSsid(ssid).setWpa2Passphrase(pass ?: "").build()
+            "WEP" -> android.net.wifi.WifiNetworkSuggestion.Builder()
+                .setSsid(ssid).setWpa2Passphrase(pass ?: "").build()
+            else -> android.net.wifi.WifiNetworkSuggestion.Builder().setSsid(ssid).build()
+        }
+        val intent = Intent(android.provider.Settings.ACTION_WIFI_ADD_NETWORKS).apply {
+            putParcelableArrayListExtra("android.net.wifi.extra.WIFI_NETWORK_LIST", arrayListOf(suggestion))
+        }
+        return "📶 Connect to Wi-Fi" to intent
+    }
+
+    /** Fires the contextual action intent for the current [exportCache]. */
+    private fun launchContextualAction() {
+        val (_, intent) = contextualAction() ?: return
+        try {
+            startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            toast(getString(R.string.export_no_app_found))
+        }
     }
 
     /** Opens the cached content in another app via a chooser. */

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [FoundCache::class, ScannedPaper::class, RetainedKey::class], version = 19, exportSchema = false)
+@Database(entities = [FoundCache::class, ScannedPaper::class, RetainedKey::class], version = 20, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun cacheDao(): CacheDao
     abstract fun paperDao(): PaperDao
@@ -193,13 +193,19 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_19_20 = object : Migration(19, 20) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE found_caches ADD COLUMN mimeTypeIsGuessed INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
         fun get(context: Context): AppDatabase = INSTANCE ?: synchronized(this) {
             INSTANCE ?: Room.databaseBuilder(
                 context.applicationContext,
                 AppDatabase::class.java,
                 DB_NAME
             )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20)
             .build().also { INSTANCE = it }
         }
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/CacheDao.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/CacheDao.kt
@@ -33,4 +33,8 @@ interface CacheDao {
     /** Other cached items whose `in_reply_to` points at [parentId] (SPEC §7) — the reverse of [FoundCache.inReplyTo]. */
     @Query("SELECT * FROM found_caches WHERE inReplyTo = :parentId ORDER BY discoveredAt DESC")
     suspend fun getRepliesTo(parentId: String): List<FoundCache>
+
+    /** Updates the stored MIME type for a single cache entry (used by the "Set type…" override in ViewDataUriActivity). */
+    @Query("UPDATE found_caches SET mimeType = :mimeType, mimeTypeIsGuessed = 0 WHERE cacheId = :cacheId")
+    suspend fun updateMimeType(cacheId: String, mimeType: String)
 }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/FoundCache.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/FoundCache.kt
@@ -30,7 +30,8 @@ data class FoundCache(
     val title: String? = null,                   // optional short subject/caption, distinct from hint (SPEC §4.3, issue #35)
     val description: String? = null,             // optional content teaser / message body (SPEC §4.3, issue #35)
     val createdAt: Long? = null,                 // author-declared Unix timestamp (seconds) this payload was authored, unverified (SPEC §3); distinct from discoveredAt
-    val pixelArt: Boolean = false                // author hint to render this image with no smoothing/nearest-neighbor scaling (SPEC §7)
+    val pixelArt: Boolean = false,               // author hint to render this image with no smoothing/nearest-neighbor scaling (SPEC §7)
+    val mimeTypeIsGuessed: Boolean = false       // true when mimeType was inferred from magic bytes / text heuristics, not declared by the author or paper manifest
 ) {
     override fun equals(other: Any?) = other is FoundCache && cacheId == other.cacheId
     override fun hashCode() = cacheId.hashCode()

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/LenientJson.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/LenientJson.kt
@@ -12,9 +12,45 @@ object LenientJson {
     private class ParseError(val message: String, val offset: Int)
 
     fun describe(bytes: ByteArray): String {
+        if (bytes.isEmpty()) return "(empty)"
         val text = bytes.toString(Charsets.UTF_8)
         if (text.isBlank()) return "(empty)"
-        return buildString { describeValue(Parser(text).parseTopLevel(), 0, this) }
+        val parsed = Parser(text).parseTopLevel()
+        if (parsed is ParseError) {
+            // Not JSON — show the error then the bytes so the user has something to work with.
+            return buildString {
+                appendLine("⚠ ${parsed.message} (at byte ${parsed.offset})")
+                appendLine()
+                appendLine("hex dump:")
+                appendLine(hexDump(bytes))
+                // Also show the raw text if the bytes are valid UTF-8 (common for plain-text QRs).
+                val asText = runCatching { bytes.toString(Charsets.UTF_8) }.getOrNull()
+                if (asText != null && asText.any { it.isLetterOrDigit() }) {
+                    appendLine()
+                    appendLine("as text:")
+                    append(asText)
+                }
+            }
+        }
+        return buildString { describeValue(parsed, 0, this) }
+    }
+
+    private fun hexDump(bytes: ByteArray): String = buildString {
+        val w = 16
+        for (offset in bytes.indices step w) {
+            val end = minOf(offset + w, bytes.size)
+            append("%08x  ".format(offset))
+            for (i in offset until offset + w) {
+                append(if (i < end) "%02x ".format(bytes[i]) else "   ")
+                if (i - offset == 7) append(' ')
+            }
+            append(' ')
+            for (i in offset until end) {
+                val c = bytes[i].toInt() and 0xFF
+                append(if (c in 0x20..0x7e) c.toChar() else '.')
+            }
+            appendLine()
+        }
     }
 
     private fun describeValue(value: Any?, indent: Int, out: StringBuilder) {

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/LenientJson.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/LenientJson.kt
@@ -17,17 +17,17 @@ object LenientJson {
         if (text.isBlank()) return "(empty)"
         val parsed = Parser(text).parseTopLevel()
         if (parsed is ParseError) {
-            // Not JSON — show the error then the bytes so the user has something to work with.
+            // Not JSON — show the hex dump first so it's immediately visible, then the error.
             return buildString {
-                appendLine("⚠ ${parsed.message} (at byte ${parsed.offset})")
+                appendLine("── hex dump ──────────────────────────────────────")
+                append(hexDump(bytes))
                 appendLine()
-                appendLine("hex dump:")
-                appendLine(hexDump(bytes))
+                appendLine("⚠ ${parsed.message} (at byte ${parsed.offset})")
                 // Also show the raw text if the bytes are valid UTF-8 (common for plain-text QRs).
                 val asText = runCatching { bytes.toString(Charsets.UTF_8) }.getOrNull()
                 if (asText != null && asText.any { it.isLetterOrDigit() }) {
                     appendLine()
-                    appendLine("as text:")
+                    appendLine("── as text ───────────────────────────────────────")
                     append(asText)
                 }
             }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/MiniCbor.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/MiniCbor.kt
@@ -161,10 +161,12 @@ object MiniCbor {
         val arg   = readArg(b and 0x1F, stream)
         return when (major) {
             0 -> arg
+            1 -> -(arg + 1)                   // negative integer
             2 -> readBytes(stream, arg.toInt())
             3 -> readBytes(stream, arg.toInt()).toString(Charsets.UTF_8)
             4 -> List(arg.toInt()) { readValue(stream) }
             5 -> readMapFromStream(stream, arg.toInt())
+            6 -> "<tag $arg>(${readValue(stream)})"  // tagged value
             7 -> when (b and 0x1F) {
                 20 -> false                   // false (0xf4)
                 21 -> true                    // true (0xf5)
@@ -240,31 +242,58 @@ object MiniCbor {
      * dump of whatever bytes remain unparsed, rather than discarding everything (this is purely a
      * discovery aid, not a correctness check).
      */
+    /**
+     * Scans [bytes] for CBOR items, decoding whatever it can and dumping unrecognised stretches as
+     * hex. Unlike a strict decoder, a failure at position N does not abort the whole walk — it adds
+     * byte N to the current "unrecognised" run and retries from N+1, so CBOR structures embedded in
+     * binary garbage (e.g. a non-CBOR file that happens to contain a CBOR map partway through) are
+     * still surfaced. The full hex dump is always printed first so the raw bytes are immediately
+     * visible even when the CBOR interpretation is entirely garbage.
+     */
     fun describeSequence(bytes: ByteArray): String {
         if (bytes.isEmpty()) return "(empty)"
-        val stream = ByteArrayInputStream(bytes)
-        val items = mutableListOf<Any>()
-        var failure: Pair<Int, String>? = null
-        while (stream.available() > 0) {
-            val offset = bytes.size - stream.available()
-            val item = runCatching { readValue(stream) }
-                .getOrElse { failure = offset to (it.message ?: it.toString()); null }
-                ?: break
-            items.add(item)
-        }
         return buildString {
-            items.forEachIndexed { i, item ->
-                if (items.size > 1 || failure != null) appendLine("— item $i —")
-                describeValue(null, item, 0, this)
-            }
-            failure?.let { (offset, message) ->
-                if (items.isNotEmpty()) appendLine()
-                appendLine("⚠ could not parse byte $offset onward: $message")
+            // Full hex dump first — always immediately visible.
+            appendLine("── hex ────────────────────────────────────────────────")
+            append(hexDump(bytes))
+            appendLine()
+            appendLine("── CBOR scan ──────────────────────────────────────────")
+
+            var offset = 0
+            var itemIndex = 0
+            val skipped = mutableListOf<Byte>() // consecutive bytes that couldn't be decoded
+
+            fun flushSkipped() {
+                if (skipped.isEmpty()) return
+                val start = offset - skipped.size
                 appendLine()
-                // Use a formatted hex dump for readability (especially when nothing decoded at all).
-                appendLine("hex dump:")
-                append(hexDump(bytes.copyOfRange(offset, bytes.size), offset))
+                appendLine("  ⚠ ${skipped.size} unrecognised byte(s) at 0x${"%x".format(start)}:")
+                append("  ")
+                append(hexDump(skipped.toByteArray(), start).trimEnd().replace("\n", "\n  "))
+                appendLine()
+                skipped.clear()
             }
+
+            while (offset < bytes.size) {
+                val slice = ByteArrayInputStream(bytes, offset, bytes.size - offset)
+                val before = slice.available()
+                val item = runCatching { readValue(slice) }.getOrNull()
+                val consumed = before - slice.available()
+
+                if (item != null && consumed > 0) {
+                    flushSkipped()
+                    appendLine()
+                    appendLine("  ── item $itemIndex  offset 0x${"%x".format(offset)}  ($consumed byte(s)) ──")
+                    describeValue(null, item, 1, this)
+                    offset += consumed
+                    itemIndex++
+                } else {
+                    skipped.add(bytes[offset])
+                    offset++
+                }
+            }
+            flushSkipped()
+            if (itemIndex == 0) appendLine("  (no CBOR items found in ${bytes.size} bytes)")
         }
     }
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/MiniCbor.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/MiniCbor.kt
@@ -207,6 +207,28 @@ object MiniCbor {
     // ── Debug ─────────────────────────────────────────────────────────────────
 
     /**
+     * Classic 16-bytes-per-line hex dump. [startOffset] is added to the printed address so a
+     * partial dump (the unparsed tail) still shows accurate file offsets.
+     */
+    private fun hexDump(bytes: ByteArray, startOffset: Int = 0): String = buildString {
+        val w = 16
+        for (base in bytes.indices step w) {
+            val end = minOf(base + w, bytes.size)
+            append("%08x  ".format(startOffset + base))
+            for (i in base until base + w) {
+                append(if (i < end) "%02x ".format(bytes[i]) else "   ")
+                if (i - base == 7) append(' ')
+            }
+            append(' ')
+            for (i in base until end) {
+                val c = bytes[i].toInt() and 0xFF
+                append(if (c in 0x20..0x7e) c.toChar() else '.')
+            }
+            appendLine()
+        }
+    }
+
+    /**
      * Pretty-prints arbitrary bytes as a generic CBOR Sequence, for inspecting content whose
      * structure isn't known ahead of time -- e.g. a found tag/QR of uncertain origin, possibly
      * truncated or damaged. Unlike [TagDropCodec.describeCbor] (which expects TagDrop's own fixed
@@ -238,7 +260,10 @@ object MiniCbor {
             failure?.let { (offset, message) ->
                 if (items.isNotEmpty()) appendLine()
                 appendLine("⚠ could not parse byte $offset onward: $message")
-                describeValue("remaining bytes", bytes.copyOfRange(offset, bytes.size), 0, this)
+                appendLine()
+                // Use a formatted hex dump for readability (especially when nothing decoded at all).
+                appendLine("hex dump:")
+                append(hexDump(bytes.copyOfRange(offset, bytes.size), offset))
             }
         }
     }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
@@ -132,10 +132,6 @@ object TagDropCodec {
     private const val K_COLLECTION_ID    = 17
     private const val K_COLLECTION_LABEL = 18
     private const val K_COLLECTION_TAG   = 19
-    private const val K_FILE_SLUG   = 20
-    private const val K_FILE_MIME   = 21
-    private const val K_FILE_ID     = 22
-    private const val K_PAPER_ID    = 23
     private const val K_ICON        = 24
     // K_ICON_IMAGE = 25 — reserved for a future small embedded image icon (bytes)
     private const val K_LAT         = 26
@@ -148,8 +144,25 @@ object TagDropCodec {
     private const val K_KDF_SALT     = 38
     private const val K_KDF_ITERS    = 39
     private const val K_DESCRIPTION       = 40  // content teaser / message body — valid for both Content and Paper
-    private const val K_FILE_DESCRIPTION  = 41
     private const val K_BULKY_COMPRESSION      = 45
+
+    // files[] entry local keys (SPEC §3 — independent namespace, not part of the global key table)
+    private const val KF_SLUG        = 1
+    private const val KF_MIME        = 2
+    private const val KF_FILE_ID     = 3
+    private const val KF_DESCRIPTION = 4
+    private const val KF_PIXEL_ART   = 5
+
+    // related[] entry local keys (SPEC §3 — independent namespace)
+    private const val KR_HINT        = 1
+    private const val KR_SET         = 2
+    private const val KR_SLUG        = 3
+    private const val KR_PAPER_ID    = 4
+    private const val KR_LAT         = 5
+    private const val KR_LNG         = 6
+    private const val KR_RADIUS_M    = 7
+    private const val KR_KEY_MATERIAL = 8
+    private const val KR_RETAIN_KEY   = 9
     private const val K_BULKY_COMPRESSED_BYTES = 46
     private const val K_BULKY_SHA              = 47
     private const val K_RADIUS_M               = 48  // circle-of-uncertainty radius in meters, wherever lat/lng appears
@@ -521,23 +534,24 @@ object TagDropCodec {
         val bulky = listOf<Pair<Int, Any?>>(
             K_FILES   to paper.files.map { f ->
                 MiniCbor.CborMap(listOf(
-                    K_FILE_SLUG to f.slug,
-                    K_FILE_MIME to f.mimeType,
-                    K_FILE_ID   to f.fileId,
-                    K_FILE_DESCRIPTION to f.description
+                    KF_SLUG        to f.slug,
+                    KF_MIME        to f.mimeType,
+                    KF_FILE_ID     to f.fileId,
+                    KF_DESCRIPTION to f.description,
+                    KF_PIXEL_ART   to true.takeIf { f.pixelArt }
                 ))
             },
             K_RELATED to paper.related.map { r ->
                 MiniCbor.CborMap(listOf(
-                    K_HINT     to r.hint,
-                    K_SET      to r.set,
-                    K_SLUG     to r.slug,
-                    K_PAPER_ID to r.paperId,
-                    K_LAT      to r.lat,
-                    K_LNG      to r.lng,
-                    K_RADIUS_M to r.radiusM,
-                    K_KEY_MATERIAL to r.keyMaterial,
-                    K_RETAIN_KEY   to false.takeIf { r.keyMaterial != null && !r.retainKey }
+                    KR_HINT        to r.hint,
+                    KR_SET         to r.set,
+                    KR_SLUG        to r.slug,
+                    KR_PAPER_ID    to r.paperId,
+                    KR_LAT         to r.lat,
+                    KR_LNG         to r.lng,
+                    KR_RADIUS_M    to r.radiusM,
+                    KR_KEY_MATERIAL to r.keyMaterial,
+                    KR_RETAIN_KEY  to false.takeIf { r.keyMaterial != null && !r.retainKey }
                 ))
             }
         )
@@ -857,25 +871,26 @@ object TagDropCodec {
         val files = (parts.bulky[K_FILES] as? List<*>)?.mapNotNull { entry ->
             val em = entry as? Map<Int, Any> ?: return@mapNotNull null
             TagDropPayload.FileEntry(
-                slug        = em.text(K_FILE_SLUG) ?: return@mapNotNull null,
-                mimeType    = em.text(K_FILE_MIME) ?: return@mapNotNull null,
-                fileId      = em.bytesOrNull(K_FILE_ID) ?: return@mapNotNull null,
-                description = em.text(K_FILE_DESCRIPTION)
+                slug        = em.text(KF_SLUG) ?: return@mapNotNull null,
+                mimeType    = em.text(KF_MIME) ?: return@mapNotNull null,
+                fileId      = em.bytesOrNull(KF_FILE_ID) ?: return@mapNotNull null,
+                description = em.text(KF_DESCRIPTION),
+                pixelArt    = em.boolOrNull(KF_PIXEL_ART) ?: false
             )
         } ?: emptyList()
 
         val related = (parts.bulky[K_RELATED] as? List<*>)?.mapNotNull { entry ->
             val em = entry as? Map<Int, Any> ?: return@mapNotNull null
             TagDropPayload.RelatedPaper(
-                hint        = em.text(K_HINT) ?: return@mapNotNull null,
-                set         = em.text(K_SET),
-                slug        = em.text(K_SLUG),
-                paperId     = em.bytesOrNull(K_PAPER_ID),
-                lat         = em.doubleOrNull(K_LAT),
-                lng         = em.doubleOrNull(K_LNG),
-                radiusM     = em.doubleOrNull(K_RADIUS_M),
-                keyMaterial = em.bytesOrNull(K_KEY_MATERIAL),
-                retainKey   = em.boolOrNull(K_RETAIN_KEY) ?: true
+                hint        = em.text(KR_HINT) ?: return@mapNotNull null,
+                set         = em.text(KR_SET),
+                slug        = em.text(KR_SLUG),
+                paperId     = em.bytesOrNull(KR_PAPER_ID),
+                lat         = em.doubleOrNull(KR_LAT),
+                lng         = em.doubleOrNull(KR_LNG),
+                radiusM     = em.doubleOrNull(KR_RADIUS_M),
+                keyMaterial = em.bytesOrNull(KR_KEY_MATERIAL),
+                retainKey   = em.boolOrNull(KR_RETAIN_KEY) ?: true
             )
         } ?: emptyList()
 
@@ -932,25 +947,36 @@ object TagDropCodec {
 
     // ── Debug ─────────────────────────────────────────────────────────────────
 
-    /** Human-readable names for TagDrop's CBOR integer keys, used by [describeCbor]. */
+    /** Human-readable names for TagDrop's top-level CBOR integer keys, used by [describeCbor]. */
     private val KEY_NAMES = mapOf(
         K_CACHE_ID to "cache_id/root_hash", K_HINT to "hint/label", K_MIME to "mime_type",
         K_CONTENT to "content", K_TOTAL_BYTES to "total_bytes", K_CONTENT_SHA to "content_sha256",
         K_FILENAME to "filename", K_COMPRESSION to "content_compression", K_SET to "set",
         K_SLUG to "slug", K_FILES to "files", K_RELATED to "related",
         K_COLLECTION_ID to "collection_id", K_COLLECTION_LABEL to "collection_label",
-        K_COLLECTION_TAG to "collection_tag", K_FILE_SLUG to "slug", K_FILE_MIME to "mime_type",
-        K_FILE_ID to "file_id", K_PAPER_ID to "paper_id", K_ICON to "icon",
+        K_COLLECTION_TAG to "collection_tag", K_ICON to "icon",
         K_LAT to "lat", K_LNG to "lng", K_ENCRYPTION to "encryption",
         K_KEY_MATERIAL to "key_material", K_RETAIN_KEY to "retain_key",
         K_KDF_ALG to "kdf_alg", K_KDF_SALT to "kdf_salt", K_KDF_ITERS to "kdf_iters",
-        K_DESCRIPTION to "description", K_FILE_DESCRIPTION to "description",
+        K_DESCRIPTION to "description",
         K_SECTOR_INDEX to "sector_index", K_SECTOR_COUNT to "sector_count", K_PARITY to "parity_scheme",
         K_BULKY_COMPRESSION to "bulky_meta_compression",
         K_BULKY_COMPRESSED_BYTES to "bulky_meta_compressed_bytes", K_BULKY_SHA to "bulky_meta_sha256",
         K_RADIUS_M to "radius_m", K_PREFER_DECLARED_LOCATION to "prefer_declared_location",
         K_IN_REPLY_TO to "in_reply_to", K_TITLE to "title", K_CREATED_AT to "created_at",
         K_DOMAIN to "domain", K_LOCATION_LABEL to "location_label", K_PIXEL_ART to "pixel_art"
+    )
+    private val FILE_ENTRY_KEY_NAMES = mapOf(
+        KF_SLUG to "slug", KF_MIME to "mime_type", KF_FILE_ID to "file_id",
+        KF_DESCRIPTION to "description", KF_PIXEL_ART to "pixel_art"
+    )
+    private val RELATED_ENTRY_KEY_NAMES = mapOf(
+        KR_HINT to "hint", KR_SET to "set", KR_SLUG to "slug", KR_PAPER_ID to "paper_id",
+        KR_LAT to "lat", KR_LNG to "lng", KR_RADIUS_M to "radius_m",
+        KR_KEY_MATERIAL to "key_material", KR_RETAIN_KEY to "retain_key"
+    )
+    private val SUB_MAP_KEY_NAMES = mapOf(
+        K_FILES to FILE_ENTRY_KEY_NAMES, K_RELATED to RELATED_ENTRY_KEY_NAMES
     )
 
     private val TYPE_NAMES = mapOf(TYPE_CONTENT to "Content", TYPE_PAPER to "Paper")
@@ -1002,19 +1028,20 @@ object TagDropCodec {
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun describeMap(map: Map<Int, Any>, indent: Int, out: StringBuilder) {
+    private fun describeMap(map: Map<Int, Any>, indent: Int, out: StringBuilder, keyNames: Map<Int, String> = KEY_NAMES) {
         val pad = "  ".repeat(indent)
         for ((key, value) in map.toSortedMap()) {
-            val label = KEY_NAMES[key]?.let { "$key ($it)" } ?: "$key"
+            val label = keyNames[key]?.let { "$key ($it)" } ?: "$key"
             when (value) {
                 is ByteArray -> out.appendLine("$pad$label: ${value.toHexDump()} (${value.size} bytes)")
                 is String    -> out.appendLine("$pad$label: \"$value\"")
                 is List<*>   -> {
                     out.appendLine("$pad$label: [")
+                    val itemKeyNames = SUB_MAP_KEY_NAMES[key] ?: keyNames
                     for (item in value) {
                         if (item is Map<*, *>) {
                             out.appendLine("$pad  {")
-                            describeMap(item as Map<Int, Any>, indent + 2, out)
+                            describeMap(item as Map<Int, Any>, indent + 2, out, itemKeyNames)
                             out.appendLine("$pad  }")
                         } else {
                             out.appendLine("$pad  $item")

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
@@ -69,7 +69,8 @@ sealed class TagDropPayload {
         val slug: String,        // URL-safe name for this file within the paper
         val mimeType: String,
         val fileId: ByteArray,   // cache_id of the file's root QR (a Content payload)
-        val description: String? = null  // optional content teaser, e.g. "A poem to read" (SPEC §4.3, issue #35)
+        val description: String? = null,  // optional content teaser, e.g. "A poem to read" (SPEC §4.3, issue #35)
+        val pixelArt: Boolean = false     // render with nearest-neighbour scaling (no smoothing) — raw QR files only
     ) {
         override fun equals(other: Any?) = other is FileEntry && slug == other.slug && fileId.contentEquals(other.fileId)
         override fun hashCode() = 31 * slug.hashCode() + fileId.contentHashCode()

--- a/app/src/main/java/com/github/mofosyne/tagdrop/util/ContentExporter.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/util/ContentExporter.kt
@@ -34,6 +34,8 @@ object ContentExporter {
     )
 
     /** Writes [cache]'s content into the app's cache dir and returns a shareable content:// URI. */
+    fun writeTempFile(context: Context, cache: FoundCache): Uri? = exportToCacheFile(context, cache)
+
     private fun exportToCacheFile(context: Context, cache: FoundCache): Uri? {
         if (!cache.isOpenable) return null
         val bytes = cache.contentBytes ?: return null

--- a/app/src/main/java/com/github/mofosyne/tagdrop/util/MimeTypeGuesser.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/util/MimeTypeGuesser.kt
@@ -1,0 +1,63 @@
+package com.github.mofosyne.tagdrop.util
+
+/**
+ * Detects a MIME type from raw bytes using magic-byte signatures and lightweight text heuristics.
+ * Used for raw QR content where no MIME type was declared by the author or by ZXing's classifier.
+ *
+ * Returns null when the bytes don't match any recognised signature — caller should fall back to
+ * text/plain (if the bytes are valid UTF-8 text) or application/octet-stream (for binary).
+ */
+object MimeTypeGuesser {
+
+    fun guess(bytes: ByteArray): String? {
+        if (bytes.isEmpty()) return null
+        // Binary magic signatures (checked first — fast, unambiguous)
+        if (bytes.startsWith(0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)) return "image/png"
+        if (bytes.startsWith(0xFF, 0xD8, 0xFF)) return "image/jpeg"
+        if (bytes.startsWith(0x47, 0x49, 0x46, 0x38)) return "image/gif"
+        if (bytes.startsWith(0x42, 0x4D)) return "image/bmp"
+        if (bytes.size >= 12 && bytes.startsWith(0x52, 0x49, 0x46, 0x46) &&
+            bytes[8] == 0x57.toByte() && bytes[9] == 0x45.toByte() &&
+            bytes[10] == 0x42.toByte() && bytes[11] == 0x50.toByte()) return "image/webp"
+        if (bytes.startsWith(0x25, 0x50, 0x44, 0x46)) return "application/pdf"
+        if (bytes.startsWith(0x50, 0x4B, 0x03, 0x04)) return "application/zip"
+        if (bytes.startsWith(0x1F, 0x8B)) return "application/gzip"
+        if (bytes.startsWith(0x4F, 0x67, 0x67, 0x53)) return "audio/ogg"
+        if (bytes.startsWith(0x49, 0x44, 0x33) || bytes.startsWith(0xFF, 0xFB) ||
+            bytes.startsWith(0xFF, 0xF3) || bytes.startsWith(0xFF, 0xF2)) return "audio/mpeg"
+        if (bytes.size >= 12 && bytes.startsWith(0x52, 0x49, 0x46, 0x46) &&
+            bytes[8] == 0x57.toByte() && bytes[9] == 0x41.toByte() &&
+            bytes[10] == 0x56.toByte() && bytes[11] == 0x45.toByte()) return "audio/wav"
+
+        // Text heuristics — only meaningful if the bytes are valid UTF-8
+        val text = bytes.toUtf8OrNull() ?: return "application/octet-stream"
+        val trimmed = text.trimStart()
+        if (trimmed.startsWith("<?xml", ignoreCase = true)) {
+            if (trimmed.contains("<svg", ignoreCase = true)) return "image/svg+xml"
+            return "application/xml"
+        }
+        if (trimmed.startsWith("<!DOCTYPE html", ignoreCase = true) ||
+            trimmed.startsWith("<html", ignoreCase = true)) return "text/html"
+        if (trimmed.startsWith("<svg", ignoreCase = true)) return "image/svg+xml"
+        if (looksLikeJson(trimmed)) return "application/json"
+        return null
+    }
+
+    private fun ByteArray.startsWith(vararg prefix: Int): Boolean {
+        if (size < prefix.size) return false
+        return prefix.indices.all { this[it] == prefix[it].toByte() }
+    }
+
+    private fun ByteArray.toUtf8OrNull(): String? = try {
+        val s = toString(Charsets.UTF_8)
+        // Reject if re-encoding doesn't round-trip (indicates non-UTF-8 binary data)
+        if (s.toByteArray(Charsets.UTF_8).contentEquals(this)) s else null
+    } catch (_: Exception) { null }
+
+    private fun looksLikeJson(text: String): Boolean {
+        if (text.isEmpty()) return false
+        val first = text[0]
+        val last = text.trimEnd().lastOrNull()
+        return (first == '{' && last == '}') || (first == '[' && last == ']')
+    }
+}

--- a/app/src/main/res/layout/activity_viewdatauri.xml
+++ b/app/src/main/res/layout/activity_viewdatauri.xml
@@ -15,6 +15,20 @@
             android:layout_height="?attr/actionBarSize" />
     </com.google.android.material.appbar.AppBarLayout>
 
+    <!-- Contextual action chip: "Add to Calendar", "Add Contact", "Connect to WiFi", etc.
+         Shown below the toolbar when a recognised content type has a direct system action.
+         Gone when not applicable. -->
+    <Button
+        android:id="@+id/actionChip"
+        style="@style/Widget.MaterialComponents.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
+        android:textAllCaps="false"
+        android:visibility="gone" />
+
     <!-- Reply links (SPEC §7): shown when this item replies to a parent, and/or other
          cached items reply to it. Each row hides itself via visibility="gone" when not applicable. -->
     <TextView

--- a/app/src/main/res/layout/activity_viewdatauri.xml
+++ b/app/src/main/res/layout/activity_viewdatauri.xml
@@ -29,6 +29,23 @@
         android:textAllCaps="false"
         android:visibility="gone" />
 
+    <!-- Shown when the MIME type was inferred from magic bytes rather than declared by the author.
+         Tapping it opens the "Set type…" dialog so the user can correct the guess. -->
+    <TextView
+        android:id="@+id/guessedTypeBanner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"
+        android:paddingTop="6dp"
+        android:paddingBottom="6dp"
+        android:background="?attr/colorSurfaceVariant"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:textSize="12sp"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="gone" />
+
     <!-- Reply links (SPEC §7): shown when this item replies to a parent, and/or other
          cached items reply to it. Each row hides itself via visibility="gone" when not applicable. -->
     <TextView

--- a/app/src/main/res/menu/menu_html_view.xml
+++ b/app/src/main/res/menu/menu_html_view.xml
@@ -19,6 +19,12 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/action_set_type"
+        android:title="@string/action_set_type"
+        android:visible="false"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_view_as"
         android:title="@string/action_view_as"
         app:showAsAction="never">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,6 +143,7 @@
     <!-- Paper manifest -->
     <string name="paper_manifest_label">Paper Manifest</string>
     <string name="paper_scanned">Paper scanned: %1$d file(s) in directory.</string>
+    <string name="paper_scanned_with_found">Paper scanned: %1$d file(s) in directory, %2$d already in your collection.</string>
     <string name="paper_set">Set: %1$s</string>
     <string name="paper_related_header">Related papers:</string>
     <string name="paper_scan_hint">Keep scanning to find files from this paper. Tap a filled block below to open it.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,7 +168,12 @@
     <string name="action_open_external">Open with…</string>
     <string name="action_share">Share</string>
     <string name="action_save">Save to device</string>
+    <string name="action_set_type">Set type…</string>
     <string name="action_view_as">View as</string>
+    <string name="guessed_type_banner">⚠️ Type guessed: %s — tap to change</string>
+    <string name="set_type_dialog_title">Set content type</string>
+    <string name="set_type_hint">MIME type (e.g. image/png)</string>
+    <string name="set_type_apply">Apply</string>
     <string name="view_mode_rendered">Rendered</string>
     <string name="view_mode_text">Text</string>
     <string name="view_mode_hex">Hex</string>

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/MiniCborTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/MiniCborTest.kt
@@ -275,7 +275,7 @@ class MiniCborTest {
         val garbage = byteArrayOf(0xFF.toByte(), 0x01, 0x02)
         val description = MiniCbor.describeSequence(cbor + garbage)
         assertTrue(description.contains("3: \"hint\""))
-        assertTrue(description.contains("remaining bytes"))
+        assertTrue(description.contains("hex dump"))
         assertTrue(description.contains("ff 01 02"))
     }
 

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/MiniCborTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/MiniCborTest.kt
@@ -248,26 +248,27 @@ class MiniCborTest {
     }
 
     @Test fun describeSequenceInvalidCbor() {
-        // Best-effort: nothing decodes, but the failure is reported rather than thrown.
+        // Single byte 0xFF is unsupported (simple value 31 = break code) — shows as unrecognised hex.
         val description = MiniCbor.describeSequence(byteArrayOf(0xFF.toByte()))
-        assertTrue(description.contains("⚠ could not parse byte 0 onward"))
+        assertTrue(description.contains("unrecognised"))
+        assertTrue(description.contains("ff"))
     }
 
     @Test fun describeSequencePlainText() {
-        // Plain text misparses as CBOR by chance (an 8-byte "byte string" happens to decode),
-        // exercising the best-effort path: what did decode is shown, followed by an error
-        // marker and a hex dump of whatever bytes remain once decoding breaks down.
+        // Plain text: some bytes may decode as CBOR items, others won't — scanner keeps going.
+        // Always shows a hex dump at the top regardless of how much decoded.
         val description = MiniCbor.describeSequence("Hello from TagDrop!".toByteArray(Charsets.UTF_8))
-        assertTrue(description.contains("⚠ could not parse byte"))
+        assertTrue(description.contains("── hex"))
+        assertTrue(description.contains("── CBOR scan"))
     }
 
     @Test fun describeSequenceShowsItemsDecodedBeforeTruncation() {
         // Two valid uint items, then a byte-string head claiming 4 bytes that never arrive.
         val truncated = MiniCbor.encodeUInt(1) + MiniCbor.encodeUInt(2) + byteArrayOf((2 shl 5 or 4).toByte())
         val description = MiniCbor.describeSequence(truncated)
-        assertTrue(description.contains("— item 0 —"))
-        assertTrue(description.contains("— item 1 —"))
-        assertTrue(description.contains("⚠ could not parse byte"))
+        assertTrue(description.contains("item 0"))
+        assertTrue(description.contains("item 1"))
+        assertTrue(description.contains("unrecognised"))
     }
 
     @Test fun describeSequenceGarbageAfterValidMapShowsMapAndRemainingHex() {
@@ -275,8 +276,8 @@ class MiniCborTest {
         val garbage = byteArrayOf(0xFF.toByte(), 0x01, 0x02)
         val description = MiniCbor.describeSequence(cbor + garbage)
         assertTrue(description.contains("3: \"hint\""))
-        assertTrue(description.contains("hex dump"))
-        assertTrue(description.contains("ff 01 02"))
+        assertTrue(description.contains("unrecognised"))
+        assertTrue(description.contains("ff"))
     }
 
     @Test fun describeSequenceSingleMap() {
@@ -284,14 +285,13 @@ class MiniCborTest {
         val description = MiniCbor.describeSequence(cbor)
         assertTrue(description.contains("3: \"hint text\""))
         assertTrue(description.contains("4: \"text/html\""))
-        assertFalse(description.contains("— item"))   // single item: no "item N" headers
     }
 
     @Test fun describeSequenceMultipleItemsLabelled() {
         val seq = MiniCbor.encodeUInt(1) + MiniCbor.encodeUInt(0)
         val description = MiniCbor.describeSequence(seq)
-        assertTrue(description.contains("— item 0 —"))
-        assertTrue(description.contains("— item 1 —"))
+        assertTrue(description.contains("item 0"))
+        assertTrue(description.contains("item 1"))
     }
 
     @Test fun describeSequenceByteStringShowsHexAndLength() {

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropCodecTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropCodecTest.kt
@@ -741,7 +741,7 @@ class TagDropCodecTest {
         assertTrue(text.contains("type: 1 (Paper)"))
         assertTrue(text.contains("3 (hint/label): \"Test Paper\""))
         assertTrue(text.contains("15 (files): ["))
-        assertTrue(text.contains("20 (slug): \"readme\""))
+        assertTrue(text.contains("1 (slug): \"readme\""))
         assertTrue(text.contains("16 (related): ["))
         assertTrue(text.contains("24 (icon): \"🌳\""))
     }

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolverTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolverTest.kt
@@ -40,6 +40,9 @@ private class FakeCacheDao : CacheDao {
     override suspend fun getPendingOverrides(): List<FoundCache> = emptyList()
     override suspend fun getRepliesTo(parentId: String): List<FoundCache> =
         caches.values.filter { it.inReplyTo == parentId }
+    override suspend fun updateMimeType(cacheId: String, mimeType: String) {
+        caches[cacheId]?.let { caches[cacheId] = it.copy(mimeType = mimeType, mimeTypeIsGuessed = false) }
+    }
 }
 
 private class FakeKeyDao : KeyDao {

--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -2,4 +2,7 @@
 - Files already cached from a previous scan are now surfaced immediately when you open a Paper manifest, without re-scanning their codes.
 - Wire format: files[] and related[] sub-map keys now use independent local ranges (1–5 and 1–9) instead of the global key space, keeping the master key table clean and giving each sub-structure room to grow.
 - Contextual action button: when viewing a scanned item, a button now appears for recognised content types — Open URL, Add Contact, Add to Calendar, Connect to Wi-Fi, Open in Maps, Dial, Send SMS, Compose Email — matching the quick-action behaviour of typical QR scanner apps.
+- MIME type guessing for raw (non-TagDrop) QR codes: the app now detects common file types from magic bytes (PNG, JPEG, PDF, ZIP, HTML, JSON, SVG, …) instead of always falling back to plain text. When the type is guessed rather than declared, a banner says so and lets you correct it with a "Set type…" action.
+- "View as" (Text / Hex / CBOR / JSON) is now available for any cached content, including binary files that can't be previewed in-app.
+- CBOR view now shows a full hex dump first, then scans the bytes for CBOR structures — continuing past failures so any structures embedded in binary files are still surfaced.
 - Note: wire format v1 is still a draft — no real codes have been deployed yet, so breaking changes can occur without a version bump until the first code is printed and distributed.

--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -1,0 +1,4 @@
+- Paper manifests can now include "Raw QR" files — content placed directly in the QR symbol with no TagDrop encoding, useful for small images or text snippets. Metadata (file name, type, pixel art flag) is declared in the manifest so the app recognises and caches them when you scan each code.
+- Files already cached from a previous scan are now surfaced immediately when you open a Paper manifest, without re-scanning their codes.
+- Wire format: files[] and related[] sub-map keys now use independent local ranges (1–5 and 1–9) instead of the global key space, keeping the master key table clean and giving each sub-structure room to grow.
+- Note: wire format v1 is still a draft — no real codes have been deployed yet, so breaking changes can occur without a version bump until the first code is printed and distributed.

--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -1,4 +1,5 @@
 - Paper manifests can now include "Raw QR" files — content placed directly in the QR symbol with no TagDrop encoding, useful for small images or text snippets. Metadata (file name, type, pixel art flag) is declared in the manifest so the app recognises and caches them when you scan each code.
 - Files already cached from a previous scan are now surfaced immediately when you open a Paper manifest, without re-scanning their codes.
 - Wire format: files[] and related[] sub-map keys now use independent local ranges (1–5 and 1–9) instead of the global key space, keeping the master key table clean and giving each sub-structure room to grow.
+- Contextual action button: when viewing a scanned item, a button now appears for recognised content types — Open URL, Add Contact, Add to Calendar, Connect to Wi-Fi, Open in Maps, Dial, Send SMS, Compose Email — matching the quick-action behaviour of typical QR scanner apps.
 - Note: wire format v1 is still a draft — no real codes have been deployed yet, so breaking changes can occur without a version bump until the first code is printed and distributed.

--- a/readme.md
+++ b/readme.md
@@ -132,8 +132,9 @@ running from source.
 
 ## Status
 
-**TagDrop v2.1** — wire format version 1, still a draft (no real-world
-deployments yet, see [SPEC.md](SPEC.md)). CBOR-sequence envelope encoding
+> ⚠ **Wire format v1 is a draft.** No real-world codes have been printed or distributed yet, so breaking wire-format changes may occur without a version bump. Once the first code is deployed the format freezes.
+
+**TagDrop v2.1** — wire format version 1 (see [SPEC.md](SPEC.md)). CBOR-sequence envelope encoding
 (`tagdrop:<base41>`) with content split into one or more sectors plus
 optional parity recovery, paper manifests with multi-file directories and
 relative-link navigation, geographic trails via `related` hints and located

--- a/tools/examples/index.html
+++ b/tools/examples/index.html
@@ -1353,11 +1353,12 @@ URL:https://example.com/trail
 END:VCARD`,
     },
     {
-      slug:     'wifi',
-      mimeType: 'text/plain',
-      // Wi-Fi credential in the standard WPA-PWD URI format recognised by
-      // Android, iOS, and most QR scanner apps out of the box.
-      content: 'WIFI:T:WPA;S:TrailheadWiFi;P:opentrail2025;;',
+      slug:     'map',
+      mimeType: 'text/uri-list',
+      // A plain URL — the most common raw QR payload. Any scanner opens it
+      // directly; TagDrop caches it under the paper and shows an "Open URL"
+      // contextual action button when you tap the tile.
+      content: 'https://www.openstreetmap.org/?mlat=51.5007&mlon=-0.1246#map=17/51.5007/-0.1246',
     },
   ],
   // files: standard TagDrop Content sectors — mixed in alongside the raw QRs.
@@ -1386,11 +1387,12 @@ code{background:#f0f0f0;padding:2px 5px;border-radius:3px;font-size:0.85em}
 <h2>Standard TagDrop codes (this page)</h2>
 <p>Content is carried inside a <code>tagdrop:</code> URI — compressed, content-addressed,
 and offline-first. Scan with the TagDrop app to cache and browse.</p>
-<h2>Raw QR codes (contact + Wi-Fi)</h2>
-<p>The <strong>contact</strong> and <strong>wifi</strong> codes carry plain content with no
-TagDrop encoding — a vCard and a Wi-Fi credential. Any standard QR scanner can read them;
+<h2>Raw QR codes (contact + map)</h2>
+<p>The <strong>contact</strong> and <strong>map</strong> codes carry plain content with no
+TagDrop encoding — a vCard and an OpenStreetMap URL. Any standard QR scanner can read them;
 the TagDrop app also caches them under this paper when it sees the matching
-<code>file_id</code> in the manifest.</p>
+<code>file_id</code> in the manifest, and shows an <em>Add Contact</em> or
+<em>Open URL</em> action button when you view the cached tile.</p>
 <div class="tip">
   Scan the manifest first, then each file code in any order. Raw-QR files you've scanned
   before are surfaced immediately from the cache — no re-scanning needed.

--- a/tools/examples/index.html
+++ b/tools/examples/index.html
@@ -484,16 +484,18 @@ const KEY_NAMES = {
   2: 'cache_id/root_hash', 3: 'hint/label', 4: 'mime_type', 5: 'content',
   7: 'total_bytes', 8: 'content_sha256',
   11: 'filename', 12: 'content_compression', 13: 'set', 14: 'slug', 15: 'files', 16: 'related',
-  17: 'collection_id', 18: 'collection_label', 19: 'collection_tag',
-  20: 'slug', 21: 'mime_type', 22: 'file_id', 23: 'paper_id', 24: 'icon',
+  17: 'collection_id', 18: 'collection_label', 19: 'collection_tag', 24: 'icon',
   26: 'lat', 27: 'lng',
   28: 'encryption', 30: 'key_material', 31: 'retain_key',
   37: 'kdf_alg', 38: 'kdf_salt', 39: 'kdf_iters',
-  40: 'description', 41: 'description',
+  40: 'description',
   42: 'sector_index', 43: 'sector_count', 44: 'parity_scheme',
   45: 'bulky_meta_compression', 46: 'bulky_meta_compressed_bytes', 47: 'bulky_meta_sha256',
   55: 'pixel_art',
 };
+const FILE_ENTRY_KEY_NAMES = { [KF.SLUG]:'slug', [KF.MIME]:'mime_type', [KF.FILE_ID]:'file_id', [KF.DESCRIPTION]:'description', [KF.PIXEL_ART]:'pixel_art' };
+const RELATED_ENTRY_KEY_NAMES = { [KR.HINT]:'hint', [KR.SET]:'set', [KR.SLUG]:'slug', [KR.PAPER_ID]:'paper_id', [KR.LAT]:'lat', [KR.LNG]:'lng', [KR.RADIUS_M]:'radius_m', [KR.KEY_MATERIAL]:'key_material', [KR.RETAIN_KEY]:'retain_key' };
+const SUB_KEY_NAMES = { 15: FILE_ENTRY_KEY_NAMES, 16: RELATED_ENTRY_KEY_NAMES };
 
 function toHexDump(bytes) {
   return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join(' ');
@@ -577,21 +579,22 @@ async function describeCbor(bytes) {
   return out;
 }
 
-function describeMap(map, indent) {
+function describeMap(map, indent, keyNames = KEY_NAMES) {
   const pad = '  '.repeat(indent);
   let out = '';
   for (const key of Object.keys(map).map(Number).sort((a, b) => a - b)) {
     const value = map[key];
-    const label = KEY_NAMES[key] ? key + ' (' + KEY_NAMES[key] + ')' : String(key);
+    const label = keyNames[key] ? key + ' (' + keyNames[key] + ')' : String(key);
     if (value instanceof Uint8Array) {
       out += pad + label + ': ' + toHexDump(value) + ' (' + value.length + ' bytes)\n';
     } else if (typeof value === 'string') {
       out += pad + label + ': "' + value + '"\n';
     } else if (Array.isArray(value)) {
       out += pad + label + ': [\n';
+      const itemKeyNames = SUB_KEY_NAMES[key] ?? keyNames;
       for (const item of value) {
         if (item !== null && typeof item === 'object' && !(item instanceof Uint8Array) && !Array.isArray(item)) {
-          out += pad + '  {\n' + describeMap(item, indent + 2) + pad + '  }\n';
+          out += pad + '  {\n' + describeMap(item, indent + 2, itemKeyNames) + pad + '  }\n';
         } else {
           out += pad + '  ' + item + '\n';
         }
@@ -672,13 +675,17 @@ const K = { CACHE_ID:2, HINT:3, MIME:4, CONTENT:5,
             TOTAL_BYTES:7, CONTENT_SHA:8,
             FILENAME:11, COMPRESSION:12, SET:13, SLUG:14, FILES:15, RELATED:16,
             COLLECTION_ID:17, COLLECTION_LABEL:18, COLLECTION_TAG:19,
-            FILE_SLUG:20, FILE_MIME:21, FILE_ID:22, PAPER_ID:23, ICON:24, LAT:26, LNG:27,
+            ICON:24, LAT:26, LNG:27,
             ENCRYPTION:28, KEY_MATERIAL:30, RETAIN_KEY:31,
             KDF_ALG:37, KDF_SALT:38, KDF_ITERS:39,
-            PAPER_DESCRIPTION:40, FILE_DESCRIPTION:41,
+            PAPER_DESCRIPTION:40,
             SECTOR_INDEX:42, SECTOR_COUNT:43, PARITY:44,
             BULKY_COMPRESSION:45, BULKY_COMPRESSED_BYTES:46, BULKY_SHA:47,
             PIXEL_ART:55 };
+// Local keys for files[] sub-map entries (independent namespace, SPEC §3)
+const KF = { SLUG:1, MIME:2, FILE_ID:3, DESCRIPTION:4, PIXEL_ART:5 };
+// Local keys for related[] sub-map entries (independent namespace, SPEC §3)
+const KR = { HINT:1, SET:2, SLUG:3, PAPER_ID:4, LAT:5, LNG:6, RADIUS_M:7, KEY_MATERIAL:8, RETAIN_KEY:9 };
 
 // Sector sizing (mirrors Kotlin TagDropCodec.MAX_URI_LENGTH / MAX_SECTOR_DATA_BYTES,
 // ../generator/index.html): MAX_URI_LENGTH/MAX_SECTOR_DATA_BYTES are the hard ceiling;
@@ -858,11 +865,11 @@ function createKeyCodeSector({ keyMaterial, retainKey = true, hint }) {
 async function buildPaperStream({ label, set, slug, files, related, collectionId, collectionLabel, collectionTag, icon }) {
   const bulky = [
     [K.FILES, files.map(f => subMap([
-      [K.FILE_SLUG, f.slug], [K.FILE_MIME, f.mimeType], [K.FILE_ID, f.fileId],
+      [KF.SLUG, f.slug], [KF.MIME, f.mimeType], [KF.FILE_ID, f.fileId],
     ]))],
     [K.RELATED, related.map(r => subMap([
-      [K.HINT, r.hint], [K.SET, r.set || null], [K.SLUG, r.slug || null], [K.PAPER_ID, r.paperId || null],
-      [K.LAT, r.lat != null ? cfloat(r.lat) : null], [K.LNG, r.lng != null ? cfloat(r.lng) : null],
+      [KR.HINT, r.hint], [KR.SET, r.set || null], [KR.SLUG, r.slug || null], [KR.PAPER_ID, r.paperId || null],
+      [KR.LAT, r.lat != null ? cfloat(r.lat) : null], [KR.LNG, r.lng != null ? cfloat(r.lng) : null],
     ]))],
   ];
   const bulkyBytes = cborMap(bulky);

--- a/tools/examples/index.html
+++ b/tools/examples/index.html
@@ -493,9 +493,6 @@ const KEY_NAMES = {
   45: 'bulky_meta_compression', 46: 'bulky_meta_compressed_bytes', 47: 'bulky_meta_sha256',
   55: 'pixel_art',
 };
-const FILE_ENTRY_KEY_NAMES = { [KF.SLUG]:'slug', [KF.MIME]:'mime_type', [KF.FILE_ID]:'file_id', [KF.DESCRIPTION]:'description', [KF.PIXEL_ART]:'pixel_art' };
-const RELATED_ENTRY_KEY_NAMES = { [KR.HINT]:'hint', [KR.SET]:'set', [KR.SLUG]:'slug', [KR.PAPER_ID]:'paper_id', [KR.LAT]:'lat', [KR.LNG]:'lng', [KR.RADIUS_M]:'radius_m', [KR.KEY_MATERIAL]:'key_material', [KR.RETAIN_KEY]:'retain_key' };
-const SUB_KEY_NAMES = { 15: FILE_ENTRY_KEY_NAMES, 16: RELATED_ENTRY_KEY_NAMES };
 
 function toHexDump(bytes) {
   return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join(' ');
@@ -686,6 +683,9 @@ const K = { CACHE_ID:2, HINT:3, MIME:4, CONTENT:5,
 const KF = { SLUG:1, MIME:2, FILE_ID:3, DESCRIPTION:4, PIXEL_ART:5 };
 // Local keys for related[] sub-map entries (independent namespace, SPEC §3)
 const KR = { HINT:1, SET:2, SLUG:3, PAPER_ID:4, LAT:5, LNG:6, RADIUS_M:7, KEY_MATERIAL:8, RETAIN_KEY:9 };
+const FILE_ENTRY_KEY_NAMES = { [KF.SLUG]:'slug', [KF.MIME]:'mime_type', [KF.FILE_ID]:'file_id', [KF.DESCRIPTION]:'description', [KF.PIXEL_ART]:'pixel_art' };
+const RELATED_ENTRY_KEY_NAMES = { [KR.HINT]:'hint', [KR.SET]:'set', [KR.SLUG]:'slug', [KR.PAPER_ID]:'paper_id', [KR.LAT]:'lat', [KR.LNG]:'lng', [KR.RADIUS_M]:'radius_m', [KR.KEY_MATERIAL]:'key_material', [KR.RETAIN_KEY]:'retain_key' };
+const SUB_KEY_NAMES = { 15: FILE_ENTRY_KEY_NAMES, 16: RELATED_ENTRY_KEY_NAMES };
 
 // Sector sizing (mirrors Kotlin TagDropCodec.MAX_URI_LENGTH / MAX_SECTOR_DATA_BYTES,
 // ../generator/index.html): MAX_URI_LENGTH/MAX_SECTOR_DATA_BYTES are the hard ceiling;

--- a/tools/examples/index.html
+++ b/tools/examples/index.html
@@ -204,6 +204,20 @@
     <div class="qr-grid" id="paper-grid"></div>
   </section>
 
+  <section id="sec-raw-qr-paper">
+    <h2>Paper with Raw QR Files</h2>
+    <p class="section-desc">
+      A paper manifest can reference <strong>raw QR files</strong> — codes whose content sits
+      directly in the QR symbol with no TagDrop encoding (a plain URL, vCard, Wi-Fi credential,
+      etc.). The manifest declares each raw file's <code>slug</code>, <code>mime_type</code>, and
+      the SHA-256 <code>file_id</code> of its raw bytes; the app recognises and caches these when
+      you scan each code. Files already cached from a previous scan are surfaced immediately when
+      you open the manifest, without re-scanning.
+    </p>
+    <div class="paper-info" id="raw-qr-paper-info"></div>
+    <div class="qr-grid" id="raw-qr-paper-grid"></div>
+  </section>
+
   <section id="sec-book">
     <h2>Mini E-Book (Markdown Pages)</h2>
     <p class="section-desc">
@@ -1312,6 +1326,81 @@ Slug:  note
   ],
 };
 
+// Raw QR + paper manifest: demonstrates files[] entries whose content lives
+// directly in a plain (non-TagDrop) QR symbol. The manifest declares each raw
+// file's slug, mime_type, and file_id (SHA-256 of the raw bytes) so the app
+// recognises and caches the file when that code is scanned. Raw QRs can be
+// mixed freely with standard TagDrop Content codes in the same paper.
+const RAW_QR_PAPER_EXAMPLE = {
+  label: 'Trailhead Info Board',
+  set:   'tagdrop-tests',
+  slug:  'trailhead-info',
+  // rawFiles: encoded directly in a plain QR (no tagdrop: envelope).
+  rawFiles: [
+    {
+      slug:     'contact',
+      mimeType: 'text/vcard',
+      // A vCard is the classic "raw QR" use-case — every standard scanner
+      // recognises it, so it works even without the TagDrop app installed.
+      content:
+`BEGIN:VCARD
+VERSION:3.0
+FN:Trailhead Visitor Centre
+ORG:TagDrop Example Trail
+TEL:+1-800-555-0191
+EMAIL:trail@example.com
+URL:https://example.com/trail
+END:VCARD`,
+    },
+    {
+      slug:     'wifi',
+      mimeType: 'text/plain',
+      // Wi-Fi credential in the standard WPA-PWD URI format recognised by
+      // Android, iOS, and most QR scanner apps out of the box.
+      content: 'WIFI:T:WPA;S:TrailheadWiFi;P:opentrail2025;;',
+    },
+  ],
+  // files: standard TagDrop Content sectors — mixed in alongside the raw QRs.
+  files: [
+    {
+      slug:     'index',
+      mimeType: 'text/html',
+      compress: true,
+      content:
+`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Trailhead Info Board</title>
+<style>
+body{font-family:system-ui,sans-serif;max-width:540px;margin:30px auto;padding:0 20px;color:#222;line-height:1.5}
+h1{color:#1a1a2e}h2{color:#2e7d32;font-size:1rem;margin-top:24px}
+code{background:#f0f0f0;padding:2px 5px;border-radius:3px;font-size:0.85em}
+.tip{background:#e8f5e9;border-left:4px solid #2e7d32;padding:10px 14px;border-radius:4px;margin:16px 0;font-size:0.9em}
+</style>
+</head>
+<body>
+<h1>🌿 Trailhead Info Board</h1>
+<p>Welcome to the TagDrop Example Trail. This paper mixes two kinds of QR codes:</p>
+<h2>Standard TagDrop codes (this page)</h2>
+<p>Content is carried inside a <code>tagdrop:</code> URI — compressed, content-addressed,
+and offline-first. Scan with the TagDrop app to cache and browse.</p>
+<h2>Raw QR codes (contact + Wi-Fi)</h2>
+<p>The <strong>contact</strong> and <strong>wifi</strong> codes carry plain content with no
+TagDrop encoding — a vCard and a Wi-Fi credential. Any standard QR scanner can read them;
+the TagDrop app also caches them under this paper when it sees the matching
+<code>file_id</code> in the manifest.</p>
+<div class="tip">
+  Scan the manifest first, then each file code in any order. Raw-QR files you've scanned
+  before are surfaced immediately from the cache — no re-scanning needed.
+</div>
+</body>
+</html>`,
+    },
+  ],
+};
+
 // Mini e-book: a paper of text/markdown pages (a cover/TOC plus three short
 // chapters) that link to each other with ordinary relative links and share
 // one style.css sibling (SPEC.md §7 "Markdown content" stylesheet
@@ -1642,6 +1731,36 @@ async function addPaperSectorCards(grid, sectors, { baseLabel }) {
   return { count, idHex };
 }
 
+// Renders a card for a raw QR file (plain content, no tagdrop: envelope).
+// Shows the raw text/URI as a QR code alongside a "raw QR" badge; omits the
+// CBOR inspect button since there's no CBOR to inspect.
+async function addRawQrCard(grid, { label, mime, rawContent, fileIdHex }) {
+  const div = document.createElement('div');
+  div.className = 'qr-card';
+  const qrSlot = document.createElement('div');
+  div.appendChild(qrSlot);
+  div.insertAdjacentHTML('beforeend', `
+    <div class="qr-label">${escHtml(label)}</div>
+    <div><span class="qr-badge">${escHtml(mime)}</span> <span class="qr-badge parity">raw QR</span></div>
+    <div class="qr-id">${fileIdHex} (sha256 file_id)</div>
+    <div class="qr-uri"><input type="text" readonly value="${escHtml(rawContent)}"></div>
+    <button class="copy-btn copy-raw">Copy content</button>`);
+  grid.appendChild(div);
+  try {
+    await renderQr(qrSlot, rawContent);
+  } catch (e) {
+    qrSlot.innerHTML = '<div class="err">QR render failed</div>';
+  }
+  div.querySelector('.copy-raw').addEventListener('click', (ev) => {
+    navigator.clipboard.writeText(rawContent).then(() => {
+      const btn = ev.target;
+      const orig = btn.textContent;
+      btn.textContent = 'Copied!';
+      setTimeout(() => { btn.textContent = orig; }, 1500);
+    });
+  });
+}
+
 // ── Main ──────────────────────────────────────────────────────────────────
 async function main() {
   // Standalone examples
@@ -1770,6 +1889,51 @@ async function main() {
   await addPaperSectorCards(paperGrid, paper.sectors, { baseLabel: p.label });
   for (const f of encodedFiles) {
     await addContentSectorCards(paperGrid, f.sectors, {
+      baseLabel: f.slug, mime: f.mimeType, extraBadge: f.compress ? 'deflate' : null,
+    });
+  }
+
+  // Raw QR + Paper manifest
+  const rqp = RAW_QR_PAPER_EXAMPLE;
+  const rqpManifestFiles = [];
+  const rqpRawFileInfos = [];
+  for (const f of rqp.rawFiles) {
+    const bytes = new TextEncoder().encode(f.content);
+    const fileId = await sha256first8(bytes);
+    rqpManifestFiles.push({ slug: f.slug, mimeType: f.mimeType, fileId });
+    rqpRawFileInfos.push({ ...f, bytes, fileId });
+  }
+  const rqpTagDropFiles = [];
+  for (const f of rqp.files) {
+    const rawBytes = new TextEncoder().encode(f.content);
+    const sectors = await createContentSectorsAutoSized({ hint: null, filename: f.slug, mimeType: f.mimeType, rawBytes, compress: f.compress });
+    rqpTagDropFiles.push({ slug: f.slug, mimeType: f.mimeType, sectors, fileId: sectors[0].partMeta.cacheId, compress: f.compress });
+    rqpManifestFiles.push({ slug: f.slug, mimeType: f.mimeType, fileId: sectors[0].partMeta.cacheId });
+  }
+  const rqpPaper = await createPaperAutoSized({ label: rqp.label, set: rqp.set, slug: rqp.slug, files: rqpManifestFiles, related: [] });
+  const rqpRootHashHex = toHex(rqpPaper.rootHash);
+
+  document.getElementById('raw-qr-paper-info').innerHTML = `
+    <strong>${escHtml(rqp.label)}</strong>
+    — set: <code>${escHtml(rqp.set)}</code>, slug: <code>${escHtml(rqp.slug)}</code><br>
+    Root hash: <code>${rqpRootHashHex}</code>
+    — ${rqpRawFileInfos.length} raw QR file(s), ${rqpTagDropFiles.length} TagDrop Content sector(s)
+    <div class="step">① Scan the <strong>manifest</strong> — it registers the paper and its file list (including the raw QR file_ids).</div>
+    <div class="step">② Scan each file QR in any order. The raw QR codes (vCard, Wi-Fi) are plain — any scanner reads them; TagDrop caches them by matching their SHA-256 to the manifest's <code>file_id</code>.</div>
+    <div class="step">③ Open <strong>index</strong> to read the info page, which also explains the mixed format.</div>`;
+
+  const rqpGrid = document.getElementById('raw-qr-paper-grid');
+  await addPaperSectorCards(rqpGrid, rqpPaper.sectors, { baseLabel: rqp.label });
+  for (const f of rqpRawFileInfos) {
+    await addRawQrCard(rqpGrid, {
+      label: f.slug + ' (raw QR)',
+      mime: f.mimeType,
+      rawContent: f.content,
+      fileIdHex: toHex(f.fileId),
+    });
+  }
+  for (const f of rqpTagDropFiles) {
+    await addContentSectorCards(rqpGrid, f.sectors, {
       baseLabel: f.slug, mime: f.mimeType, extraBadge: f.compress ? 'deflate' : null,
     });
   }

--- a/tools/generator/index.html
+++ b/tools/generator/index.html
@@ -179,6 +179,7 @@
   <div>
     <h1>TagDrop Generator</h1>
     <small>Create QR codes for physical paper drops</small>
+    <small style="display:block;margin-top:4px;color:#b05000;">⚠ Wire format v1 is a draft — no real codes deployed yet. Breaking changes may occur without a version bump until the first code is printed and distributed.</small>
   </div>
   <nav>
     <a href="../">← Home</a> ·
@@ -805,17 +806,19 @@ const KEY_NAMES = {
   2: 'cache_id/root_hash', 3: 'hint/label', 4: 'mime_type', 5: 'content',
   7: 'total_bytes', 8: 'content_sha256',
   11: 'filename', 12: 'content_compression', 13: 'set', 14: 'slug', 15: 'files', 16: 'related',
-  17: 'collection_id', 18: 'collection_label', 19: 'collection_tag',
-  20: 'slug', 21: 'mime_type', 22: 'file_id', 23: 'paper_id', 24: 'icon',
+  17: 'collection_id', 18: 'collection_label', 19: 'collection_tag', 24: 'icon',
   26: 'lat', 27: 'lng',
   28: 'encryption', 30: 'key_material', 31: 'retain_key',
   37: 'kdf_alg', 38: 'kdf_salt', 39: 'kdf_iters',
-  40: 'description', 41: 'description',
+  40: 'description',
   42: 'sector_index', 43: 'sector_count', 44: 'parity_scheme',
   45: 'bulky_meta_compression', 46: 'bulky_meta_compressed_bytes', 47: 'bulky_meta_sha256',
   48: 'radius_m', 49: 'prefer_declared_location',
   50: 'in_reply_to', 51: 'title', 52: 'created_at', 54: 'location_label', 55: 'pixel_art',
 };
+const FILE_ENTRY_KEY_NAMES = { [KF.SLUG]:'slug', [KF.MIME]:'mime_type', [KF.FILE_ID]:'file_id', [KF.DESCRIPTION]:'description', [KF.PIXEL_ART]:'pixel_art' };
+const RELATED_ENTRY_KEY_NAMES = { [KR.HINT]:'hint', [KR.SET]:'set', [KR.SLUG]:'slug', [KR.PAPER_ID]:'paper_id', [KR.LAT]:'lat', [KR.LNG]:'lng', [KR.RADIUS_M]:'radius_m', [KR.KEY_MATERIAL]:'key_material', [KR.RETAIN_KEY]:'retain_key' };
+const SUB_KEY_NAMES = { 15: FILE_ENTRY_KEY_NAMES, 16: RELATED_ENTRY_KEY_NAMES };
 
 function toHexDump(bytes) {
   return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join(' ');
@@ -899,21 +902,22 @@ async function describeCbor(bytes) {
   return out;
 }
 
-function describeMap(map, indent) {
+function describeMap(map, indent, keyNames = KEY_NAMES) {
   const pad = '  '.repeat(indent);
   let out = '';
   for (const key of Object.keys(map).map(Number).sort((a, b) => a - b)) {
     const value = map[key];
-    const label = KEY_NAMES[key] ? key + ' (' + KEY_NAMES[key] + ')' : String(key);
+    const label = keyNames[key] ? key + ' (' + keyNames[key] + ')' : String(key);
     if (value instanceof Uint8Array) {
       out += pad + label + ': ' + toHexDump(value) + ' (' + value.length + ' bytes)\n';
     } else if (typeof value === 'string') {
       out += pad + label + ': "' + value + '"\n';
     } else if (Array.isArray(value)) {
       out += pad + label + ': [\n';
+      const itemKeyNames = SUB_KEY_NAMES[key] ?? keyNames;
       for (const item of value) {
         if (item !== null && typeof item === 'object' && !(item instanceof Uint8Array) && !Array.isArray(item)) {
-          out += pad + '  {\n' + describeMap(item, indent + 2) + pad + '  }\n';
+          out += pad + '  {\n' + describeMap(item, indent + 2, itemKeyNames) + pad + '  }\n';
         } else {
           out += pad + '  ' + item + '\n';
         }
@@ -993,14 +997,18 @@ const K = { CACHE_ID:2, HINT:3, MIME:4, CONTENT:5,
              TOTAL_BYTES:7, CONTENT_SHA:8,
              FILENAME:11, COMPRESSION:12, SET:13, SLUG:14, FILES:15, RELATED:16,
              COLLECTION_ID:17, COLLECTION_LABEL:18, COLLECTION_TAG:19,
-             FILE_SLUG:20, FILE_MIME:21, FILE_ID:22, PAPER_ID:23, ICON:24, LAT:26, LNG:27,
+             ICON:24, LAT:26, LNG:27,
              ENCRYPTION:28, KEY_MATERIAL:30, RETAIN_KEY:31,
              KDF_ALG:37, KDF_SALT:38, KDF_ITERS:39,
-             PAPER_DESCRIPTION:40, FILE_DESCRIPTION:41,
+             PAPER_DESCRIPTION:40,
              SECTOR_INDEX:42, SECTOR_COUNT:43, PARITY:44,
              BULKY_COMPRESSION:45, BULKY_COMPRESSED_BYTES:46, BULKY_SHA:47,
              RADIUS_M:48, PREFER_DECLARED_LOCATION:49,
              IN_REPLY_TO:50, TITLE:51, CREATED_AT:52, DOMAIN:53, LOCATION_LABEL:54, PIXEL_ART:55 };
+// Local keys for files[] sub-map entries (independent namespace, SPEC §3)
+const KF = { SLUG:1, MIME:2, FILE_ID:3, DESCRIPTION:4, PIXEL_ART:5 };
+// Local keys for related[] sub-map entries (independent namespace, SPEC §3)
+const KR = { HINT:1, SET:2, SLUG:3, PAPER_ID:4, LAT:5, LNG:6, RADIUS_M:7, KEY_MATERIAL:8, RETAIN_KEY:9 };
 
 // Sector sizing (mirrors Kotlin TagDropCodec.MAX_URI_LENGTH / MAX_SECTOR_DATA_BYTES):
 // MAX_URI_LENGTH/MAX_SECTOR_DATA_BYTES are the hard ceiling beyond which a sector's
@@ -1204,15 +1212,16 @@ function createKeyCodeSector({ keyMaterial, retainKey = true, hint }) {
 async function buildPaperStream({ label, set, slug, domain, files, related, description, collectionId, collectionLabel, collectionTag, icon, keyMaterial, retainKey = true, lat, lng, radiusM, preferDeclaredLocation = false, locationLabel, inReplyTo, title, createdAt }) {
   const bulky = [
     [K.FILES, files.map(f => subMap([
-      [K.FILE_SLUG, f.slug], [K.FILE_MIME, f.mimeType], [K.FILE_ID, f.fileId],
-      [K.FILE_DESCRIPTION, f.description || null],
+      [KF.SLUG, f.slug], [KF.MIME, f.mimeType], [KF.FILE_ID, f.fileId],
+      [KF.DESCRIPTION, f.description || null],
+      [KF.PIXEL_ART, f.pixelArt || null],
     ]))],
     [K.RELATED, related.map(r => subMap([
-      [K.HINT, r.hint], [K.SET, r.set || null], [K.SLUG, r.slug || null], [K.PAPER_ID, r.paperId || null],
-      [K.LAT, r.lat != null ? cfloat(r.lat) : null], [K.LNG, r.lng != null ? cfloat(r.lng) : null],
-      [K.RADIUS_M, r.radiusM != null ? cfloat(r.radiusM) : null],
-      [K.KEY_MATERIAL, r.keyMaterial || null],
-      [K.RETAIN_KEY, (r.keyMaterial && r.retainKey === false) ? false : null],
+      [KR.HINT, r.hint], [KR.SET, r.set || null], [KR.SLUG, r.slug || null], [KR.PAPER_ID, r.paperId || null],
+      [KR.LAT, r.lat != null ? cfloat(r.lat) : null], [KR.LNG, r.lng != null ? cfloat(r.lng) : null],
+      [KR.RADIUS_M, r.radiusM != null ? cfloat(r.radiusM) : null],
+      [KR.KEY_MATERIAL, r.keyMaterial || null],
+      [KR.RETAIN_KEY, (r.keyMaterial && r.retainKey === false) ? false : null],
     ]))],
   ];
   const bulkyBytes = cborMap(bulky);
@@ -2184,31 +2193,40 @@ function addFileEntry() {
         <label>Slug <small>(URL-safe name, e.g. index or map)</small></label>
         <input type="text" id="fslug-${id}" placeholder="index">
       </div>
-      <div>
-        <label>MIME type</label>
-        <select id="fmime-${id}">
-          <option value="text/html" selected>text/html</option>
-          <option value="text/plain">text/plain</option>
-          <option value="text/markdown">text/markdown</option>
-          <option value="text/css">text/css</option>
-          <option value="application/json">application/json</option>
-          <option value="image/svg+xml">image/svg+xml</option>
-          <option value="image/jpeg">image/jpeg (paste base64)</option>
-          <option value="image/png">image/png (paste base64)</option>
-          <option value="audio/midi">audio/midi (paste base64)</option>
-          <option value="audio/mpeg">audio/mpeg (paste base64)</option>
-        </select>
-      </div>
     </div>
     <label>Description <small>(optional — content teaser shown in the paper's directory, e.g. "A poem to read")</small></label>
     <input type="text" id="fdesc-${id}" placeholder="e.g. A poem to read">
-    <label><input type="checkbox" id="fcompress-${id}"> Compress with DEFLATE</label>
+    <div class="row">
+      <div style="flex:1"><label>MIME type</label><select id="fmime-${id}">
+        <option value="text/html" selected>text/html</option>
+        <option value="text/plain">text/plain</option>
+        <option value="text/markdown">text/markdown</option>
+        <option value="text/css">text/css</option>
+        <option value="application/json">application/json</option>
+        <option value="image/svg+xml">image/svg+xml</option>
+        <option value="image/jpeg">image/jpeg (paste base64)</option>
+        <option value="image/png">image/png (paste base64)</option>
+        <option value="audio/midi">audio/midi (paste base64)</option>
+        <option value="audio/mpeg">audio/mpeg (paste base64)</option>
+      </select></div>
+    </div>
+    <label><input type="checkbox" id="fraw-${id}" onchange="updateRawMode(${id})"> 📄 Raw QR — bare content in the QR symbol, metadata (MIME type, slug) declared in the manifest above</label>
+    <div id="fencoded-${id}">
+      <label><input type="checkbox" id="fcompress-${id}"> Compress with DEFLATE</label>
+    </div>
     <label><input type="checkbox" id="fpixelart-${id}"> 🟪 Pixel art (no smoothing, SPEC §7)</label>
     <label>Content</label>
     <textarea id="fcontent-${id}" placeholder="HTML, text, SVG…"></textarea>`;
   document.getElementById('p-files').appendChild(div);
   updatePaperEstimate();
   return id;
+}
+
+function updateRawMode(id) {
+  const raw = document.getElementById('fraw-' + id)?.checked;
+  const encodedDiv = document.getElementById('fencoded-' + id);
+  if (encodedDiv) encodedDiv.style.display = raw ? 'none' : '';
+  updatePaperEstimate();
 }
 
 // Adds a new file entry pre-filled from already-read bytes (e.g. a ZIP entry).
@@ -2319,12 +2337,26 @@ async function computePaperSectorPlan() {
   const encodedFiles = [];
   for (const id of fileEntries) {
     const fslug    = document.getElementById('fslug-' + id)?.value.trim();
+    const fraw     = document.getElementById('fraw-' + id)?.checked;
     const fmime    = document.getElementById('fmime-' + id)?.value;
     const fcompr   = document.getElementById('fcompress-' + id)?.checked;
     const fcontent = document.getElementById('fcontent-' + id)?.value;
     const fdesc    = document.getElementById('fdesc-' + id)?.value.trim() || null;
     const fpixelart = document.getElementById('fpixelart-' + id)?.checked ?? false;
     if (!fcontent?.trim()) throw new Error(`File "${fslug}" has no content.`);
+
+    if (fraw) {
+      let rawBytes;
+      try { rawBytes = bytesFromContent(fcontent, fmime); }
+      catch (e) { throw new Error(`File "${fslug}" content isn't valid base64 for MIME type "${fmime}".`); }
+      const fileId = await sha256first8(rawBytes);
+      // For text MIMEs, pass a decoded string so the QR library uses text/alphanumeric mode
+      // (more compact, readable by stock scanners). For binary MIMEs, pass raw bytes → byte mode.
+      const qrPayload = isTextMime(fmime) ? new TextDecoder().decode(rawBytes) : rawBytes;
+      encodedFiles.push({ slug: fslug, mimeType: fmime, fileId, sectors: null, description: fdesc, pixelArt: fpixelart, rawQrPayload: qrPayload });
+      continue;
+    }
+
     let rawBytes;
     try { rawBytes = bytesFromContent(fcontent, fmime); }
     catch (e) { throw new Error(`File "${fslug}" content isn't valid base64 for MIME type "${fmime}".`); }
@@ -2361,7 +2393,7 @@ async function computePaperSectorPlan() {
   });
 
   // Encode the paper itself
-  const manifestFiles = encodedFiles.map(f => ({ slug: f.slug, mimeType: f.mimeType, fileId: f.fileId, description: f.description }));
+  const manifestFiles = encodedFiles.map(f => ({ slug: f.slug, mimeType: f.mimeType, fileId: f.fileId, description: f.description, pixelArt: f.pixelArt || false }));
   let paper;
   try {
     paper = await createPaperAutoSized({
@@ -2387,7 +2419,7 @@ const updatePaperEstimate = debounce(async () => {
   if (!el) return;
   try {
     const plan = await computePaperSectorPlan();
-    const total = plan.encodedFiles.reduce((sum, f) => sum + f.sectors.length, 0) + plan.paper.sectors.length;
+    const total = plan.encodedFiles.reduce((sum, f) => sum + (f.sectors ? f.sectors.length : 1), 0) + plan.paper.sectors.length;
     if (seq === paperEstimateSeq) showEstimate(el, describeQrCountEstimate(total), false);
   } catch (e) {
     if (seq === paperEstimateSeq) showEstimate(el, e.message, true);
@@ -2477,8 +2509,31 @@ async function generatePaper() {
   // once the reader has scanned/assembled them.
   for (const f of encodedFiles) {
     const homeBadge = HOME_SLUGS.includes(f.slug) ? '🏠 homepage' : null;
-    const fCount = f.sectors.length;
     const fIdHex = toHex(f.fileId);
+
+    if (f.rawQrPayload != null) {
+      // Raw QR — bare content in the symbol, no TagDrop encoding.
+      // manifest file_id = SHA-256(raw bytes)[0:8] links it to this paper without a SPEC change.
+      const isBinary = f.rawQrPayload instanceof Uint8Array;
+      const sub = isBinary ? `📄 raw QR · ${f.rawQrPayload.length} bytes · ${f.mimeType}` : `📄 raw QR · ${f.mimeType}`;
+      const fItem = makeQrItem(f.slug, sub, fIdHex, null, homeBadge, f.rawQrPayload);
+      fItem.div.querySelector('.inspect-cbor')?.remove();
+      grid.appendChild(fItem.div);
+      try {
+        await renderQr(fItem.qrDiv, f.rawQrPayload);
+        paperBulkItems.push({
+          filename: `tagdrop-${slugifyForFilename(f.slug)}-${fIdHex}.png`,
+          qrData: f.rawQrPayload,
+          caption: `${f.slug} (raw QR · ${f.mimeType})`,
+        });
+      } catch(e) {
+        fItem.div.querySelector('.action-row')?.remove();
+        fItem.div.insertAdjacentHTML('beforeend', `<div class="err">Render failed — content is too large for a single raw QR.</div>`);
+      }
+      continue;
+    }
+
+    const fCount = f.sectors.length;
     if (fCount > 1) {
       msgs.innerHTML += `<div class="warn">"${escHtml(f.slug)}" is ${f.sectors[0].partMeta.totalBytes} bytes
         — split into ${fCount} sector QR codes.${addParity ? ' 🛟 A parity code is included so any one of these can be reconstructed if lost.' : ''}</div>`;

--- a/tools/generator/index.html
+++ b/tools/generator/index.html
@@ -816,9 +816,6 @@ const KEY_NAMES = {
   48: 'radius_m', 49: 'prefer_declared_location',
   50: 'in_reply_to', 51: 'title', 52: 'created_at', 54: 'location_label', 55: 'pixel_art',
 };
-const FILE_ENTRY_KEY_NAMES = { [KF.SLUG]:'slug', [KF.MIME]:'mime_type', [KF.FILE_ID]:'file_id', [KF.DESCRIPTION]:'description', [KF.PIXEL_ART]:'pixel_art' };
-const RELATED_ENTRY_KEY_NAMES = { [KR.HINT]:'hint', [KR.SET]:'set', [KR.SLUG]:'slug', [KR.PAPER_ID]:'paper_id', [KR.LAT]:'lat', [KR.LNG]:'lng', [KR.RADIUS_M]:'radius_m', [KR.KEY_MATERIAL]:'key_material', [KR.RETAIN_KEY]:'retain_key' };
-const SUB_KEY_NAMES = { 15: FILE_ENTRY_KEY_NAMES, 16: RELATED_ENTRY_KEY_NAMES };
 
 function toHexDump(bytes) {
   return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join(' ');
@@ -1009,6 +1006,9 @@ const K = { CACHE_ID:2, HINT:3, MIME:4, CONTENT:5,
 const KF = { SLUG:1, MIME:2, FILE_ID:3, DESCRIPTION:4, PIXEL_ART:5 };
 // Local keys for related[] sub-map entries (independent namespace, SPEC §3)
 const KR = { HINT:1, SET:2, SLUG:3, PAPER_ID:4, LAT:5, LNG:6, RADIUS_M:7, KEY_MATERIAL:8, RETAIN_KEY:9 };
+const FILE_ENTRY_KEY_NAMES = { [KF.SLUG]:'slug', [KF.MIME]:'mime_type', [KF.FILE_ID]:'file_id', [KF.DESCRIPTION]:'description', [KF.PIXEL_ART]:'pixel_art' };
+const RELATED_ENTRY_KEY_NAMES = { [KR.HINT]:'hint', [KR.SET]:'set', [KR.SLUG]:'slug', [KR.PAPER_ID]:'paper_id', [KR.LAT]:'lat', [KR.LNG]:'lng', [KR.RADIUS_M]:'radius_m', [KR.KEY_MATERIAL]:'key_material', [KR.RETAIN_KEY]:'retain_key' };
+const SUB_KEY_NAMES = { 15: FILE_ENTRY_KEY_NAMES, 16: RELATED_ENTRY_KEY_NAMES };
 
 // Sector sizing (mirrors Kotlin TagDropCodec.MAX_URI_LENGTH / MAX_SECTOR_DATA_BYTES):
 // MAX_URI_LENGTH/MAX_SECTOR_DATA_BYTES are the hard ceiling beyond which a sector's

--- a/tools/reader/index.html
+++ b/tools/reader/index.html
@@ -198,6 +198,7 @@ main { max-width: 720px; margin: 0 auto; padding: 20px 16px; }
     </svg>
     <div>
       <h1>TagDrop Reader</h1>
+      <small style="display:block;color:#b05000;">⚠ Wire format v1 is a draft — breaking changes may occur before the first real code is deployed.</small>
       <nav style="font-size:0.8rem; margin-top:4px;">
         <a href="../" style="color:#D9652B;">← Home</a> ·
         <a href="../generator/" style="color:#D9652B;">Generator</a> ·
@@ -532,16 +533,20 @@ const K = {
   TOTAL_BYTES:7, CONTENT_SHA:8,
   FILENAME:11, COMPRESSION:12, SET:13, SLUG:14, FILES:15, RELATED:16,
   COLLECTION_ID:17, COLLECTION_LABEL:18, COLLECTION_TAG:19,
-  FILE_SLUG:20, FILE_MIME:21, FILE_ID:22, PAPER_ID:23, ICON:24,
+  ICON:24,
   LAT:26, LNG:27,
   ENCRYPTION:28, KEY_MATERIAL:30, RETAIN_KEY:31,
   KDF_ALG:37, KDF_SALT:38, KDF_ITERS:39,
-  PAPER_DESCRIPTION:40, FILE_DESCRIPTION:41,
+  PAPER_DESCRIPTION:40,
   SECTOR_INDEX:42, SECTOR_COUNT:43, PARITY:44,
   BULKY_COMPRESSION:45, BULKY_COMPRESSED_BYTES:46, BULKY_SHA:47,
   RADIUS_M:48, PREFER_DECLARED_LOCATION:49,
   IN_REPLY_TO:50, TITLE:51, CREATED_AT:52, DOMAIN:53, LOCATION_LABEL:54, PIXEL_ART:55
 };
+// Local keys for files[] sub-map entries (independent namespace, SPEC §3)
+const KF = { SLUG:1, MIME:2, FILE_ID:3, DESCRIPTION:4, PIXEL_ART:5 };
+// Local keys for related[] sub-map entries (independent namespace, SPEC §3)
+const KR = { HINT:1, SET:2, SLUG:3, PAPER_ID:4, LAT:5, LNG:6, RADIUS_M:7, KEY_MATERIAL:8, RETAIN_KEY:9 };
 
 // CBOR-sequence envelope (SPEC §2):
 // tagdrop:<base41( CBOR(version) || CBOR(type) || CBOR(part_meta) || CBOR(sector_bytes) )>
@@ -602,17 +607,19 @@ const KEY_NAMES = {
   2: 'cache_id/root_hash', 3: 'hint/label', 4: 'mime_type', 5: 'content',
   7: 'total_bytes', 8: 'content_sha256',
   11: 'filename', 12: 'content_compression', 13: 'set', 14: 'slug', 15: 'files', 16: 'related',
-  17: 'collection_id', 18: 'collection_label', 19: 'collection_tag',
-  20: 'slug', 21: 'mime_type', 22: 'file_id', 23: 'paper_id', 24: 'icon',
+  17: 'collection_id', 18: 'collection_label', 19: 'collection_tag', 24: 'icon',
   26: 'lat', 27: 'lng',
   28: 'encryption', 30: 'key_material', 31: 'retain_key',
   37: 'kdf_alg', 38: 'kdf_salt', 39: 'kdf_iters',
-  40: 'description', 41: 'description',
+  40: 'description',
   42: 'sector_index', 43: 'sector_count', 44: 'parity_scheme',
   45: 'bulky_meta_compression', 46: 'bulky_meta_compressed_bytes', 47: 'bulky_meta_sha256',
   48: 'radius_m', 49: 'prefer_declared_location',
   50: 'in_reply_to', 51: 'title', 52: 'created_at', 53: 'domain', 54: 'location_label', 55: 'pixel_art',
 };
+const FILE_ENTRY_KEY_NAMES = { [KF.SLUG]:'slug', [KF.MIME]:'mime_type', [KF.FILE_ID]:'file_id', [KF.DESCRIPTION]:'description', [KF.PIXEL_ART]:'pixel_art' };
+const RELATED_ENTRY_KEY_NAMES = { [KR.HINT]:'hint', [KR.SET]:'set', [KR.SLUG]:'slug', [KR.PAPER_ID]:'paper_id', [KR.LAT]:'lat', [KR.LNG]:'lng', [KR.RADIUS_M]:'radius_m', [KR.KEY_MATERIAL]:'key_material', [KR.RETAIN_KEY]:'retain_key' };
+const SUB_KEY_NAMES = { 15: FILE_ENTRY_KEY_NAMES, 16: RELATED_ENTRY_KEY_NAMES };
 
 function toHexDump(bytes) {
   return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join(' ');
@@ -656,21 +663,22 @@ async function describeCbor(bytes) {
   return out;
 }
 
-function describeMap(map, indent) {
+function describeMap(map, indent, keyNames = KEY_NAMES) {
   const pad = '  '.repeat(indent);
   let out = '';
   for (const key of Object.keys(map).map(Number).sort((a, b) => a - b)) {
     const value = map[key];
-    const label = KEY_NAMES[key] ? key + ' (' + KEY_NAMES[key] + ')' : String(key);
+    const label = keyNames[key] ? key + ' (' + keyNames[key] + ')' : String(key);
     if (value instanceof Uint8Array) {
       out += pad + label + ': ' + toHexDump(value) + ' (' + value.length + ' bytes)\n';
     } else if (typeof value === 'string') {
       out += pad + label + ': "' + value + '"\n';
     } else if (Array.isArray(value)) {
       out += pad + label + ': [\n';
+      const itemKeyNames = SUB_KEY_NAMES[key] ?? keyNames;
       for (const item of value) {
         if (item !== null && typeof item === 'object' && !(item instanceof Uint8Array) && !Array.isArray(item)) {
-          out += pad + '  {\n' + describeMap(item, indent + 2) + pad + '  }\n';
+          out += pad + '  {\n' + describeMap(item, indent + 2, itemKeyNames) + pad + '  }\n';
         } else {
           out += pad + '  ' + item + '\n';
         }
@@ -854,26 +862,26 @@ function paperFromParts(parts, rootHash) {
   const filesRaw = parts.bulky[K.FILES];
   const files = Array.isArray(filesRaw) ? filesRaw.flatMap(entry => {
     if (!isCborMap(entry)) return [];
-    const slug = entry[K.FILE_SLUG], mimeType = entry[K.FILE_MIME], fileId = entry[K.FILE_ID];
+    const slug = entry[KF.SLUG], mimeType = entry[KF.MIME], fileId = entry[KF.FILE_ID];
     if (!slug || !mimeType || !fileId) return [];
-    return [{ slug, mimeType, fileId: toHex(fileId), description: entry[K.FILE_DESCRIPTION] ?? null }];
+    return [{ slug, mimeType, fileId: toHex(fileId), description: entry[KF.DESCRIPTION] ?? null, pixelArt: entry[KF.PIXEL_ART] === true }];
   }) : [];
 
   const relatedRaw = parts.bulky[K.RELATED];
   const related = Array.isArray(relatedRaw) ? relatedRaw.flatMap(entry => {
     if (!isCborMap(entry)) return [];
-    const hint = entry[K.HINT];
+    const hint = entry[KR.HINT];
     if (!hint) return [];
     return [{
       hint,
-      set:         entry[K.SET] ?? null,
-      slug:        entry[K.SLUG] ?? null,
-      paperId:     entry[K.PAPER_ID] ? toHex(entry[K.PAPER_ID]) : null,
-      lat:         entry[K.LAT] ?? null,
-      lng:         entry[K.LNG] ?? null,
-      radiusM:     entry[K.RADIUS_M] ?? null,
-      keyMaterial: entry[K.KEY_MATERIAL] ?? null,
-      retainKey:   entry[K.RETAIN_KEY] !== false,
+      set:         entry[KR.SET] ?? null,
+      slug:        entry[KR.SLUG] ?? null,
+      paperId:     entry[KR.PAPER_ID] ? toHex(entry[KR.PAPER_ID]) : null,
+      lat:         entry[KR.LAT] ?? null,
+      lng:         entry[KR.LNG] ?? null,
+      radiusM:     entry[KR.RADIUS_M] ?? null,
+      keyMaterial: entry[KR.KEY_MATERIAL] ?? null,
+      retainKey:   entry[KR.RETAIN_KEY] !== false,
     }];
   }) : [];
 
@@ -1549,12 +1557,27 @@ function updateCborButton() {
   document.getElementById('btnCbor').disabled = !lastScannedCbor;
 }
 
+/** Tries to match a non-TagDrop QR scan against the active paper's file_id list.
+ *  Raw QR files declare file_id = SHA-256(raw bytes)[0:8] in the manifest; content
+ *  and MIME type come from the QR bytes + the manifest entry respectively.
+ *  Requires a paper to have been scanned first (activePaperHash must be set). */
+async function handleRawScan(bytes) {
+  if (!activePaperHash) { showMsg('Not a TagDrop QR code.', 'err'); return; }
+  const paper = await dbGet('papers', activePaperHash);
+  if (!paper) { showMsg('Not a TagDrop QR code.', 'err'); return; }
+  const hashHex = toHex((await sha256(bytes)).slice(0, 8));
+  const file = paper.files.find(f => f.fileId === hashHex);
+  if (!file) { showMsg('Not a TagDrop QR code.', 'err'); return; }
+  await completeSingle(hashHex, null, file.slug, file.mimeType, bytes, { pixelArt: file.pixelArt ?? false });
+  showMsg('Found: ' + file.slug + ' (' + file.mimeType + ')', 'ok');
+}
+
 async function handleScanned(rawBytes) {
   const bytes = rawBytes instanceof Uint8Array ? rawBytes : new Uint8Array(rawBytes);
   let parsed;
   try { parsed = await parseScannedBytes(bytes); }
   catch (e) { showMsg('Parse error: ' + e.message, 'err'); return; }
-  if (!parsed) { showMsg('Not a TagDrop QR code.', 'err'); return; }
+  if (!parsed) { await handleRawScan(bytes); return; }
 
   switch (parsed.type) {
 
@@ -1632,7 +1655,10 @@ async function handlePaper(paper) {
   for (const related of paper.related) {
     if (related.keyMaterial) await handleDiscoveredKey(related.keyMaterial, related.retainKey, related.hint);
   }
-  showMsg('Paper: ' + (paper.label || 'untitled') + ' — ' + paper.files.length + ' file(s)', 'ok');
+  const cachedIds = new Set((await dbGetAll('caches')).map(c => c.cacheId));
+  const alreadyFoundCount = paper.files.filter(f => cachedIds.has(f.fileId)).length;
+  const foundSuffix = alreadyFoundCount > 0 ? ', ' + alreadyFoundCount + ' already in your collection' : '';
+  showMsg('Paper: ' + (paper.label || 'untitled') + ' — ' + paper.files.length + ' file(s)' + foundSuffix, 'ok');
   await renderPaper(paper.rootHash);
 }
 


### PR DESCRIPTION
## Summary

- **Raw QR mode for paper files (issue #44 v1)** — a file in a paper manifest can now be marked "Raw QR": its bytes go directly into the QR symbol with no `tagdrop:` encoding. Metadata (slug, MIME type, `pixel_art`) is declared in the manifest's `files[]` entry so the app recognises and caches the code when scanned. Text and binary MIME types both work; the generator picks alphanumeric vs byte QR mode via `isTextMime()`. Reader's `handleRawScan()` matches scanned bytes' SHA-256[0:8] against the active paper's `files[]` fileIds. Android `ReceiveActivity.completeRawScan()` looks up the matching paper file for `mimeType` and `pixelArt`. `pixel_art` (key 55) is now valid in both `core_meta_item` (Content) and paper manifest `files[]` entries.

- **Surface already-cached files on manifest scan** — when a Paper manifest is first scanned, files the user has previously cached are surfaced immediately without re-scanning their codes.

- **SPEC §3 key table consolidation** — single master table with "Valid in" column replaces two separate tables. `files[]` and `related[]` sub-maps now use independent local key ranges (files[]: 1–5; related[]: 1–9) instead of global keys 20–23 and 41, which are retired. Both codec implementations (Kotlin + all three JS tools) updated; `describeMap` uses a `SUB_MAP_KEY_NAMES` lookup table so future list-of-maps fields need no change to the function.

- **Draft wire-format warning** — generator, reader, and readme now prominently note that wire format v1 is a draft with no deployed codes yet.

## Breaking change note

The `files[]` and `related[]` sub-map key renumbering is a breaking wire-format change. It is safe because wire format v1 is a draft and no real TagDrop codes have been printed or distributed yet (SPEC.md Status: Draft). Once the first code is deployed the format freezes.

## Test plan

- [x] Existing unit tests pass (239 tests, `./gradlew testDebugUnitTest`)
- [x] Generate a paper with a Raw QR file in the web generator; confirm QR renders and the manifest lists it
- [ ] Scan the manifest in the web reader, then scan the raw QR — confirm it matches and caches
- [x] Confirm CBOR inspector in generator/reader labels `files[]` sub-map entries with names (`slug`, `mime_type`, etc.) not raw integers
- [x] Confirm encoded Paper codes from before this change no longer decode correctly (expected — breaking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGZv8zpdtbbc3NBVpdmsVM