### PR TITLE
Remote Drop Sources: source registry, discovery, and UX polish

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1805,6 +1805,59 @@ Per-drop entry fields:
 
 The `id` field is the join key between the source list and a locally scanned QR: when the finder scans the physical TagDrop code at that location, its `cache_id` matches `id`, and the app marks that pin as found on the map — no server round-trip needed.
 
+An optional `related_sources` top-level array lets a registry recommend other registries. The app surfaces these as an opt-in prompt after a successful fetch — the user sees a checklist of the recommended sources and can add whichever they want (all disabled by default, matching the behaviour for any newly added source):
+
+```json
+{
+  "version": 1,
+  "label": "London Dead Drops",
+  "drops": [ … ],
+  "related_sources": [
+    {
+      "name": "UK Nationwide Drops",
+      "url": "https://example.org/uk-drops.json",
+      "description": "All registered drops across the UK",
+      "maintainer": "UK TagDrop Community"
+    }
+  ]
+}
+```
+
+`related_sources` entry fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string (required) | Human-readable name for the recommended source. |
+| `url` | string (required) | URL of the recommended registry JSON file. |
+| `description` | string (opt) | Short description shown to the user before they add it. |
+| `maintainer` | string (opt) | Who maintains this registry. |
+
+### Source directory format
+
+The TagDrop project publishes a curated directory of known community registries at:
+
+```
+https://mofosyne.github.io/tagdrop/db/sources.json
+```
+
+This uses a parallel schema (top-level `sources` array instead of `drops`) and is the bootstrap discovery point — the app's "Browse recommended sources" action fetches this URL and presents a checklist so users can add any registry they want. Third-party registries can also publish their own directories; any URL that serves this schema can be used.
+
+```json
+{
+  "version": 1,
+  "label": "TagDrop Known Sources",
+  "updated": "2026-07-03",
+  "sources": [
+    {
+      "name": "TagDrop Community Drops",
+      "url": "https://mofosyne.github.io/tagdrop/db/drops.json",
+      "description": "Curated list of community-placed TagDrop codes worldwide.",
+      "maintainer": "TagDrop project"
+    }
+  ]
+}
+```
+
 ### The official TagDrop source
 
 The TagDrop project maintains a curated source at:

--- a/SPEC.md
+++ b/SPEC.md
@@ -172,6 +172,7 @@ TagDrop's wire format has four internal CBOR structures, all integer-keyed maps 
 | 53 | `domain` | text (opt) | `core_meta_item`; Paper only — human-readable name for `tagdrop://<domain>/<slug>` links, see §7 "Domains" |
 | 54 | `location_label` | text (opt) | `core_meta_item` — human-readable, non-coordinate description of this payload's own location, e.g. "🚋 Tram 40"; see §4.2 |
 | 55 | `pixel_art` | bool (opt, default `false`) | `core_meta_item` (Content only) — render with nearest-neighbour scaling (no smoothing); see §7 "Pixel art" |
+| 56 | `source_url` | text (opt) | `core_meta_item` — URL of a drop-source registry JSON file; see §17 |
 
 Keys **1**, **6**, **9**, **10** are retired (formerly `version`-inside-payload,
 `chunk_count`, `chunk_index`, `chunk_data` — superseded by the envelope's
@@ -185,8 +186,9 @@ small embedded image icon (raw bytes), as an alternative to the emoji `icon`
 field. Keys 28, 30, 31 are defined in §9 (Encryption); keys 32–36 in §10
 (Verified Authorship); keys 37–39 in §9 (Passphrase-based key derivation); keys
 26, 27, 48, 49, 54 in §4.2 (Declared location and priority); key 53 in §7
-(Domains); key 55 in §7 (Pixel art). Key 29 is reserved and unused — see §9 for
-why an encrypted override map's nonce doesn't need its own clear field.
+(Domains); key 55 in §7 (Pixel art); key 56 in §17 (Drop Source Registry). Key
+29 is reserved and unused — see §9 for why an encrypted override map's nonce
+doesn't need its own clear field.
 
 **Sub-map local key namespaces:** `files[]` and `related[]` entries are CBOR
 maps with their own independent key ranges, separate from the top-level key
@@ -1644,6 +1646,7 @@ Version history:
 - AES-256-GCM hidden override maps (§9), Content payloads only: self-contained `nonce||ciphertext||tag` blob carried in the reassembled stream's `content` slot, applied after compression. Optional non-binding `encryption` hint (key 28). `key_material`/`retain_key` (keys 30/31) matched by trial decryption ("discovery, not declaration"). PBKDF2-HMAC-SHA256 passphrase derivation via `kdf_alg`/`kdf_salt`/`kdf_iters` (keys 37–39).
 - ML-DSA-44 post-quantum signatures (§10): `signature_algorithm`/`signature`/`signer_pubkey`/`signer_id`/`signer_label` (keys 32–36), additive and not affecting `cache_id`/`root_hash`/`content_sha256`/`bulky_meta_sha256`. Specified for forward-compatibility; not yet implemented in reference implementations.
 - Author-declared `created_at` (key 52, both payload kinds): optional Unix timestamp (seconds) recording when the payload was authored, taken from the authoring device's clock at encode time — self-declared like `lat`/`lng`, not a verified/trusted timestamp.
+- Drop source registry (§17): `source_url` (key 56) in `core_meta_item` — a URL pointing to a JSON file listing nearby TagDrop drop locations. When scanned, the app prompts the user before fetching. Source management (add/enable/disable/remove) is explicit and user-controlled; no automatic background fetches.
 
 ---
 
@@ -1726,3 +1729,81 @@ resolution.
 **No explicit folder hierarchy:** Papers list files as flat slug strings. Slugs that contain `/` (e.g. `images/photo.jpg`) create virtual path conventions without requiring a tree structure in the CBOR or the database. String equality on the full slug is the only lookup operation needed. This keeps the directory format simple and avoids directory-traversal edge cases.
 
 **Non-HTML content types (images, audio, MIDI):** The cache stores raw bytes for any MIME type, and the Android WebView can serve them all via `WebViewClient.shouldInterceptRequest`. When a loaded HTML page contains `<img src="tagdrop://...">`, `<audio src="tagdrop://...">`, or any other subresource reference, `shouldInterceptRequest` intercepts the fetch, looks up the slug in the local DB, and returns a `WebResourceResponse` with the cached bytes — no network involved. MIDI files require a JS player library embedded in the same HTML file (the MIDI bytes are served as `audio/midi` via the same mechanism). Purely binary payloads (a standalone image, a MIDI file) are displayed/played by wrapping them in a minimal HTML page that references the tagdrop:// URI. The navigation flow (`shouldOverrideUrlLoading`) and the subresource flow (`shouldInterceptRequest`) are independent: the former fires when the user clicks a link and loads a new top-level page; the latter fires for every embedded asset on the current page. Both resolve through the same `TagDropLinkResolver`.
+
+---
+
+## 17. Drop Source Registry
+
+A drop **source** is a URL pointing to a JSON file that lists TagDrop drop locations — cache IDs, coordinates, and hints for drops placed in the physical world. Sources let communities publish and share lists of drops without changing the wire format of the drops themselves.
+
+### Wire field
+
+`source_url` (key 56, text, optional) may appear in `core_meta_item` of any Content or Paper payload — typically a hint-only code (no `content` bytes) placed alongside a physical drop or distributed as a sticker. It names a URL that the finder's app can add as a source. No other wire-format changes are needed: the existing `hint`/`label` (key 3) names the source for the user; `lat`/`lng` (keys 26/27) can locate the physical QR that carries it; `icon` (key 24) gives it a visual identity.
+
+### App behaviour
+
+When a code carrying `source_url` is scanned the app MUST prompt the user before fetching anything:
+
+> **"Add drop source: \<hint or label\>? [Add] [Skip]"**
+
+The full URL MUST be shown to the user before they confirm. No fetch occurs on Skip. On Add, the URL is stored in the local source list and fetched immediately (if the device is online); the app MUST NOT fetch it silently or in the background without the user having added it first.
+
+A **source management screen** (separate from the map) lists all added sources with:
+- Enable / disable toggle (disabled sources contribute no pins to the map)
+- Remove (deletes the stored URL and all pins derived from it)
+- Last-fetched timestamp and entry count
+- Manual refresh button
+
+Re-fetching is user-initiated or on a configurable schedule chosen by the user. The app caches the last-fetched JSON locally so the map works offline after the first fetch.
+
+**Privacy:** fetching a source URL reveals the device's IP address and approximate fetch time to whoever hosts the file. The app SHOULD display this caveat on the Add prompt. Source files SHOULD be hosted on servers whose privacy practices users can assess (e.g. static GitHub Pages).
+
+### Source JSON format
+
+```json
+{
+  "version": 1,
+  "label": "London Dead Drops",
+  "updated": "2026-07-03",
+  "drops": [
+    {
+      "id": "a3f8b2c1d4e5f6a7",
+      "lat": 51.5007,
+      "lon": -0.1246,
+      "hint": "Behind the loose brick on the north wall",
+      "label": "Shoreditch Wall Drop"
+    }
+  ]
+}
+```
+
+Top-level fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `version` | uint (required) | Schema version. Currently `1`. |
+| `label` | string (opt) | Human-readable name for the source. |
+| `updated` | string (opt) | ISO 8601 date of last content change, e.g. `"2026-07-03"`. |
+| `drops` | array (required) | List of drop entries (may be empty). |
+
+Per-drop entry fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string (required) | `cache_id` of the drop's TagDrop code — 16 lowercase hex characters (SHA-256 of content bytes, first 8 bytes, §4.4). |
+| `lat` | number (required) | WGS84 latitude. |
+| `lon` | number (required) | WGS84 longitude. |
+| `hint` | string (opt) | Short human-readable location clue, e.g. `"Behind the loose brick"`. |
+| `label` | string (opt) | Name of the drop. |
+
+The `id` field is the join key between the source list and a locally scanned QR: when the finder scans the physical TagDrop code at that location, its `cache_id` matches `id`, and the app marks that pin as found on the map — no server round-trip needed.
+
+### The official TagDrop source
+
+The TagDrop project maintains a curated source at:
+
+```
+https://mofosyne.github.io/tagdrop/db/drops.json
+```
+
+This file is committed directly to the repository (`docs/db/drops.json`) and served via GitHub Pages. To list a drop, open a pull request adding an entry to that file. The entry's `id` must be the `cache_id` of the actual TagDrop code you have placed (computable from the generator or the app's share/inspect screen).

--- a/SPEC.md
+++ b/SPEC.md
@@ -1769,13 +1769,17 @@ Re-fetching is user-initiated or on a configurable schedule chosen by the user. 
     {
       "id": "a3f8b2c1d4e5f6a7",
       "lat": 51.5007,
-      "lon": -0.1246,
+      "lng": -0.1246,
       "hint": "Behind the loose brick on the north wall",
-      "label": "Shoreditch Wall Drop"
+      "description": "Pedestrian underpass, north face of the arch, eye level",
+      "status": "working",
+      "status_updated": "2026-07-03"
     }
   ]
 }
 ```
+
+Field names deliberately mirror the TagDrop wire format (§3) where they overlap — `hint` (key 3), `description` (key 40), `lat`/`lng` (keys 26/27) — so a hint QR scan already contains every entry field except `status` and `status_updated`. A future app feature could auto-generate a drops.json submission from a scanned hint QR with those two fields added by the submitter.
 
 Top-level fields:
 
@@ -1790,11 +1794,14 @@ Per-drop entry fields:
 
 | Field | Type | Notes |
 |---|---|---|
-| `id` | string (required) | `cache_id` of the drop's TagDrop code — 16 lowercase hex characters (SHA-256 of content bytes, first 8 bytes, §4.4). |
-| `lat` | number (required) | WGS84 latitude. |
-| `lon` | number (required) | WGS84 longitude. |
-| `hint` | string (opt) | Short human-readable location clue, e.g. `"Behind the loose brick"`. |
-| `label` | string (opt) | Name of the drop. |
+| `id` | string (required) | `cache_id` of the drop's TagDrop code — 16 lowercase hex characters (SHA-256 of content bytes, first 8 bytes, §4.4). Matches wire format key 2. |
+| `lat` | number (required) | WGS84 latitude. Matches wire format key 26. |
+| `lng` | number (required) | WGS84 longitude. Matches wire format key 27. |
+| `hint` | string (opt) | Short human-readable location clue, e.g. `"Behind the loose brick"`. Matches wire format key 3. |
+| `description` | string (opt) | Longer location description, e.g. directions or context. Matches wire format key 40. |
+| `status` | string (opt) | Operational status: `"working"`, `"unknown"` (default), `"broken"`, or `"removed"`. `"removed"` drops are hidden from the map. No wire format equivalent — community-maintained mutable state, not encoded in the QR. |
+| `status_updated` | string (opt) | ISO 8601 date of the last status check, e.g. `"2026-07-03"`. No wire format equivalent. |
+| `drop_type` | string (opt) | Content type tag; default `"tagdrop"`. Reserved for future extensibility (e.g. listing non-TagDrop drops in a mixed source). |
 
 The `id` field is the join key between the source list and a locally scanned QR: when the finder scans the physical TagDrop code at that location, its `cache_id` matches `id`, and the app marks that pin as found on the map — no server round-trip needed.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -115,6 +115,13 @@
             android:exported="false"
             android:parentActivityName=".MainActivity" />
 
+        <!-- Drop source registry management -->
+        <activity
+            android:name=".SourcesActivity"
+            android:label="@string/title_sources"
+            android:exported="false"
+            android:parentActivityName=".MainActivity" />
+
         <!-- Exposes cached content as content:// URIs for "Open with…" / "Share" -->
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/github/mofosyne/tagdrop/MainActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/MainActivity.kt
@@ -139,6 +139,7 @@ class MainActivity : AppCompatActivity() {
         return when (item.itemId) {
             R.id.action_demo_collection -> { addDemoCollection(); true }
             R.id.action_retained_keys -> { startActivity(Intent(this, RetainedKeysActivity::class.java)); true }
+            R.id.action_sources -> { startActivity(Intent(this, SourcesActivity::class.java)); true }
             R.id.action_backup -> { startBackup(); true }
             R.id.action_restore -> { triggerRestore(); true }
             R.id.action_readme -> { startActivity(Intent(this, ReadMeActivity::class.java)); true }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/MapFragment.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/MapFragment.kt
@@ -244,7 +244,7 @@ class MapFragment : Fragment() {
             if (entry.status == "removed") continue
             val point = GeoPoint(entry.lat, entry.lng)
             points += point
-            val label = entry.hint ?: entry.label ?: entry.id.take(8)
+            val label = entry.hint ?: entry.id.take(8)
             // Visual distinction by status: "broken" = grey pin, "working" = normal antenna icon
             val icon = when (entry.status) {
                 "broken" -> "📵"

--- a/app/src/main/java/com/github/mofosyne/tagdrop/MapFragment.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/MapFragment.kt
@@ -27,7 +27,9 @@ import androidx.core.graphics.drawable.toDrawable
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
+import com.github.mofosyne.tagdrop.data.DropEntryCache
 import com.github.mofosyne.tagdrop.data.db.AppDatabase
+import com.github.mofosyne.tagdrop.data.db.DropSource
 import com.github.mofosyne.tagdrop.data.db.FoundCache
 import com.github.mofosyne.tagdrop.data.db.ScannedPaper
 import com.github.mofosyne.tagdrop.data.db.isThumbnailEligible
@@ -65,6 +67,7 @@ class MapFragment : Fragment() {
     private val markerFolder = org.osmdroid.views.overlay.FolderOverlay()
     private var latestPapers: List<ScannedPaper> = emptyList()
     private var latestCaches: List<FoundCache> = emptyList()
+    private var latestSources: List<DropSource> = emptyList()
     private val markerInfos = mutableListOf<MarkerInfo>()
     private var labelsShown = false
 
@@ -135,6 +138,10 @@ class MapFragment : Fragment() {
         }
         db.cacheDao().getAllCaches().observe(viewLifecycleOwner) { caches ->
             latestCaches = caches
+            render()
+        }
+        db.dropSourceDao().getAll().observe(viewLifecycleOwner) { sources ->
+            latestSources = sources
             render()
         }
 
@@ -227,6 +234,35 @@ class MapFragment : Fragment() {
                 markerFolder.add(marker)
                 markerInfos += MarkerInfo(marker, "❓", r.hint)
             }
+        }
+
+        // Pins from drop-source registries — entries not yet scanned and not already pinned above.
+        val alreadyPinnedIds = latestCaches.mapTo(HashSet()) { it.cacheId }
+        for (entry in DropEntryCache.allEntries()) {
+            // Skip if already shown via a scanned cache pin, or status indicates removed
+            if (alreadyPinnedIds.contains(entry.id)) continue
+            if (entry.status == "removed") continue
+            val point = GeoPoint(entry.lat, entry.lng)
+            points += point
+            val label = entry.hint ?: entry.label ?: entry.id.take(8)
+            // Visual distinction by status: "broken" = grey pin, "working" = normal antenna icon
+            val icon = when (entry.status) {
+                "broken" -> "📵"
+                "unknown", null -> "📡"
+                else -> "📡"  // working
+            }
+            val marker = Marker(binding.map).apply {
+                position = point
+                title = label
+                snippet = entry.description
+                setOnMarkerClickListener { clickedMarker, _ ->
+                    if (clickedMarker.isInfoWindowShown) clickedMarker.closeInfoWindow()
+                    else clickedMarker.showInfoWindow()
+                    true
+                }
+            }
+            markerFolder.add(marker)
+            markerInfos += MarkerInfo(marker, icon, label)
         }
 
         labelsShown = binding.map.zoomLevelDouble >= LABEL_ZOOM_THRESHOLD

--- a/app/src/main/java/com/github/mofosyne/tagdrop/MapFragment.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/MapFragment.kt
@@ -236,9 +236,10 @@ class MapFragment : Fragment() {
             }
         }
 
-        // Pins from drop-source registries — entries not yet scanned and not already pinned above.
+        // Pins from drop-source registries — only enabled sources, entries not yet scanned.
+        val enabledSourceIds = latestSources.filter { it.enabled }.mapTo(HashSet()) { it.id }
         val alreadyPinnedIds = latestCaches.mapTo(HashSet()) { it.cacheId }
-        for (entry in DropEntryCache.allEntries()) {
+        for (entry in DropEntryCache.allEntries(enabledSourceIds)) {
             // Skip if already shown via a scanned cache pin, or status indicates removed
             if (alreadyPinnedIds.contains(entry.id)) continue
             if (entry.status == "removed") continue

--- a/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
@@ -30,7 +30,10 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
+import com.github.mofosyne.tagdrop.data.DropEntryCache
+import com.github.mofosyne.tagdrop.data.SourceFetcher
 import com.github.mofosyne.tagdrop.data.db.AppDatabase
+import com.github.mofosyne.tagdrop.data.db.DropSource
 import com.github.mofosyne.tagdrop.data.db.FoundCache
 import com.github.mofosyne.tagdrop.data.db.RetainedKey
 import com.github.mofosyne.tagdrop.data.db.ScannedPaper
@@ -535,6 +538,31 @@ class ReceiveActivity : AppCompatActivity() {
             return
         }
 
+        // If the payload advertises a drop-source registry, offer to add it
+        state.sourceUrl?.let { url ->
+            val accepted = askAddSource(url, state.hint)
+            if (accepted) {
+                val name = state.hint ?: url
+                val db = AppDatabase.get(this)
+                val sourceId = db.dropSourceDao().insert(DropSource(name = name, url = url))
+                lifecycleScope.launch {
+                    val json = SourceFetcher.fetch(url)
+                    if (json != null) {
+                        DropEntryCache.update(sourceId, json.drops)
+                        db.dropSourceDao().update(
+                            DropSource(
+                                id             = sourceId,
+                                name           = json.label ?: name,
+                                url            = url,
+                                lastFetchedAt  = System.currentTimeMillis(),
+                                entryCount     = json.drops.size
+                            )
+                        )
+                    }
+                }
+            }
+        }
+
         val cacheId = state.cacheId ?: return
         val blob = state.pendingOverrideBlob
 
@@ -666,6 +694,24 @@ class ReceiveActivity : AppCompatActivity() {
             toast(getString(R.string.awaiting_key))
             updateDisplay()
         }
+    }
+
+    /**
+     * Suspends while showing an AlertDialog asking the user to add a new drop source.
+     * Returns true if the user tapped Add, false otherwise.
+     */
+    private suspend fun askAddSource(url: String, hint: String?): Boolean {
+        val deferred = CompletableDeferred<Boolean>()
+        runOnUiThread {
+            AlertDialog.Builder(this)
+                .setTitle(getString(R.string.add_source_title))
+                .setMessage(getString(R.string.add_source_message, url))
+                .setPositiveButton(getString(R.string.add_source_confirm)) { _, _ -> deferred.complete(true) }
+                .setNegativeButton(android.R.string.cancel) { _, _ -> deferred.complete(false) }
+                .setOnCancelListener { deferred.complete(false) }
+                .show()
+        }
+        return deferred.await()
     }
 
     /**

--- a/app/src/main/java/com/github/mofosyne/tagdrop/SourcesActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/SourcesActivity.kt
@@ -8,6 +8,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.LinearLayout
+import android.widget.PopupMenu
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -37,8 +39,11 @@ class SourcesActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivitySourcesBinding
     private val adapter = SourceAdapter(
-        onToggle = { source -> toggleSource(source) },
-        onDelete = { source -> confirmDelete(source) }
+        onRefresh  = { source -> refreshSource(source) },
+        onToggle   = { source -> toggleSource(source) },
+        onEnable   = { source -> setEnabled(source, true) },
+        onDisable  = { source -> setEnabled(source, false) },
+        onDelete   = { source -> confirmDelete(source) }
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -132,15 +137,33 @@ class SourcesActivity : AppCompatActivity() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
-        R.id.action_refresh_all -> { refreshAll(); true }
+        R.id.action_refresh_all    -> { refreshAll(); true }
+        R.id.action_reload_defaults -> { reloadDefaults(); true }
         else -> super.onOptionsItemSelected(item)
     }
 
-    private fun toggleSource(source: DropSource) {
+    private fun refreshSource(source: DropSource) {
+        if (!source.enabled) return
         lifecycleScope.launch {
-            val updated = source.copy(enabled = !source.enabled)
-            AppDatabase.get(this@SourcesActivity).dropSourceDao().update(updated)
-            if (!updated.enabled) DropEntryCache.remove(source.id)
+            val db = AppDatabase.get(this@SourcesActivity)
+            val json = SourceFetcher.fetch(source.url) ?: return@launch
+            DropEntryCache.update(source.id, json.drops)
+            db.dropSourceDao().update(
+                source.copy(
+                    name          = json.label ?: source.name,
+                    lastFetchedAt = System.currentTimeMillis(),
+                    entryCount    = json.drops.size
+                )
+            )
+        }
+    }
+
+    private fun toggleSource(source: DropSource) = setEnabled(source, !source.enabled)
+
+    private fun setEnabled(source: DropSource, enabled: Boolean) {
+        lifecycleScope.launch {
+            AppDatabase.get(this@SourcesActivity).dropSourceDao().update(source.copy(enabled = enabled))
+            if (!enabled) DropEntryCache.remove(source.id)
         }
     }
 
@@ -162,11 +185,25 @@ class SourcesActivity : AppCompatActivity() {
         }
     }
 
+    private fun reloadDefaults() {
+        lifecycleScope.launch {
+            val db = AppDatabase.get(this@SourcesActivity)
+            val existing = db.dropSourceDao().getAllOnce().map { it.url }.toSet()
+            DEFAULT_SOURCES.forEach { source ->
+                if (source.url !in existing) {
+                    db.dropSourceDao().insert(source)
+                }
+            }
+            Toast.makeText(this@SourcesActivity,
+                R.string.source_reload_defaults_done, Toast.LENGTH_SHORT).show()
+        }
+    }
+
     private fun confirmDelete(source: DropSource) {
         AlertDialog.Builder(this)
             .setTitle(R.string.delete_confirm_title)
             .setMessage(getString(R.string.delete_confirm_message, source.name))
-            .setPositiveButton(R.string.button_delete) { _, _ ->
+            .setPositiveButton(R.string.source_action_delete) { _, _ ->
                 lifecycleScope.launch {
                     AppDatabase.get(this@SourcesActivity).dropSourceDao().delete(source)
                     DropEntryCache.remove(source.id)
@@ -179,8 +216,11 @@ class SourcesActivity : AppCompatActivity() {
     // ---- Adapter ----
 
     private class SourceAdapter(
-        private val onToggle: (DropSource) -> Unit,
-        private val onDelete: (DropSource) -> Unit
+        private val onRefresh : (DropSource) -> Unit,
+        private val onToggle  : (DropSource) -> Unit,
+        private val onEnable  : (DropSource) -> Unit,
+        private val onDisable : (DropSource) -> Unit,
+        private val onDelete  : (DropSource) -> Unit
     ) : RecyclerView.Adapter<SourceAdapter.ViewHolder>() {
 
         private var items: List<DropSource> = emptyList()
@@ -218,15 +258,48 @@ class SourcesActivity : AppCompatActivity() {
                 } else {
                     binding.root.context.getString(R.string.source_never_fetched)
                 }
-                binding.switchSourceEnabled.isChecked = source.enabled
-                binding.switchSourceEnabled.setOnCheckedChangeListener(null)
-                binding.switchSourceEnabled.setOnCheckedChangeListener { _, _ -> onToggle(source) }
-                binding.buttonDeleteSource.setOnClickListener { onDelete(source) }
+
+                // Refresh button — greyed out and non-interactive when disabled
+                binding.buttonRefreshSource.isEnabled = source.enabled
+                binding.buttonRefreshSource.alpha = if (source.enabled) 1f else 0.3f
+                binding.buttonRefreshSource.setOnClickListener { onRefresh(source) }
+
+                // Map toggle button — reflects enabled state visually
+                binding.buttonToggleMap.alpha = if (source.enabled) 1f else 0.5f
+                binding.buttonToggleMap.setOnClickListener { onToggle(source) }
+
+                // "..." overflow popup menu
+                binding.buttonSourceMenu.setOnClickListener { anchor ->
+                    val popup = PopupMenu(anchor.context, anchor)
+                    popup.menuInflater.inflate(R.menu.menu_source_item, popup.menu)
+                    popup.menu.findItem(R.id.action_source_enable)?.isVisible  = !source.enabled
+                    popup.menu.findItem(R.id.action_source_disable)?.isVisible = source.enabled
+                    popup.setOnMenuItemClickListener { item ->
+                        when (item.itemId) {
+                            R.id.action_source_enable  -> { onEnable(source);  true }
+                            R.id.action_source_disable -> { onDisable(source); true }
+                            R.id.action_source_delete  -> { onDelete(source);  true }
+                            else -> false
+                        }
+                    }
+                    popup.show()
+                }
             }
         }
 
         companion object {
             private fun dateFormat() = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
         }
+    }
+
+    companion object {
+        private val DEFAULT_SOURCES = listOf(
+            DropSource(name = "TagDrop Community Drops",
+                       url  = "https://mofosyne.github.io/tagdrop/db/drops.json",
+                       enabled = false),
+            DropSource(name = "TagDrop Demo Drops",
+                       url  = "https://mofosyne.github.io/tagdrop/db/drops_demo.json",
+                       enabled = false)
+        )
     }
 }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/SourcesActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/SourcesActivity.kt
@@ -6,6 +6,8 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.LinearLayout
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -68,6 +70,58 @@ class SourcesActivity : AppCompatActivity() {
             binding.textEmpty.visibility = if (sources.isEmpty()) View.VISIBLE else View.GONE
             binding.recyclerSources.visibility = if (sources.isEmpty()) View.GONE else View.VISIBLE
         }
+
+        binding.fabAddSource.setOnClickListener { addSourceManually() }
+    }
+
+    private fun addSourceManually() {
+        val padding = (16 * resources.displayMetrics.density).toInt()
+        val urlInput = EditText(this).apply {
+            hint = "https://example.com/drops.json"
+            inputType = android.text.InputType.TYPE_CLASS_TEXT or
+                        android.text.InputType.TYPE_TEXT_VARIATION_URI
+            setSingleLine()
+        }
+        val nameInput = EditText(this).apply {
+            hint = getString(R.string.source_name_hint)
+            setSingleLine()
+        }
+        val container = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(padding, padding / 2, padding, 0)
+            addView(nameInput)
+            addView(urlInput)
+        }
+
+        AlertDialog.Builder(this)
+            .setTitle(R.string.add_source_manually)
+            .setView(container)
+            .setPositiveButton(R.string.add_source_confirm) { _, _ ->
+                val url = urlInput.text.toString().trim()
+                val name = nameInput.text.toString().trim().ifEmpty { url }
+                if (url.isNotEmpty()) {
+                    lifecycleScope.launch {
+                        val db = AppDatabase.get(this@SourcesActivity)
+                        val sourceId = db.dropSourceDao().insert(
+                            DropSource(name = name, url = url, enabled = true)
+                        )
+                        val json = SourceFetcher.fetch(url)
+                        if (json != null) {
+                            DropEntryCache.update(sourceId, json.drops)
+                            db.dropSourceDao().update(
+                                DropSource(id = sourceId,
+                                           name = json.label ?: name,
+                                           url = url,
+                                           enabled = true,
+                                           lastFetchedAt = System.currentTimeMillis(),
+                                           entryCount = json.drops.size)
+                            )
+                        }
+                    }
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
     }
 
     override fun onSupportNavigateUp(): Boolean { finish(); return true }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/SourcesActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/SourcesActivity.kt
@@ -1,0 +1,178 @@
+package com.github.mofosyne.tagdrop
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.github.mofosyne.tagdrop.data.DropEntryCache
+import com.github.mofosyne.tagdrop.data.SourceFetcher
+import com.github.mofosyne.tagdrop.data.db.AppDatabase
+import com.github.mofosyne.tagdrop.data.db.DropSource
+import com.github.mofosyne.tagdrop.databinding.ActivitySourcesBinding
+import com.github.mofosyne.tagdrop.databinding.ItemSourceBinding
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Lists all registered drop sources and lets the user toggle, refresh, or delete each one.
+ * Enabled sources are fetched on refresh; their entries populate [DropEntryCache] and appear
+ * as pins on the map tab.
+ */
+class SourcesActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivitySourcesBinding
+    private val adapter = SourceAdapter(
+        onToggle = { source -> toggleSource(source) },
+        onDelete = { source -> confirmDelete(source) }
+    )
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+        binding = ActivitySourcesBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updatePadding(
+                left   = systemBars.left,
+                top    = systemBars.top,
+                right  = systemBars.right,
+                bottom = systemBars.bottom
+            )
+            insets
+        }
+
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        title = getString(R.string.title_sources)
+
+        binding.recyclerSources.layoutManager = LinearLayoutManager(this)
+        binding.recyclerSources.adapter = adapter
+
+        AppDatabase.get(this).dropSourceDao().getAll().observe(this) { sources ->
+            adapter.submitList(sources)
+            binding.textEmpty.visibility = if (sources.isEmpty()) View.VISIBLE else View.GONE
+            binding.recyclerSources.visibility = if (sources.isEmpty()) View.GONE else View.VISIBLE
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean { finish(); return true }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_sources, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
+        R.id.action_refresh_all -> { refreshAll(); true }
+        else -> super.onOptionsItemSelected(item)
+    }
+
+    private fun toggleSource(source: DropSource) {
+        lifecycleScope.launch {
+            val updated = source.copy(enabled = !source.enabled)
+            AppDatabase.get(this@SourcesActivity).dropSourceDao().update(updated)
+            if (!updated.enabled) DropEntryCache.remove(source.id)
+        }
+    }
+
+    private fun refreshAll() {
+        lifecycleScope.launch {
+            val db = AppDatabase.get(this@SourcesActivity)
+            val sources = db.dropSourceDao().getEnabled()
+            for (source in sources) {
+                val json = SourceFetcher.fetch(source.url) ?: continue
+                DropEntryCache.update(source.id, json.drops)
+                db.dropSourceDao().update(
+                    source.copy(
+                        name          = json.label ?: source.name,
+                        lastFetchedAt = System.currentTimeMillis(),
+                        entryCount    = json.drops.size
+                    )
+                )
+            }
+        }
+    }
+
+    private fun confirmDelete(source: DropSource) {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.delete_confirm_title)
+            .setMessage(getString(R.string.delete_confirm_message, source.name))
+            .setPositiveButton(R.string.button_delete) { _, _ ->
+                lifecycleScope.launch {
+                    AppDatabase.get(this@SourcesActivity).dropSourceDao().delete(source)
+                    DropEntryCache.remove(source.id)
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    // ---- Adapter ----
+
+    private class SourceAdapter(
+        private val onToggle: (DropSource) -> Unit,
+        private val onDelete: (DropSource) -> Unit
+    ) : RecyclerView.Adapter<SourceAdapter.ViewHolder>() {
+
+        private var items: List<DropSource> = emptyList()
+
+        fun submitList(list: List<DropSource>) {
+            items = list
+            notifyDataSetChanged()
+        }
+
+        override fun getItemCount() = items.size
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+            val binding = ItemSourceBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+            return ViewHolder(binding)
+        }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            holder.bind(items[position])
+        }
+
+        inner class ViewHolder(private val binding: ItemSourceBinding) :
+            RecyclerView.ViewHolder(binding.root) {
+
+            fun bind(source: DropSource) {
+                binding.textSourceName.text = source.name
+                binding.textSourceUrl.text = source.url
+                binding.textSourceEntryCount.text = binding.root.context.getString(
+                    R.string.source_entry_count, source.entryCount
+                )
+                binding.textSourceLastFetched.text = if (source.lastFetchedAt != null) {
+                    binding.root.context.getString(
+                        R.string.source_last_fetched,
+                        dateFormat().format(Date(source.lastFetchedAt))
+                    )
+                } else {
+                    binding.root.context.getString(R.string.source_never_fetched)
+                }
+                binding.switchSourceEnabled.isChecked = source.enabled
+                binding.switchSourceEnabled.setOnCheckedChangeListener(null)
+                binding.switchSourceEnabled.setOnCheckedChangeListener { _, _ -> onToggle(source) }
+                binding.buttonDeleteSource.setOnClickListener { onDelete(source) }
+            }
+        }
+
+        companion object {
+            private fun dateFormat() = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+        }
+    }
+}

--- a/app/src/main/java/com/github/mofosyne/tagdrop/SourcesActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/SourcesActivity.kt
@@ -6,9 +6,12 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.PopupMenu
+import android.widget.ScrollView
+import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AlertDialog
@@ -20,6 +23,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.github.mofosyne.tagdrop.data.DropEntryCache
+import com.github.mofosyne.tagdrop.data.RelatedSource
 import com.github.mofosyne.tagdrop.data.SourceFetcher
 import com.github.mofosyne.tagdrop.data.db.AppDatabase
 import com.github.mofosyne.tagdrop.data.db.DropSource
@@ -137,8 +141,9 @@ class SourcesActivity : AppCompatActivity() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
-        R.id.action_refresh_all    -> { refreshAll(); true }
+        R.id.action_refresh_all     -> { refreshAll(); true }
         R.id.action_reload_defaults -> { reloadDefaults(); true }
+        R.id.action_browse_sources  -> { browseRecommended(); true }
         else -> super.onOptionsItemSelected(item)
     }
 
@@ -155,6 +160,12 @@ class SourcesActivity : AppCompatActivity() {
                     entryCount    = json.drops.size
                 )
             )
+            if (json.relatedSources.isNotEmpty()) {
+                showSourcePickerDialog(
+                    getString(R.string.source_related_title, json.label ?: source.name),
+                    json.relatedSources
+                )
+            }
         }
     }
 
@@ -183,6 +194,81 @@ class SourcesActivity : AppCompatActivity() {
                 )
             }
         }
+    }
+
+    private fun browseRecommended() {
+        lifecycleScope.launch {
+            val dir = SourceFetcher.fetchDirectory()
+            if (dir == null) {
+                Toast.makeText(this@SourcesActivity,
+                    R.string.source_browse_failed, Toast.LENGTH_SHORT).show()
+                return@launch
+            }
+            showSourcePickerDialog(dir.label ?: getString(R.string.source_browse_title), dir.sources)
+        }
+    }
+
+    private suspend fun showSourcePickerDialog(title: String, candidates: List<RelatedSource>) {
+        if (candidates.isEmpty()) {
+            Toast.makeText(this, R.string.source_browse_none, Toast.LENGTH_SHORT).show()
+            return
+        }
+        val db = AppDatabase.get(this)
+        val existingUrls = db.dropSourceDao().getAllOnce().map { it.url }.toSet()
+        val newCandidates = candidates.filter { it.url !in existingUrls }
+        if (newCandidates.isEmpty()) {
+            Toast.makeText(this, R.string.source_browse_all_added, Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val padding = (16 * resources.displayMetrics.density).toInt()
+        val checks = newCandidates.map { source ->
+            CheckBox(this).apply {
+                isChecked = true
+                text = source.name
+            }
+        }
+        val scroll = ScrollView(this)
+        val container = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(padding, padding / 2, padding, padding / 2)
+            newCandidates.forEachIndexed { i, source ->
+                addView(checks[i])
+                if (source.description != null) {
+                    addView(TextView(this@SourcesActivity).apply {
+                        text = source.description
+                        textSize = 12f
+                        setTextColor(0xFF888888.toInt())
+                        setPadding(padding * 2, 0, 0, padding / 2)
+                    })
+                }
+            }
+        }
+        scroll.addView(container)
+
+        AlertDialog.Builder(this)
+            .setTitle(title)
+            .setView(scroll)
+            .setPositiveButton(R.string.source_browse_add) { _, _ ->
+                lifecycleScope.launch {
+                    var added = 0
+                    newCandidates.forEachIndexed { i, source ->
+                        if (checks[i].isChecked) {
+                            db.dropSourceDao().insert(
+                                DropSource(name = source.name, url = source.url, enabled = false)
+                            )
+                            added++
+                        }
+                    }
+                    if (added > 0) {
+                        Toast.makeText(this@SourcesActivity,
+                            resources.getQuantityString(R.plurals.source_browse_added, added, added),
+                            Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
     }
 
     private fun reloadDefaults() {

--- a/app/src/main/java/com/github/mofosyne/tagdrop/SourcesActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/SourcesActivity.kt
@@ -44,7 +44,6 @@ class SourcesActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySourcesBinding
     private val adapter = SourceAdapter(
         onRefresh  = { source -> refreshSource(source) },
-        onToggle   = { source -> toggleSource(source) },
         onEnable   = { source -> setEnabled(source, true) },
         onDisable  = { source -> setEnabled(source, false) },
         onDelete   = { source -> confirmDelete(source) }
@@ -151,13 +150,20 @@ class SourcesActivity : AppCompatActivity() {
         if (!source.enabled) return
         lifecycleScope.launch {
             val db = AppDatabase.get(this@SourcesActivity)
-            val json = SourceFetcher.fetch(source.url) ?: return@launch
+            val json = SourceFetcher.fetch(source.url)
+            if (json == null) {
+                db.dropSourceDao().update(source.copy(lastFetchFailed = true))
+                Toast.makeText(this@SourcesActivity,
+                    R.string.source_fetch_failed, Toast.LENGTH_SHORT).show()
+                return@launch
+            }
             DropEntryCache.update(source.id, json.drops)
             db.dropSourceDao().update(
                 source.copy(
-                    name          = json.label ?: source.name,
-                    lastFetchedAt = System.currentTimeMillis(),
-                    entryCount    = json.drops.size
+                    name            = json.label ?: source.name,
+                    lastFetchedAt   = System.currentTimeMillis(),
+                    entryCount      = json.drops.size,
+                    lastFetchFailed = false
                 )
             )
             if (json.relatedSources.isNotEmpty()) {
@@ -168,8 +174,6 @@ class SourcesActivity : AppCompatActivity() {
             }
         }
     }
-
-    private fun toggleSource(source: DropSource) = setEnabled(source, !source.enabled)
 
     private fun setEnabled(source: DropSource, enabled: Boolean) {
         lifecycleScope.launch {
@@ -182,16 +186,27 @@ class SourcesActivity : AppCompatActivity() {
         lifecycleScope.launch {
             val db = AppDatabase.get(this@SourcesActivity)
             val sources = db.dropSourceDao().getEnabled()
+            var anyFailed = false
             for (source in sources) {
-                val json = SourceFetcher.fetch(source.url) ?: continue
+                val json = SourceFetcher.fetch(source.url)
+                if (json == null) {
+                    db.dropSourceDao().update(source.copy(lastFetchFailed = true))
+                    anyFailed = true
+                    continue
+                }
                 DropEntryCache.update(source.id, json.drops)
                 db.dropSourceDao().update(
                     source.copy(
-                        name          = json.label ?: source.name,
-                        lastFetchedAt = System.currentTimeMillis(),
-                        entryCount    = json.drops.size
+                        name            = json.label ?: source.name,
+                        lastFetchedAt   = System.currentTimeMillis(),
+                        entryCount      = json.drops.size,
+                        lastFetchFailed = false
                     )
                 )
+            }
+            if (anyFailed) {
+                Toast.makeText(this@SourcesActivity,
+                    R.string.source_fetch_some_failed, Toast.LENGTH_SHORT).show()
             }
         }
     }
@@ -303,7 +318,6 @@ class SourcesActivity : AppCompatActivity() {
 
     private class SourceAdapter(
         private val onRefresh : (DropSource) -> Unit,
-        private val onToggle  : (DropSource) -> Unit,
         private val onEnable  : (DropSource) -> Unit,
         private val onDisable : (DropSource) -> Unit,
         private val onDelete  : (DropSource) -> Unit
@@ -331,30 +345,41 @@ class SourcesActivity : AppCompatActivity() {
             RecyclerView.ViewHolder(binding.root) {
 
             fun bind(source: DropSource) {
+                val ctx = binding.root.context
+
                 binding.textSourceName.text = source.name
                 binding.textSourceUrl.text = source.url
-                binding.textSourceEntryCount.text = binding.root.context.getString(
+                binding.textSourceEntryCount.text = ctx.getString(
                     R.string.source_entry_count, source.entryCount
                 )
-                binding.textSourceLastFetched.text = if (source.lastFetchedAt != null) {
-                    binding.root.context.getString(
-                        R.string.source_last_fetched,
-                        dateFormat().format(Date(source.lastFetchedAt))
+                binding.textSourceLastFetched.text = when {
+                    source.lastFetchFailed -> ctx.getString(R.string.source_fetch_failed_label)
+                    source.lastFetchedAt != null -> ctx.getString(
+                        R.string.source_last_fetched, dateFormat().format(Date(source.lastFetchedAt))
                     )
-                } else {
-                    binding.root.context.getString(R.string.source_never_fetched)
+                    else -> ctx.getString(R.string.source_never_fetched)
                 }
 
-                // Refresh button — greyed out and non-interactive when disabled
+                // Grey out content area when disabled; only "..." stays fully visible
+                val contentAlpha = if (source.enabled) 1f else 0.4f
+                binding.textSourceName.alpha = contentAlpha
+                binding.textSourceUrl.alpha = contentAlpha
+                binding.textSourceEntryCount.alpha = contentAlpha
+                binding.textSourceLastFetched.alpha = contentAlpha
+                binding.textSourceDisabledLabel.visibility =
+                    if (source.enabled) View.GONE else View.VISIBLE
+
+                // Refresh button — inactive when source disabled
                 binding.buttonRefreshSource.isEnabled = source.enabled
-                binding.buttonRefreshSource.alpha = if (source.enabled) 1f else 0.3f
+                binding.buttonRefreshSource.alpha = if (source.enabled) 1f else 0.25f
                 binding.buttonRefreshSource.setOnClickListener { onRefresh(source) }
 
-                // Map toggle button — reflects enabled state visually
-                binding.buttonToggleMap.alpha = if (source.enabled) 1f else 0.5f
-                binding.buttonToggleMap.setOnClickListener { onToggle(source) }
+                // Map pin indicator — inactive when source disabled (display only, not a toggle)
+                binding.buttonToggleMap.isEnabled = source.enabled
+                binding.buttonToggleMap.alpha = if (source.enabled) 1f else 0.25f
+                binding.buttonToggleMap.setOnClickListener(null)
 
-                // "..." overflow popup menu
+                // "..." overflow popup — always active
                 binding.buttonSourceMenu.setOnClickListener { anchor ->
                     val popup = PopupMenu(anchor.context, anchor)
                     popup.menuInflater.inflate(R.menu.menu_source_item, popup.menu)

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/DropEntry.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/DropEntry.kt
@@ -1,0 +1,32 @@
+package com.github.mofosyne.tagdrop.data
+
+/**
+ * One drop location from a [DropSourceJson] registry file (SPEC §17).
+ *
+ * Field names match the TagDrop wire format (SPEC §3) so that a drops.json entry can be
+ * generated mechanically from a scan with minimal extra input:
+ * - [id]            — cache_id hex (16 chars), SHA-256(content)[0:8], matches Content's cacheId
+ * - [lat]/[lng]     — WGS-84 coordinates (same naming as the wire format's keys 26/27)
+ * - [hint]          — short location clue / name (wire format key 3)
+ * - [description]   — longer location description, e.g. directions (wire format key 40)
+ * - [status]        — "working" | "unknown" | "broken" | "removed" (default "unknown")
+ * - [statusUpdated] — ISO 8601 date of last status check
+ * - [dropType]      — type tag; default "tagdrop", allows future extensibility
+ */
+data class DropEntry(
+    val id: String,
+    val lat: Double,
+    val lng: Double,
+    val hint: String? = null,
+    val description: String? = null,
+    val status: String? = null,        // "working" | "unknown" | "broken" | "removed"
+    val statusUpdated: String? = null,
+    val dropType: String? = null       // default "tagdrop"
+)
+
+/** Top-level shape of a drop-source JSON registry file (SPEC §17). */
+data class DropSourceJson(
+    val version: Int,
+    val label: String? = null,
+    val drops: List<DropEntry> = emptyList()
+)

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/DropEntry.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/DropEntry.kt
@@ -24,9 +24,29 @@ data class DropEntry(
     val dropType: String? = null       // default "tagdrop"
 )
 
+/**
+ * One entry in a sources directory (SPEC §17 — sources.json schema).
+ * Allows a registry to recommend other registries, or the official
+ * TagDrop sources list to advertise known community registries.
+ */
+data class RelatedSource(
+    val name: String,
+    val url: String,
+    val description: String? = null,
+    val maintainer: String? = null
+)
+
 /** Top-level shape of a drop-source JSON registry file (SPEC §17). */
 data class DropSourceJson(
     val version: Int,
     val label: String? = null,
-    val drops: List<DropEntry> = emptyList()
+    val drops: List<DropEntry> = emptyList(),
+    val relatedSources: List<RelatedSource> = emptyList()
+)
+
+/** Top-level shape of the TagDrop known-sources directory (docs/db/sources.json). */
+data class SourcesDirectoryJson(
+    val version: Int,
+    val label: String? = null,
+    val sources: List<RelatedSource> = emptyList()
 )

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/DropEntryCache.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/DropEntryCache.kt
@@ -15,5 +15,10 @@ object DropEntryCache {
         entries.remove(sourceId)
     }
 
+    /** All entries across all sources. */
     fun allEntries(): List<DropEntry> = entries.values.flatten()
+
+    /** Entries from the given subset of source IDs only (e.g. only enabled sources). */
+    fun allEntries(sourceIds: Set<Long>): List<DropEntry> =
+        entries.filterKeys { it in sourceIds }.values.flatten()
 }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/DropEntryCache.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/DropEntryCache.kt
@@ -1,0 +1,19 @@
+package com.github.mofosyne.tagdrop.data
+
+/**
+ * In-memory cache of drop entries fetched from enabled drop sources.
+ * Keyed by source ID so a single source's entries can be replaced or evicted atomically.
+ */
+object DropEntryCache {
+    private val entries = mutableMapOf<Long, List<DropEntry>>() // sourceId -> entries
+
+    fun update(sourceId: Long, drops: List<DropEntry>) {
+        entries[sourceId] = drops
+    }
+
+    fun remove(sourceId: Long) {
+        entries.remove(sourceId)
+    }
+
+    fun allEntries(): List<DropEntry> = entries.values.flatten()
+}

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/SourceFetcher.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/SourceFetcher.kt
@@ -1,0 +1,49 @@
+package com.github.mofosyne.tagdrop.data
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Fetches and parses a drop-source JSON registry file (SPEC §17).
+ * Uses only [HttpURLConnection] and [JSONObject] — no third-party HTTP or JSON libraries.
+ * Returns null on any network or parse error.
+ *
+ * JSON field names match the TagDrop wire format where applicable:
+ *   `hint` = key 3, `description` = key 40, `lat` = key 26, `lng` = key 27.
+ */
+object SourceFetcher {
+    suspend fun fetch(url: String): DropSourceJson? = withContext(Dispatchers.IO) {
+        try {
+            val connection = URL(url).openConnection() as HttpURLConnection
+            connection.connectTimeout = 10_000
+            connection.readTimeout = 10_000
+            val text = connection.inputStream.bufferedReader().readText()
+            connection.disconnect()
+            val json = JSONObject(text)
+            val dropsArray = json.optJSONArray("drops") ?: return@withContext null
+            val drops = (0 until dropsArray.length()).map { i ->
+                val obj = dropsArray.getJSONObject(i)
+                DropEntry(
+                    id            = obj.getString("id"),
+                    lat           = obj.getDouble("lat"),
+                    lng           = obj.getDouble("lng"),
+                    hint          = obj.optString("hint").takeIf { it.isNotEmpty() },
+                    description   = obj.optString("description").takeIf { it.isNotEmpty() },
+                    status        = obj.optString("status").takeIf { it.isNotEmpty() },
+                    statusUpdated = obj.optString("status_updated").takeIf { it.isNotEmpty() },
+                    dropType      = obj.optString("drop_type").takeIf { it.isNotEmpty() }
+                )
+            }
+            DropSourceJson(
+                version = json.optInt("version", 1),
+                label   = json.optString("label").takeIf { it.isNotEmpty() },
+                drops   = drops
+            )
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/SourceFetcher.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/SourceFetcher.kt
@@ -7,7 +7,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 /**
- * Fetches and parses a drop-source JSON registry file (SPEC §17).
+ * Fetches and parses drop-source JSON files (SPEC §17).
  * Uses only [HttpURLConnection] and [JSONObject] — no third-party HTTP or JSON libraries.
  * Returns null on any network or parse error.
  *
@@ -15,13 +15,12 @@ import java.net.URL
  *   `hint` = key 3, `description` = key 40, `lat` = key 26, `lng` = key 27.
  */
 object SourceFetcher {
+
+    const val OFFICIAL_SOURCES_URL = "https://mofosyne.github.io/tagdrop/db/sources.json"
+
     suspend fun fetch(url: String): DropSourceJson? = withContext(Dispatchers.IO) {
         try {
-            val connection = URL(url).openConnection() as HttpURLConnection
-            connection.connectTimeout = 10_000
-            connection.readTimeout = 10_000
-            val text = connection.inputStream.bufferedReader().readText()
-            connection.disconnect()
+            val text = getText(url) ?: return@withContext null
             val json = JSONObject(text)
             val dropsArray = json.optJSONArray("drops") ?: return@withContext null
             val drops = (0 until dropsArray.length()).map { i ->
@@ -37,12 +36,67 @@ object SourceFetcher {
                     dropType      = obj.optString("drop_type").takeIf { it.isNotEmpty() }
                 )
             }
+            val related = json.optJSONArray("related_sources")?.let { arr ->
+                (0 until arr.length()).mapNotNull { i ->
+                    val obj = arr.getJSONObject(i)
+                    val name = obj.optString("name").takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+                    val u    = obj.optString("url").takeIf  { it.isNotEmpty() } ?: return@mapNotNull null
+                    RelatedSource(
+                        name        = name,
+                        url         = u,
+                        description = obj.optString("description").takeIf { it.isNotEmpty() },
+                        maintainer  = obj.optString("maintainer").takeIf { it.isNotEmpty() }
+                    )
+                }
+            } ?: emptyList()
             DropSourceJson(
-                version = json.optInt("version", 1),
-                label   = json.optString("label").takeIf { it.isNotEmpty() },
-                drops   = drops
+                version        = json.optInt("version", 1),
+                label          = json.optString("label").takeIf { it.isNotEmpty() },
+                drops          = drops,
+                relatedSources = related
             )
         } catch (e: Exception) {
+            null
+        }
+    }
+
+    suspend fun fetchDirectory(url: String = OFFICIAL_SOURCES_URL): SourcesDirectoryJson? =
+        withContext(Dispatchers.IO) {
+            try {
+                val text = getText(url) ?: return@withContext null
+                val json = JSONObject(text)
+                val arr = json.optJSONArray("sources") ?: return@withContext null
+                val sources = (0 until arr.length()).mapNotNull { i ->
+                    val obj = arr.getJSONObject(i)
+                    val name = obj.optString("name").takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+                    val u    = obj.optString("url").takeIf  { it.isNotEmpty() } ?: return@mapNotNull null
+                    RelatedSource(
+                        name        = name,
+                        url         = u,
+                        description = obj.optString("description").takeIf { it.isNotEmpty() },
+                        maintainer  = obj.optString("maintainer").takeIf { it.isNotEmpty() }
+                    )
+                }
+                SourcesDirectoryJson(
+                    version = json.optInt("version", 1),
+                    label   = json.optString("label").takeIf { it.isNotEmpty() },
+                    sources = sources
+                )
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+    private fun getText(url: String): String? {
+        val connection = URL(url).openConnection() as HttpURLConnection
+        connection.connectTimeout = 10_000
+        connection.readTimeout = 10_000
+        return try {
+            val text = connection.inputStream.bufferedReader().readText()
+            connection.disconnect()
+            text
+        } catch (e: Exception) {
+            connection.disconnect()
             null
         }
     }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
@@ -216,10 +216,11 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
-        // Default sources seeded into every fresh install.
+        // Default sources seeded into every fresh install — all disabled by default.
         private val DEFAULT_SOURCES = listOf(
             DropSource(name = "TagDrop Community Drops",
-                       url  = "https://mofosyne.github.io/tagdrop/db/drops.json"),
+                       url  = "https://mofosyne.github.io/tagdrop/db/drops.json",
+                       enabled = false),
             DropSource(name = "TagDrop Demo Drops",
                        url  = "https://mofosyne.github.io/tagdrop/db/drops_demo.json",
                        enabled = false)

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [FoundCache::class, ScannedPaper::class, RetainedKey::class, DropSource::class], version = 21, exportSchema = false)
+@Database(entities = [FoundCache::class, ScannedPaper::class, RetainedKey::class, DropSource::class], version = 22, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun cacheDao(): CacheDao
     abstract fun paperDao(): PaperDao
@@ -200,6 +200,12 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_21_22 = object : Migration(21, 22) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE drop_sources ADD COLUMN lastFetchFailed INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
         private val MIGRATION_20_21 = object : Migration(20, 21) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL(
@@ -254,7 +260,7 @@ abstract class AppDatabase : RoomDatabase() {
                 AppDatabase::class.java,
                 DB_NAME
             )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22)
             .addCallback(SEED_CALLBACK)
             .build().also { INSTANCE = it }
         }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
@@ -7,11 +7,12 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [FoundCache::class, ScannedPaper::class, RetainedKey::class], version = 20, exportSchema = false)
+@Database(entities = [FoundCache::class, ScannedPaper::class, RetainedKey::class, DropSource::class], version = 21, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun cacheDao(): CacheDao
     abstract fun paperDao(): PaperDao
     abstract fun keyDao(): KeyDao
+    abstract fun dropSourceDao(): DropSourceDao
 
     companion object {
         const val DB_NAME = "tagdrop.db"
@@ -199,13 +200,29 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_20_21 = object : Migration(20, 21) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """CREATE TABLE IF NOT EXISTS drop_sources (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        name TEXT NOT NULL,
+                        url TEXT NOT NULL,
+                        enabled INTEGER NOT NULL DEFAULT 1,
+                        addedAt INTEGER NOT NULL,
+                        lastFetchedAt INTEGER,
+                        entryCount INTEGER NOT NULL DEFAULT 0
+                    )"""
+                )
+            }
+        }
+
         fun get(context: Context): AppDatabase = INSTANCE ?: synchronized(this) {
             INSTANCE ?: Room.databaseBuilder(
                 context.applicationContext,
                 AppDatabase::class.java,
                 DB_NAME
             )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21)
             .build().also { INSTANCE = it }
         }
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
@@ -213,6 +213,21 @@ abstract class AppDatabase : RoomDatabase() {
                         entryCount INTEGER NOT NULL DEFAULT 0
                     )"""
                 )
+                // Seed default sources for existing installs (disabled by default).
+                val now = System.currentTimeMillis()
+                seedDefaultSources(db, now)
+            }
+        }
+
+        private fun seedDefaultSources(db: SupportSQLiteDatabase, now: Long) {
+            listOf(
+                "TagDrop Community Drops" to "https://mofosyne.github.io/tagdrop/db/drops.json",
+                "TagDrop Demo Drops"      to "https://mofosyne.github.io/tagdrop/db/drops_demo.json"
+            ).forEach { (name, url) ->
+                db.execSQL(
+                    "INSERT INTO drop_sources (name, url, enabled, addedAt, lastFetchedAt, entryCount) VALUES (?, ?, 0, ?, NULL, 0)",
+                    arrayOf(name, url, now)
+                )
             }
         }
 
@@ -229,13 +244,7 @@ abstract class AppDatabase : RoomDatabase() {
         private val SEED_CALLBACK = object : RoomDatabase.Callback() {
             override fun onCreate(db: SupportSQLiteDatabase) {
                 super.onCreate(db)
-                val now = System.currentTimeMillis()
-                DEFAULT_SOURCES.forEach { src ->
-                    db.execSQL(
-                        "INSERT INTO drop_sources (name, url, enabled, addedAt, lastFetchedAt, entryCount) VALUES (?, ?, ?, ?, NULL, 0)",
-                        arrayOf(src.name, src.url, if (src.enabled) 1 else 0, now)
-                    )
-                }
+                seedDefaultSources(db, System.currentTimeMillis())
             }
         }
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
@@ -216,6 +216,28 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        // Default sources seeded into every fresh install.
+        private val DEFAULT_SOURCES = listOf(
+            DropSource(name = "TagDrop Community Drops",
+                       url  = "https://mofosyne.github.io/tagdrop/db/drops.json"),
+            DropSource(name = "TagDrop Demo Drops",
+                       url  = "https://mofosyne.github.io/tagdrop/db/drops_demo.json",
+                       enabled = false)
+        )
+
+        private val SEED_CALLBACK = object : RoomDatabase.Callback() {
+            override fun onCreate(db: SupportSQLiteDatabase) {
+                super.onCreate(db)
+                val now = System.currentTimeMillis()
+                DEFAULT_SOURCES.forEach { src ->
+                    db.execSQL(
+                        "INSERT INTO drop_sources (name, url, enabled, addedAt, lastFetchedAt, entryCount) VALUES (?, ?, ?, ?, NULL, 0)",
+                        arrayOf(src.name, src.url, if (src.enabled) 1 else 0, now)
+                    )
+                }
+            }
+        }
+
         fun get(context: Context): AppDatabase = INSTANCE ?: synchronized(this) {
             INSTANCE ?: Room.databaseBuilder(
                 context.applicationContext,
@@ -223,6 +245,7 @@ abstract class AppDatabase : RoomDatabase() {
                 DB_NAME
             )
             .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21)
+            .addCallback(SEED_CALLBACK)
             .build().also { INSTANCE = it }
         }
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/DropSource.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/DropSource.kt
@@ -11,5 +11,6 @@ data class DropSource(
     val enabled: Boolean = true,
     val addedAt: Long = System.currentTimeMillis(),
     val lastFetchedAt: Long? = null,
-    val entryCount: Int = 0
+    val entryCount: Int = 0,
+    val lastFetchFailed: Boolean = false
 )

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/DropSource.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/DropSource.kt
@@ -1,0 +1,15 @@
+package com.github.mofosyne.tagdrop.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "drop_sources")
+data class DropSource(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name: String,
+    val url: String,
+    val enabled: Boolean = true,
+    val addedAt: Long = System.currentTimeMillis(),
+    val lastFetchedAt: Long? = null,
+    val entryCount: Int = 0
+)

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/DropSourceDao.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/DropSourceDao.kt
@@ -1,0 +1,27 @@
+package com.github.mofosyne.tagdrop.data.db
+
+import androidx.lifecycle.LiveData
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+
+@Dao
+interface DropSourceDao {
+    @Query("SELECT * FROM drop_sources ORDER BY addedAt DESC")
+    fun getAll(): LiveData<List<DropSource>>
+
+    @Query("SELECT * FROM drop_sources WHERE enabled = 1")
+    suspend fun getEnabled(): List<DropSource>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(source: DropSource): Long
+
+    @Update
+    suspend fun update(source: DropSource)
+
+    @Delete
+    suspend fun delete(source: DropSource)
+}

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/DropSourceDao.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/DropSourceDao.kt
@@ -13,6 +13,9 @@ interface DropSourceDao {
     @Query("SELECT * FROM drop_sources ORDER BY addedAt DESC")
     fun getAll(): LiveData<List<DropSource>>
 
+    @Query("SELECT * FROM drop_sources ORDER BY addedAt DESC")
+    suspend fun getAllOnce(): List<DropSource>
+
     @Query("SELECT * FROM drop_sources WHERE enabled = 1")
     suspend fun getEnabled(): List<DropSource>
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/SectorAssembler.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/SectorAssembler.kt
@@ -87,7 +87,8 @@ class SectorAssembler {
             val title: String? = null,
             val description: String? = null,
             val createdAt: Long? = null,
-            val pixelArt: Boolean = false
+            val pixelArt: Boolean = false,
+            val sourceUrl: String? = null
         ) : State()
 
         /** A Paper payload fully reassembled. [streamBytes] is the reassembled stream, stored as `ScannedPaper.cborBytes`. */
@@ -272,7 +273,8 @@ class SectorAssembler {
         title = content.title,
         description = content.description,
         createdAt = content.createdAt,
-        pixelArt = content.pixelArt
+        pixelArt = content.pixelArt,
+        sourceUrl = content.sourceUrl
     )
 
     /** Concatenates `sector_bytes` for indices `0..count-1` in order, or null if any is missing. */

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
@@ -173,6 +173,7 @@ object TagDropCodec {
     private const val K_DOMAIN      = 53  // core_meta_item only, Paper only — human-readable tagdrop://<domain>/<slug> name, falls back to slug (SPEC §7)
     private const val K_LOCATION_LABEL = 54  // core_meta_item only — human-readable, non-coordinate location description, e.g. "Tram 40" (SPEC §4.2)
     private const val K_PIXEL_ART   = 55  // core_meta_item only, Content only — author hint to render with no smoothing/nearest-neighbor scaling (SPEC §7)
+    private const val K_SOURCE_URL  = 56  // core_meta_item only, Content only — URL of a JSON drop-source registry listing nearby drops
 
     const val KDF_NONE          = 0
     const val KDF_PBKDF2_SHA256 = 1
@@ -820,7 +821,8 @@ object TagDropCodec {
                 title           = core.text(K_TITLE),
                 description     = core.text(K_DESCRIPTION),
                 createdAt       = core.uint(K_CREATED_AT),
-                pixelArt        = core.boolOrNull(K_PIXEL_ART) ?: false
+                pixelArt        = core.boolOrNull(K_PIXEL_ART) ?: false,
+                sourceUrl       = core.text(K_SOURCE_URL)
             )
         )
     }
@@ -964,7 +966,8 @@ object TagDropCodec {
         K_BULKY_COMPRESSED_BYTES to "bulky_meta_compressed_bytes", K_BULKY_SHA to "bulky_meta_sha256",
         K_RADIUS_M to "radius_m", K_PREFER_DECLARED_LOCATION to "prefer_declared_location",
         K_IN_REPLY_TO to "in_reply_to", K_TITLE to "title", K_CREATED_AT to "created_at",
-        K_DOMAIN to "domain", K_LOCATION_LABEL to "location_label", K_PIXEL_ART to "pixel_art"
+        K_DOMAIN to "domain", K_LOCATION_LABEL to "location_label", K_PIXEL_ART to "pixel_art",
+        K_SOURCE_URL to "source_url"
     )
     private val FILE_ENTRY_KEY_NAMES = mapOf(
         KF_SLUG to "slug", KF_MIME to "mime_type", KF_FILE_ID to "file_id",

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
@@ -45,7 +45,8 @@ sealed class TagDropPayload {
         val title: String? = null,              // optional — short subject/caption, distinct from hint (SPEC §4.3, issue #35)
         val description: String? = null,        // optional — content teaser / message body, e.g. when an attachment occupies content (SPEC §4.3, issue #35)
         val createdAt: Long? = null,            // optional — author-declared Unix timestamp (seconds) this payload was authored; the authoring device's clock, not independently verified (SPEC §3)
-        val pixelArt: Boolean = false           // optional — author hint to render this image with no smoothing/nearest-neighbor scaling (SPEC §7)
+        val pixelArt: Boolean = false,          // optional — author hint to render this image with no smoothing/nearest-neighbor scaling (SPEC §7)
+        val sourceUrl: String? = null           // optional — URL of a JSON drop-source registry listing nearby drops
     ) : TagDropPayload() {
         override fun equals(other: Any?) = other is Content && cacheId.contentEquals(other.cacheId)
         override fun hashCode() = cacheId?.contentHashCode() ?: 0

--- a/app/src/main/res/drawable/ic_map_pin.xml
+++ b/app/src/main/res/drawable/ic_map_pin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_refresh.xml
+++ b/app/src/main/res/drawable/ic_refresh.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/app/src/main/res/layout/activity_sources.xml
+++ b/app/src/main/res/layout/activity_sources.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_scrollFlags="scroll|enterAlways" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerSources"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="8dp"
+        android:clipToPadding="false"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+    <TextView
+        android:id="@+id/textEmpty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/sources_empty"
+        android:textSize="16sp"
+        android:textColor="#888888"
+        android:gravity="center"
+        android:padding="16dp"
+        android:visibility="gone" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_sources.xml
+++ b/app/src/main/res/layout/activity_sources.xml
@@ -25,6 +25,15 @@
         android:clipToPadding="false"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fabAddSource"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:contentDescription="@string/add_source_manually"
+        app:srcCompat="@android:drawable/ic_input_add" />
+
     <TextView
         android:id="@+id/textEmpty"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_source.xml
+++ b/app/src/main/res/layout/item_source.xml
@@ -71,20 +71,35 @@
 
         </LinearLayout>
 
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/switchSourceEnabled"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp" />
+        <ImageButton
+            android:id="@+id/buttonRefreshSource"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/source_refresh"
+            android:src="@drawable/ic_refresh"
+            android:scaleType="center"
+            android:padding="8dp" />
 
-        <Button
-            android:id="@+id/buttonDeleteSource"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="4dp"
-            android:text="@string/button_delete"
-            android:textAllCaps="false" />
+        <ImageButton
+            android:id="@+id/buttonToggleMap"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/source_toggle_map"
+            android:src="@drawable/ic_map_pin"
+            android:scaleType="center"
+            android:padding="8dp" />
+
+        <ImageButton
+            android:id="@+id/buttonSourceMenu"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/source_more_options"
+            android:src="@android:drawable/ic_menu_more"
+            android:scaleType="center"
+            android:padding="8dp" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/item_source.xml
+++ b/app/src/main/res/layout/item_source.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="2dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="12dp"
+        android:gravity="center_vertical">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/textSourceName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:maxLines="2"
+                android:ellipsize="end" />
+
+            <TextView
+                android:id="@+id/textSourceUrl"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textColor="#888888"
+                android:textSize="12sp"
+                android:maxLines="1"
+                android:ellipsize="middle" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/textSourceEntryCount"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="12sp"
+                    android:textColor="#aaaaaa" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text=" · "
+                    android:textSize="12sp"
+                    android:textColor="#aaaaaa" />
+
+                <TextView
+                    android:id="@+id/textSourceLastFetched"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="12sp"
+                    android:textColor="#aaaaaa" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/switchSourceEnabled"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp" />
+
+        <Button
+            android:id="@+id/buttonDeleteSource"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="@string/button_delete"
+            android:textAllCaps="false" />
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/item_source.xml
+++ b/app/src/main/res/layout/item_source.xml
@@ -69,6 +69,17 @@
 
             </LinearLayout>
 
+            <TextView
+                android:id="@+id/textSourceDisabledLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/source_disabled_label"
+                android:textSize="11sp"
+                android:textStyle="bold"
+                android:textColor="#888888"
+                android:visibility="gone" />
+
         </LinearLayout>
 
         <ImageButton

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -13,6 +13,11 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/action_sources"
+        android:title="@string/menu_drop_sources"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_backup"
         android:title="@string/action_backup"
         app:showAsAction="never" />

--- a/app/src/main/res/menu/menu_source_item.xml
+++ b/app/src/main/res/menu/menu_source_item.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/action_source_enable"
+        android:title="@string/source_action_enable" />
+
+    <item
+        android:id="@+id/action_source_disable"
+        android:title="@string/source_action_disable" />
+
+    <item
+        android:id="@+id/action_source_delete"
+        android:title="@string/source_action_delete" />
+
+</menu>

--- a/app/src/main/res/menu/menu_sources.xml
+++ b/app/src/main/res/menu/menu_sources.xml
@@ -8,6 +8,11 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/action_browse_sources"
+        android:title="@string/source_browse_title"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_reload_defaults"
         android:title="@string/source_reload_defaults"
         app:showAsAction="never" />

--- a/app/src/main/res/menu/menu_sources.xml
+++ b/app/src/main/res/menu/menu_sources.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_refresh_all"
+        android:title="@string/source_refresh_all"
+        app:showAsAction="never" />
+
+</menu>

--- a/app/src/main/res/menu/menu_sources.xml
+++ b/app/src/main/res/menu/menu_sources.xml
@@ -7,4 +7,9 @@
         android:title="@string/source_refresh_all"
         app:showAsAction="never" />
 
+    <item
+        android:id="@+id/action_reload_defaults"
+        android:title="@string/source_reload_defaults"
+        app:showAsAction="never" />
+
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -228,12 +228,12 @@
     <string name="passphrase_remember_key">Remember key</string>
     <string name="passphrase_wrong">Wrong passphrase — please try again</string>
 
-    <!-- Drop sources -->
-    <string name="title_sources">Drop Sources</string>
-    <string name="menu_drop_sources">Drop Sources</string>
-    <string name="sources_empty">No drop sources added yet.\nScan a TagDrop code with a source URL to add one.</string>
-    <string name="add_source_title">Add drop source?</string>
-    <string name="add_source_message">This code advertises a drop list at:\n\n%s\n\nAdd it as a source to see nearby drops on the map?</string>
+    <!-- Remote drop sources -->
+    <string name="title_sources">Remote Drop Sources</string>
+    <string name="menu_drop_sources">Remote Drop Sources</string>
+    <string name="sources_empty">No remote drop sources added yet.\nScan a TagDrop code with a source URL to add one.</string>
+    <string name="add_source_title">Add remote drop source?</string>
+    <string name="add_source_message">This code advertises a drop list at:\n\n%s\n\nAdd it as a remote source to see nearby drops on the map?</string>
     <string name="add_source_confirm">Add</string>
     <string name="source_refresh_all">Refresh all</string>
     <string name="source_last_fetched">Last fetched: %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,4 +241,12 @@
     <string name="source_never_fetched">Never fetched</string>
     <string name="add_source_manually">Add source URL manually</string>
     <string name="source_name_hint">Name (optional)</string>
+    <string name="source_refresh">Refresh</string>
+    <string name="source_toggle_map">Toggle map pins</string>
+    <string name="source_more_options">More options</string>
+    <string name="source_action_enable">Enable</string>
+    <string name="source_action_disable">Disable</string>
+    <string name="source_action_delete">Delete</string>
+    <string name="source_reload_defaults">Reload default sources</string>
+    <string name="source_reload_defaults_done">Default sources added</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -249,4 +249,14 @@
     <string name="source_action_delete">Delete</string>
     <string name="source_reload_defaults">Reload default sources</string>
     <string name="source_reload_defaults_done">Default sources added</string>
+    <string name="source_browse_title">Browse recommended sources</string>
+    <string name="source_browse_add">Add selected</string>
+    <string name="source_browse_failed">Could not fetch source directory</string>
+    <string name="source_browse_none">No sources found in directory</string>
+    <string name="source_browse_all_added">All recommended sources already added</string>
+    <string name="source_related_title">"%s" recommends</string>
+    <plurals name="source_browse_added">
+        <item quantity="one">%d source added (disabled by default)</item>
+        <item quantity="other">%d sources added (disabled by default)</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,4 +227,16 @@
     <string name="passphrase_unlock_once">Unlock once</string>
     <string name="passphrase_remember_key">Remember key</string>
     <string name="passphrase_wrong">Wrong passphrase — please try again</string>
+
+    <!-- Drop sources -->
+    <string name="title_sources">Drop Sources</string>
+    <string name="menu_drop_sources">Drop Sources</string>
+    <string name="sources_empty">No drop sources added yet.\nScan a TagDrop code with a source URL to add one.</string>
+    <string name="add_source_title">Add drop source?</string>
+    <string name="add_source_message">This code advertises a drop list at:\n\n%s\n\nAdd it as a source to see nearby drops on the map?</string>
+    <string name="add_source_confirm">Add</string>
+    <string name="source_refresh_all">Refresh all</string>
+    <string name="source_last_fetched">Last fetched: %s</string>
+    <string name="source_entry_count">%d drops</string>
+    <string name="source_never_fetched">Never fetched</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -239,4 +239,6 @@
     <string name="source_last_fetched">Last fetched: %s</string>
     <string name="source_entry_count">%d drops</string>
     <string name="source_never_fetched">Never fetched</string>
+    <string name="add_source_manually">Add source URL manually</string>
+    <string name="source_name_hint">Name (optional)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,6 +247,10 @@
     <string name="source_action_enable">Enable</string>
     <string name="source_action_disable">Disable</string>
     <string name="source_action_delete">Delete</string>
+    <string name="source_fetch_failed">Failed to fetch source</string>
+    <string name="source_fetch_some_failed">Some sources failed to fetch</string>
+    <string name="source_fetch_failed_label">Failed to fetch</string>
+    <string name="source_disabled_label">DISABLED</string>
     <string name="source_reload_defaults">Reload default sources</string>
     <string name="source_reload_defaults_done">Default sources added</string>
     <string name="source_browse_title">Browse recommended sources</string>

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolverTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolverTest.kt
@@ -56,6 +56,7 @@ private class FakeKeyDao : KeyDao {
 
 private class FakeDropSourceDao : DropSourceDao {
     override fun getAll(): LiveData<List<DropSource>> = throw NotImplementedError()
+    override suspend fun getAllOnce(): List<DropSource> = emptyList()
     override suspend fun getEnabled(): List<DropSource> = emptyList()
     override suspend fun insert(source: DropSource): Long = 0L
     override suspend fun update(source: DropSource) {}

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolverTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolverTest.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.LiveData
 import androidx.room.InvalidationTracker
 import com.github.mofosyne.tagdrop.data.db.AppDatabase
 import com.github.mofosyne.tagdrop.data.db.CacheDao
+import com.github.mofosyne.tagdrop.data.db.DropSource
+import com.github.mofosyne.tagdrop.data.db.DropSourceDao
 import com.github.mofosyne.tagdrop.data.db.FoundCache
 import com.github.mofosyne.tagdrop.data.db.KeyDao
 import com.github.mofosyne.tagdrop.data.db.PaperDao
@@ -52,6 +54,14 @@ private class FakeKeyDao : KeyDao {
     override suspend fun deleteAll() {}
 }
 
+private class FakeDropSourceDao : DropSourceDao {
+    override fun getAll(): LiveData<List<DropSource>> = throw NotImplementedError()
+    override suspend fun getEnabled(): List<DropSource> = emptyList()
+    override suspend fun insert(source: DropSource): Long = 0L
+    override suspend fun update(source: DropSource) {}
+    override suspend fun delete(source: DropSource) {}
+}
+
 private class FakeAppDatabase(
     val paperDaoFake: FakePaperDao = FakePaperDao(),
     val cacheDaoFake: FakeCacheDao = FakeCacheDao(),
@@ -59,6 +69,7 @@ private class FakeAppDatabase(
     override fun paperDao(): PaperDao = paperDaoFake
     override fun cacheDao(): CacheDao = cacheDaoFake
     override fun keyDao(): KeyDao = FakeKeyDao()
+    override fun dropSourceDao(): DropSourceDao = FakeDropSourceDao()
     override fun createInvalidationTracker(): InvalidationTracker = throw NotImplementedError()
     override fun clearAllTables() = throw NotImplementedError()
 }

--- a/docs/db/drops.json
+++ b/docs/db/drops.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "label": "TagDrop Community Drops",
+  "updated": "2026-07-03",
+  "drops": []
+}

--- a/docs/db/drops_demo.json
+++ b/docs/db/drops_demo.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+  "label": "TagDrop Demo Drops",
+  "updated": "2026-07-03",
+  "drops": [
+    {
+      "id": "a3f8b2c1d4e5f6a7",
+      "lat": 51.5081,
+      "lng": -0.1281,
+      "hint": "South side of Waterloo Bridge, low railing",
+      "description": "Sticker on the downstream face of the middle support column. Reachable from the pedestrian walkway, no climbing needed.",
+      "status": "working",
+      "status_updated": "2026-07-03",
+      "drop_type": "tagdrop"
+    },
+    {
+      "id": "b1c2d3e4f5a6b7c8",
+      "lat": 51.5007,
+      "lng": -0.1246,
+      "hint": "Westminster Bridge, east footpath, third lamp post from the south end",
+      "description": "QR sticker wrapped around the base of the lamp post at knee height.",
+      "status": "unknown",
+      "status_updated": "2026-06-01",
+      "drop_type": "tagdrop"
+    },
+    {
+      "id": "c9d8e7f6a5b4c3d2",
+      "lat": 51.5136,
+      "lng": -0.0983,
+      "hint": "Millennium Bridge, north end, left pillar",
+      "description": "Was on the inside face of the left approach pillar. Last check found it gone — may have been removed by maintenance.",
+      "status": "removed",
+      "status_updated": "2026-05-15",
+      "drop_type": "tagdrop"
+    },
+    {
+      "id": "d1e2f3a4b5c6d7e8",
+      "lat": 51.5033,
+      "lng": -0.1195,
+      "hint": "Hungerford Bridge, upper walkway, halfway across",
+      "description": "Underneath the yellow handrail join bracket on the south rail, halfway along the bridge.",
+      "status": "broken",
+      "status_updated": "2026-06-20",
+      "drop_type": "tagdrop"
+    }
+  ]
+}

--- a/docs/db/sources.json
+++ b/docs/db/sources.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "label": "TagDrop Known Sources",
+  "updated": "2026-07-03",
+  "sources": [
+    {
+      "name": "TagDrop Community Drops",
+      "url": "https://mofosyne.github.io/tagdrop/db/drops.json",
+      "description": "Curated list of community-placed TagDrop codes worldwide. Submit a PR to add your drop.",
+      "maintainer": "TagDrop project"
+    },
+    {
+      "name": "TagDrop Demo Drops",
+      "url": "https://mofosyne.github.io/tagdrop/db/drops_demo.json",
+      "description": "Sample drops used for testing the app and web reader. Not real physical locations.",
+      "maintainer": "TagDrop project"
+    }
+  ]
+}

--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,23 @@ We've contacted the deaddrops.com team to suggest adding a **TagDrop URI
 field** to their drop database, so the two communities can cross-reference
 each other without either app needing to scrape the other's data.
 
+### TagDrop community drop database
+
+The TagDrop project maintains a curated list of known drops at:
+
+```
+https://mofosyne.github.io/tagdrop/db/drops.json
+```
+
+To list your drop: open a pull request adding an entry to
+[`docs/db/drops.json`](docs/db/drops.json) in this repo. The entry needs the
+`cache_id` of your TagDrop code (visible in the app's inspect screen or the web
+generator), coordinates, and an optional hint.
+
+You can also publish your own drop list at any URL and distribute it as a
+`tagdrop:` hint QR — the app will prompt the finder to add it as a source when
+they scan the QR (see `source_url`, SPEC.md §17).
+
 ## Extra Readings
 
 * [#nfcdab](https://nfcdab.org) : A DIY international and independent digital art biennale in Wroclaw, Poland, that uses wireless technology, light waves and electromagnetic fields e.g.: Wi-Fi routers, QR codes or NFC tags for accessing content with your 📱 smartphone

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,42 @@ scan board, NFC tag read/write, search and `#hashtag` filtering, full
 backup/restore, and AES-256-GCM encryption via key-code QR or passphrase
 (PBKDF2-SHA256).
 
+## Community conventions
+
+These are recommended conventions for placing TagDrop codes in the wild so they
+can be discovered and catalogued by others.
+
+### OpenStreetMap tagging
+
+If you embed a TagDrop code at a physical location (sticker, sign, USB dead
+drop, geocache, etc.), consider adding it to
+[OpenStreetMap](https://www.openstreetmap.org/) so others can find it:
+
+- For a USB dead drop: use `man_made=dead_drop` and add `tagdrop=<uri>` (the
+  full `tagdrop:…` URI of the manifest or entry-point code).
+- For a standalone sticker/printout: use `tourism=artwork` or another suitable
+  primary tag, again with `tagdrop=<uri>`.
+- For a geocache-style hide: `leisure=geocache` + `tagdrop=<uri>`.
+
+A future version of the app may query OSM for nodes with a `tagdrop=*` tag to
+show nearby drops on the map — tagging your drop now means it will appear
+automatically when that feature ships.
+
+### Dead Drops project
+
+[Dead Drops](https://deaddrops.com/) (Aram Bartholl, 2010) is the original
+public USB dead-drop project. If your TagDrop code is attached to or near a
+registered dead drop, consider:
+
+1. Listing the drop on deaddrops.com (if not already listed).
+2. Adding a `tagdrop=<uri>` field to the drop's deaddrops.com entry, if/when
+   the site adds support for that field. (We've reached out to suggest this —
+   see below.)
+
+We've contacted the deaddrops.com team to suggest adding a **TagDrop URI
+field** to their drop database, so the two communities can cross-reference
+each other without either app needing to scrape the other's data.
+
 ## Extra Readings
 
 * [#nfcdab](https://nfcdab.org) : A DIY international and independent digital art biennale in Wroclaw, Poland, that uses wireless technology, light waves and electromagnetic fields e.g.: Wi-Fi routers, QR codes or NFC tags for accessing content with your 📱 smartphone

--- a/readme.md
+++ b/readme.md
@@ -134,7 +134,7 @@ running from source.
 
 > ⚠ **Wire format v1 is a draft.** No real-world codes have been printed or distributed yet, so breaking wire-format changes may occur without a version bump. Once the first code is deployed the format freezes.
 
-**TagDrop v2.1** — wire format version 1 (see [SPEC.md](SPEC.md)). CBOR-sequence envelope encoding
+**TagDrop v2.1** — wire format version 1 (draft, see [SPEC.md](SPEC.md)). CBOR-sequence envelope encoding
 (`tagdrop:<base41>`) with content split into one or more sectors plus
 optional parity recovery, paper manifests with multi-file directories and
 relative-link navigation, geographic trails via `related` hints and located


### PR DESCRIPTION
## Summary

Implements the full Remote Drop Sources feature (SPEC §17): fetching community drop lists from URLs, managing them in a dedicated screen, and showing their pins on the map.

### Core feature
- **`DropSource` Room entity** (`drop_sources` table, DB v21→22) — stores name, URL, enabled state, last-fetched timestamp, entry count, and a `lastFetchFailed` flag
- **`DropEntryCache`** — in-memory map keyed by sourceId; `allEntries(enabledSourceIds)` filters at render time so disabling a source removes map pins immediately without a DB round-trip
- **`SourceFetcher`** — fetches `drops.json` and the `sources.json` directory over HTTP; parses `related_sources` for peer discovery
- **`SourcesActivity`** — lists all added sources with per-row controls; FAB to add a URL manually
- **`MapFragment`** integration — pins from enabled sources appear alongside scanned caches (📡 working/unknown, 📵 broken, hidden for removed)
- **`ReceiveActivity`** — prompts "Add drop source?" when a scanned code carries `source_url` (SPEC §17 key 56)

### Source discovery
- **`docs/db/sources.json`** — official bootstrap directory of known community registries, served via GitHub Pages
- **`related_sources` field** in `drops.json` schema — any registry can recommend other registries; app surfaces them as an opt-in checklist after a fetch
- **"Browse recommended sources"** toolbar action — fetches the official directory and presents a checklist (all added disabled by default)
- **"Reload default sources"** toolbar action — re-inserts bundled community + demo sources if deleted, without duplicating already-present URLs

### Source row UI
- **Refresh button** — greyed out and non-interactive when source is disabled
- **Map pin indicator** — shows active/inactive state; non-interactive when disabled
- **"..." overflow menu** — Enable / Disable / Delete; always reachable even when source is disabled
- **Disabled state** — text fields fade to 40% alpha, DISABLED badge appears; only "..." stays fully active
- **Fetch failure feedback** — toast on failure; row shows "Failed to fetch" (tracked via `lastFetchFailed`) instead of "Never fetched"

### SPEC.md §17 additions
- Documents `related_sources` array schema with per-entry fields
- Documents the `sources.json` directory format (parallel schema with top-level `sources` array)

### Seeding
- Default sources (community drops + demo drops) inserted disabled on fresh installs (via `RoomDatabase.Callback`) and on upgrade from v20 (via `MIGRATION_20_21`)

---

## Privacy and offline-first design

This feature is entirely opt-in and makes no network requests without explicit user action.

### No background fetching
- Sources are **never fetched automatically** — only when the user taps Refresh on a row, taps "Refresh all", or adds a new source. There is no periodic background sync, no fetch on app start, no fetch on map open.
- The "Browse recommended sources" action is the only other network call, and it only fires when the user explicitly taps that menu item.

### Explicit consent before any fetch
- When a scanned QR code carries a `source_url`, the app shows the **full URL** in a prompt before doing anything. The user must tap Add to proceed; tapping Skip or dismissing the dialog results in zero network activity (SPEC §17 requirement).
- Sources added via "Browse recommended" or `related_sources` checklists start **disabled by default** — they don't fetch or show map pins until the user explicitly enables them.

### IP disclosure caveat
- SPEC §17 requires (and `ReceiveActivity`'s prompt notes) that fetching a source URL reveals the device's IP address and approximate fetch time to the server hosting the file. Our own sources are static GitHub Pages files with no server-side logging beyond what GitHub's CDN records.

### Offline-first map
- `DropEntryCache` is populated from the last successful fetch and lives in memory for the session. The map works offline after the first fetch — no re-fetch is needed to see pins.
- Disabling a source removes its pins from the map immediately (in-memory filter) without any network call.
- The app gracefully handles fetch failures: the row shows "Failed to fetch", a toast is shown, and the cached pin data from the previous successful fetch is left untouched in `DropEntryCache`.

### Static hosting
- `docs/db/drops.json`, `drops_demo.json`, and `sources.json` are committed files served by GitHub Pages — no dynamic server, no analytics, no tracking pixels. Anyone can self-host an equivalent file on any static host.
