### PR TITLE
Add "Write to NFC tag" button to the single-code Create screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,3 +197,20 @@ again or a concrete need emerges.
   text, never raw camera frames/bitmaps, so this would need a parallel
   capture pipeline (frame access, contour detection, homography warp,
   crop) built from scratch.
+- **NFC: auto-fallback to standard-record-readable tags when they'd fit
+  unsplit** (assessed: *medium usefulness, medium complexity — reasonable
+  to defer*; tracked in
+  [#58](https://github.com/mofosyne/tagdrop/issues/58)). Today
+  `WriteNfcTagActivity`'s "include standard record" option (added in #43)
+  is opt-in and off by default, so non-TagDrop phones can't read a tag
+  unless the user checks a box first. Making it the effective default for
+  content that fits one tag either way isn't just a checkbox flip, though:
+  `sectorsFittingTag()` currently refuses to split when a standard record
+  is requested, so it would need a genuine try-with-standard-record-first,
+  fall-back-to-TagDrop-only-and-split-if-needed order, decided only after
+  `onTagDiscovered()` measures the real tapped tag's capacity, plus
+  post-write UI feedback showing which mode actually got written. Useful
+  mainly for the "no app installed" case — and since this app is
+  F-Droid-distributed, the AAR's built-in fallback (Play Store redirect)
+  is already weak for its actual users — but most taps come from people
+  already in the ecosystem, so it's a nice-to-have, not core.

--- a/app/src/main/java/com/github/mofosyne/tagdrop/CreateActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/CreateActivity.kt
@@ -35,6 +35,7 @@ class CreateActivity : AppCompatActivity() {
     private lateinit var binding: ActivityCreateBinding
     private var lastUri: String = ""
     private var lastPayloadHint: String? = null
+    private var lastCacheId: String? = null
 
     private val mimeTypes = listOf("text/plain", "text/html", "text/markdown", "application/json", "image/svg+xml")
 
@@ -63,9 +64,10 @@ class CreateActivity : AppCompatActivity() {
             this, android.R.layout.simple_spinner_item, mimeTypes
         ).also { it.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item) }
 
-        binding.buttonGenerate.setOnClickListener { generate() }
-        binding.buttonShare.setOnClickListener    { shareUri() }
-        binding.buttonPrint.setOnClickListener    { printQr() }
+        binding.buttonGenerate.setOnClickListener  { generate() }
+        binding.buttonShare.setOnClickListener     { shareUri() }
+        binding.buttonPrint.setOnClickListener     { printQr() }
+        binding.buttonWriteNfc.setOnClickListener  { writeNfc() }
     }
 
     private fun generate() {
@@ -93,6 +95,7 @@ class CreateActivity : AppCompatActivity() {
             val idHex = (sector.partMeta.cacheId ?: ByteArray(0)).joinToString("") { "%02x".format(it) }
             binding.textCacheId.text = getString(R.string.qr_cache_id, idHex)
             binding.textUri.text = uri
+            lastCacheId = idHex
             setResultsVisible(true)
             saveToMyDrops(idHex, hint, filename, mimeType, rawContent, icon)
         } catch (e: WriterException) {
@@ -132,6 +135,11 @@ class CreateActivity : AppCompatActivity() {
         ))
     }
 
+    private fun writeNfc() {
+        val cacheId = lastCacheId ?: return
+        startActivity(Intent(this, WriteNfcTagActivity::class.java).putExtra(WriteNfcTagActivity.EXTRA_CACHE_ID, cacheId))
+    }
+
     private fun printQr() {
         if (lastUri.isBlank()) return
         val printManager = getSystemService(PRINT_SERVICE) as PrintManager
@@ -169,10 +177,11 @@ class CreateActivity : AppCompatActivity() {
 
     private fun setResultsVisible(visible: Boolean) {
         val v = if (visible) View.VISIBLE else View.GONE
-        binding.imageQr.visibility     = v
+        binding.imageQr.visibility      = v
         binding.textCacheId.visibility  = v
         binding.buttonShare.visibility  = v
         binding.buttonPrint.visibility  = v
+        binding.buttonWriteNfc.visibility = v
         binding.textUri.visibility     = v
     }
 

--- a/app/src/main/res/layout/activity_create.xml
+++ b/app/src/main/res/layout/activity_create.xml
@@ -150,6 +150,16 @@
                     android:text="@string/button_print"
                     android:visibility="gone" />
 
+                <Button
+                    android:id="@+id/buttonWriteNfc"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="8dp"
+                    android:text="@string/action_write_nfc"
+                    android:visibility="gone" />
+
             </LinearLayout>
 
             <TextView


### PR DESCRIPTION
CreateActivity previously only offered Share and Print after generating a
QR code; writing the same content to an NFC tag required navigating to
the item's entry in My Drops and using its overflow menu. This adds a
third button that launches the existing WriteNfcTagActivity directly for
the just-created cache, reusing its standard-record option so tags can
still be made readable by non-TagDrop NFC apps.