### PR TITLE
Add trail step/fork ordering to the wire format

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -173,6 +173,7 @@ TagDrop's wire format has four internal CBOR structures, all integer-keyed maps 
 | 54 | `location_label` | text (opt) | `core_meta_item` — human-readable, non-coordinate description of this payload's own location, e.g. "🚋 Tram 40"; see §4.2 |
 | 55 | `pixel_art` | bool (opt, default `false`) | `core_meta_item` (Content only) — render with nearest-neighbour scaling (no smoothing); see §7 "Pixel art" |
 | 56 | `source_url` | text (opt) | `core_meta_item` — URL of a drop-source registry JSON file; see §17 |
+| 57 | `step` | uint (opt) | `core_meta_item` (Paper only) — this paper's own absolute position within its `set` trail; see §4.3 "Trail steps and forks" |
 
 Keys **1**, **6**, **9**, **10** are retired (formerly `version`-inside-payload,
 `chunk_count`, `chunk_index`, `chunk_data` — superseded by the envelope's
@@ -218,6 +219,7 @@ conflict, because CBOR map keys are scoped per-map.
 | 7 | `radius_m` | float64 (opt) | Circle-of-uncertainty radius in meters |
 | 8 | `key_material` | bytes (32, opt) | Decryption key for that paper's content (§9) |
 | 9 | `retain_key` | bool (opt, default `true`) | See §9 |
+| 10 | `step` | uint (opt) | Absolute position of the related paper within its `set` trail; see §4.3 "Trail steps and forks" |
 
 **`content_sha256`/`bulky_meta_sha256` are REQUIRED whenever `sector_count >
 1`.** Without it, an adversary who substitutes one sector of a multi-sector
@@ -254,7 +256,7 @@ Each element is a CBOR map using local keys **1** (`slug`), **2** (`mime_type`),
 
 ### Related paper sub-keys (elements of key 16)
 
-Each element is a CBOR map using local keys **1** (`hint`), **2** (`set`), **3** (`slug`), **4** (`paper_id`), **5** (`lat`), **6** (`lng`), **7** (`radius_m`), **8** (`key_material`), **9** (`retain_key`). These keys are local to the sub-map and independent of the top-level key space — see the `related[]` entry key table in §3.
+Each element is a CBOR map using local keys **1** (`hint`), **2** (`set`), **3** (`slug`), **4** (`paper_id`), **5** (`lat`), **6** (`lng`), **7** (`radius_m`), **8** (`key_material`), **9** (`retain_key`), **10** (`step`). These keys are local to the sub-map and independent of the top-level key space — see the `related[]` entry key table in §3.
 
 ---
 
@@ -433,16 +435,17 @@ core_meta_item {
   26: -33.8688,                  // lat — optional, author-declared location of this paper
   27: 151.2093,                  // lng — optional, author-declared location of this paper
   48: 25.0,                      // radius_m — optional, circle of uncertainty in meters
+  57: 3,                         // step — this paper is stop 3 of the "sunset-trail" set
 }
 bulky_meta_item {
-  15: [                         // files — directory of codes on this paper
-    {20: "index", 21: "text/html",    22: h'<file_id>', 41: "A poem to read"},
-    {20: "map",   21: "image/svg+xml", 22: h'<file_id>', 41: "A hand-drawn map"},
+  15: [                         // files — directory of codes on this paper (local keys, see §3)
+    {1: "index", 2: "text/html",    3: h'<file_id>', 4: "A poem to read"},
+    {1: "map",   2: "image/svg+xml", 3: h'<file_id>', 4: "A hand-drawn map"},
   ],
-  16: [                         // related — hints to other papers
-    {3: "Next stop: the red letterbox 200m north", 14: "letterbox",
-     23: h'<paper_id>', 26: -33.8688, 27: 151.2093, 48: 50.0},
-    {3: "Start of trail: town square notice board"},
+  16: [                         // related — hints to other papers (local keys, see §3)
+    {1: "Next stop: the red letterbox 200m north", 2: "sunset-trail", 3: "letterbox",
+     4: h'<paper_id>', 5: -33.8688, 6: 151.2093, 7: 50.0, 10: 4},
+    {1: "Start of trail: town square notice board", 2: "sunset-trail", 10: 1},
   ],
 }
 content: (empty)
@@ -494,6 +497,38 @@ related papers that haven't been scanned yet, helping the finder navigate
 toward them. Once that paper is scanned, its own `ScannedPaper` location
 (resolved from the device's live GPS fix and/or that paper's own declared
 location, per §4.2's priority rule) replaces the placeholder.
+
+**Trail steps and forks:** `step` (key 57 in `core_meta_item`; local key 10
+in a `related` entry) is an optional absolute ordinal — "this is stop N" —
+scoped by `set` (key 13 / local key 2), not globally: two papers' `step`
+values are only comparable when their `set` strings match. A paper declares
+its own position via its `core_meta_item`'s `step`; a `related` entry
+declares the position of the paper it points to, so a finder can see "stop 4
+of the sunset-trail" before ever scanning stop 4. Absolute numbering (rather
+than a relative "next"/"previous" offset) is deliberate: it keeps degrading
+gracefully when a stop is missing (a decoder can still show "stop 4 of 9"
+even with gaps) and doesn't require knowing your own position to interpret
+a pointer, unlike a relative offset which breaks the moment one hop is
+scanned out of order or lost.
+
+A **fork** is just two or more `related` entries that share both the same
+`set` and the same `step` — the app presents all of them as alternative
+next stops rather than picking one. Entries that share a `step` but *not*
+the same `set` are not a fork; they're two unrelated trails that happen to
+cross at the same physical hub paper (e.g. a noticeboard that is stop 4 on
+"sunset-trail" and, separately, stop 2 on "history-trail"), and are shown as
+separate trails with separate progress. `step` is deliberately not required
+to be unique per `related[]` array for exactly this reason.
+
+**Missing-tag resilience:** because a trail is just a chain of `related`
+pointers, a single missing or destroyed stop can strand a finder who only
+ever listed the immediate next one. There's no protocol-level fix for
+this — the wire format has no notion of "skip" — so authors SHOULD list
+more than one stop ahead (e.g. both stop 5 and stop 6 from stop 4), or a
+link back to a known hub/index stop, giving a finder a way around a single
+gone-missing tag. This is authoring guidance, not a new mechanism: it's the
+same `related[]` array already used for the single-pointer case, just
+populated with an extra entry.
 
 **Navigation:** HTML files on the paper can link to other files using:
 ```html
@@ -1647,6 +1682,7 @@ Version history:
 - ML-DSA-44 post-quantum signatures (§10): `signature_algorithm`/`signature`/`signer_pubkey`/`signer_id`/`signer_label` (keys 32–36), additive and not affecting `cache_id`/`root_hash`/`content_sha256`/`bulky_meta_sha256`. Specified for forward-compatibility; not yet implemented in reference implementations.
 - Author-declared `created_at` (key 52, both payload kinds): optional Unix timestamp (seconds) recording when the payload was authored, taken from the authoring device's clock at encode time — self-declared like `lat`/`lng`, not a verified/trusted timestamp.
 - Drop source registry (§17): `source_url` (key 56) in `core_meta_item` — a URL pointing to a JSON file listing nearby TagDrop drop locations. When scanned, the app prompts the user before fetching. Source management (add/enable/disable/remove) is explicit and user-controlled; no automatic background fetches.
+- Trail steps and forks (§4.3): `step` (key 57 in `core_meta_item`; local key 10 in a `related` entry) is an optional absolute ordinal scoped by `set`, letting a decoder show "stop N of the trail" and, when two `related` entries share the same `set`/`step`, present a fork of alternative next stops rather than a single pointer.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -501,15 +501,25 @@ location, per §4.2's priority rule) replaces the placeholder.
 **Trail steps and forks:** `step` (key 57 in `core_meta_item`; local key 10
 in a `related` entry) is an optional absolute ordinal — "this is stop N" —
 scoped by `set` (key 13 / local key 2), not globally: two papers' `step`
-values are only comparable when their `set` strings match. A paper declares
-its own position via its `core_meta_item`'s `step`; a `related` entry
-declares the position of the paper it points to, so a finder can see "stop 4
-of the sunset-trail" before ever scanning stop 4. Absolute numbering (rather
-than a relative "next"/"previous" offset) is deliberate: it keeps degrading
-gracefully when a stop is missing (a decoder can still show "stop 4 of 9"
-even with gaps) and doesn't require knowing your own position to interpret
-a pointer, unlike a relative offset which breaks the moment one hop is
-scanned out of order or lost.
+values are only comparable when their `set` strings match. `step` is
+**1-based**: the first stop in a trail is `step: 1`, not `0` (unlike
+`sector_index`, §4.1, which is 0-based — the two counters are unrelated and
+deliberately don't share a convention). A paper declares its own position
+via its `core_meta_item`'s `step`; a `related` entry declares the position
+of the paper it points to, so a finder can see "stop 4 of the sunset-trail"
+before ever scanning stop 4. There is no declared trail length anywhere in
+the format — a decoder only knows about the `step` values it has actually
+seen mentioned (in a scanned paper's own `step`, or in a `related` entry
+pointing at one), so "stop 4" can be shown with confidence but "stop 4 of
+9" cannot unless every paper 1 through 9 happens to have been referenced
+somewhere; a decoder MUST NOT assume the highest `step` value it has seen
+is the trail's true last stop. Absolute numbering (rather than a relative
+"next"/"previous" offset) is still the right choice despite this: it keeps
+degrading gracefully when a stop is missing — a decoder can still place a
+newly-scanned paper at its correct position among whatever other steps it
+already knows about, gaps and all — and it doesn't require knowing your own
+position to interpret a pointer, unlike a relative offset, which breaks the
+moment one hop is scanned out of order or lost.
 
 A **fork** is just two or more `related` entries that share both the same
 `set` and the same `step` — the app presents all of them as alternative
@@ -1682,7 +1692,7 @@ Version history:
 - ML-DSA-44 post-quantum signatures (§10): `signature_algorithm`/`signature`/`signer_pubkey`/`signer_id`/`signer_label` (keys 32–36), additive and not affecting `cache_id`/`root_hash`/`content_sha256`/`bulky_meta_sha256`. Specified for forward-compatibility; not yet implemented in reference implementations.
 - Author-declared `created_at` (key 52, both payload kinds): optional Unix timestamp (seconds) recording when the payload was authored, taken from the authoring device's clock at encode time — self-declared like `lat`/`lng`, not a verified/trusted timestamp.
 - Drop source registry (§17): `source_url` (key 56) in `core_meta_item` — a URL pointing to a JSON file listing nearby TagDrop drop locations. When scanned, the app prompts the user before fetching. Source management (add/enable/disable/remove) is explicit and user-controlled; no automatic background fetches.
-- Trail steps and forks (§4.3): `step` (key 57 in `core_meta_item`; local key 10 in a `related` entry) is an optional absolute ordinal scoped by `set`, letting a decoder show "stop N of the trail" and, when two `related` entries share the same `set`/`step`, present a fork of alternative next stops rather than a single pointer.
+- Trail steps and forks (§4.3): `step` (key 57 in `core_meta_item`; local key 10 in a `related` entry) is an optional 1-based absolute ordinal scoped by `set` (no declared trail length), letting a decoder show "stop N" and, when two `related` entries share the same `set`/`step`, present a fork of alternative next stops rather than a single pointer.
 
 ---
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
@@ -163,6 +163,7 @@ object TagDropCodec {
     private const val KR_RADIUS_M    = 7
     private const val KR_KEY_MATERIAL = 8
     private const val KR_RETAIN_KEY   = 9
+    private const val KR_STEP         = 10 // 1-based position of the related paper within its `set` trail (SPEC §4.3)
     private const val K_BULKY_COMPRESSED_BYTES = 46
     private const val K_BULKY_SHA              = 47
     private const val K_RADIUS_M               = 48  // circle-of-uncertainty radius in meters, wherever lat/lng appears
@@ -174,6 +175,7 @@ object TagDropCodec {
     private const val K_LOCATION_LABEL = 54  // core_meta_item only — human-readable, non-coordinate location description, e.g. "Tram 40" (SPEC §4.2)
     private const val K_PIXEL_ART   = 55  // core_meta_item only, Content only — author hint to render with no smoothing/nearest-neighbor scaling (SPEC §7)
     private const val K_SOURCE_URL  = 56  // core_meta_item only, Content only — URL of a JSON drop-source registry listing nearby drops
+    private const val K_STEP        = 57  // core_meta_item only, Paper only — 1-based position of this paper within its `set` trail (SPEC §4.3)
 
     const val KDF_NONE          = 0
     const val KDF_PBKDF2_SHA256 = 1
@@ -466,6 +468,7 @@ object TagDropCodec {
         title: String? = null,
         createdAt: Long? = null,
         domain: String? = null,
+        step: Int? = null,
         maxSectorDataBytes: Int = Int.MAX_VALUE
     ): Pair<TagDropPayload.Paper, List<Sector>> {
         val draft = TagDropPayload.Paper(
@@ -476,7 +479,7 @@ object TagDropCodec {
             keyMaterial = keyMaterial, retainKey = retainKey,
             lat = lat, lng = lng, radiusM = radiusM, preferDeclaredLocation = preferDeclaredLocation,
             locationLabel = locationLabel,
-            inReplyTo = inReplyTo, title = title, createdAt = createdAt, domain = domain
+            inReplyTo = inReplyTo, title = title, createdAt = createdAt, domain = domain, step = step
         )
         val stream = buildPaperStream(draft)
         val rootHash = sha256(stream).copyOf(8)
@@ -497,14 +500,15 @@ object TagDropCodec {
         inReplyTo: ByteArray? = null,
         title: String? = null,
         createdAt: Long? = null,
-        domain: String? = null
+        domain: String? = null,
+        step: Int? = null
     ): Pair<TagDropPayload.Paper, List<Sector>> {
         val first = createPaper(
             label, set, slug, files, related, description,
             collectionId, collectionLabel, collectionTag, icon,
             keyMaterial, retainKey,
             lat, lng, radiusM, preferDeclaredLocation, locationLabel, inReplyTo, title,
-            createdAt, domain,
+            createdAt, domain, step,
             maxSectorDataBytes = Int.MAX_VALUE
         )
         if (encode(first.second.first()).length <= DEFAULT_URI_LENGTH) return first
@@ -513,7 +517,7 @@ object TagDropCodec {
             collectionId, collectionLabel, collectionTag, icon,
             keyMaterial, retainKey,
             lat, lng, radiusM, preferDeclaredLocation, locationLabel, inReplyTo, title,
-            createdAt, domain,
+            createdAt, domain, step,
             maxSectorDataBytes = DEFAULT_SECTOR_DATA_BYTES
         )
     }
@@ -552,7 +556,8 @@ object TagDropCodec {
                     KR_LNG         to r.lng,
                     KR_RADIUS_M    to r.radiusM,
                     KR_KEY_MATERIAL to r.keyMaterial,
-                    KR_RETAIN_KEY  to false.takeIf { r.keyMaterial != null && !r.retainKey }
+                    KR_RETAIN_KEY  to false.takeIf { r.keyMaterial != null && !r.retainKey },
+                    KR_STEP        to r.step
                 ))
             }
         )
@@ -577,6 +582,7 @@ object TagDropCodec {
             K_IN_REPLY_TO to paper.inReplyTo,
             K_CREATED_AT to paper.createdAt,
             K_DOMAIN to paper.domain,
+            K_STEP to paper.step,
             K_BULKY_SHA to sha256(bulkyBytes)
         )
         val out = ByteArrayOutputStream()
@@ -892,7 +898,8 @@ object TagDropCodec {
                 lng         = em.doubleOrNull(KR_LNG),
                 radiusM     = em.doubleOrNull(KR_RADIUS_M),
                 keyMaterial = em.bytesOrNull(KR_KEY_MATERIAL),
-                retainKey   = em.boolOrNull(KR_RETAIN_KEY) ?: true
+                retainKey   = em.boolOrNull(KR_RETAIN_KEY) ?: true,
+                step        = em.uint(KR_STEP)?.toInt()
             )
         } ?: emptyList()
 
@@ -918,7 +925,8 @@ object TagDropCodec {
             inReplyTo       = parts.core.bytesOrNull(K_IN_REPLY_TO),
             title           = parts.core.text(K_TITLE),
             createdAt       = parts.core.uint(K_CREATED_AT),
-            domain          = parts.core.text(K_DOMAIN)
+            domain          = parts.core.text(K_DOMAIN),
+            step            = parts.core.uint(K_STEP)?.toInt()
         )
     }
 
@@ -967,7 +975,7 @@ object TagDropCodec {
         K_RADIUS_M to "radius_m", K_PREFER_DECLARED_LOCATION to "prefer_declared_location",
         K_IN_REPLY_TO to "in_reply_to", K_TITLE to "title", K_CREATED_AT to "created_at",
         K_DOMAIN to "domain", K_LOCATION_LABEL to "location_label", K_PIXEL_ART to "pixel_art",
-        K_SOURCE_URL to "source_url"
+        K_SOURCE_URL to "source_url", K_STEP to "step"
     )
     private val FILE_ENTRY_KEY_NAMES = mapOf(
         KF_SLUG to "slug", KF_MIME to "mime_type", KF_FILE_ID to "file_id",
@@ -976,7 +984,7 @@ object TagDropCodec {
     private val RELATED_ENTRY_KEY_NAMES = mapOf(
         KR_HINT to "hint", KR_SET to "set", KR_SLUG to "slug", KR_PAPER_ID to "paper_id",
         KR_LAT to "lat", KR_LNG to "lng", KR_RADIUS_M to "radius_m",
-        KR_KEY_MATERIAL to "key_material", KR_RETAIN_KEY to "retain_key"
+        KR_KEY_MATERIAL to "key_material", KR_RETAIN_KEY to "retain_key", KR_STEP to "step"
     )
     private val SUB_MAP_KEY_NAMES = mapOf(
         K_FILES to FILE_ENTRY_KEY_NAMES, K_RELATED to RELATED_ENTRY_KEY_NAMES

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
@@ -87,7 +87,8 @@ sealed class TagDropPayload {
         val lng: Double? = null,       // longitude of the related paper, if known
         val radiusM: Double? = null,   // optional — circle-of-uncertainty radius in meters around lat/lng
         val keyMaterial: ByteArray? = null,  // optional — a decryption key for the related paper (SPEC §9)
-        val retainKey: Boolean = true        // recommendation for whether keyMaterial should be remembered (SPEC §9)
+        val retainKey: Boolean = true,       // recommendation for whether keyMaterial should be remembered (SPEC §9)
+        val step: Int? = null                // optional — 1-based position of the related paper within its `set` trail (SPEC §4.3)
     ) {
         override fun equals(other: Any?) = other is RelatedPaper && hint == other.hint
         override fun hashCode() = hint.hashCode()
@@ -133,7 +134,8 @@ sealed class TagDropPayload {
         val inReplyTo: ByteArray? = null,       // optional — cache_id/root_hash of the single parent this is replying to (SPEC §7)
         val title: String? = null,              // optional — short subject/caption, distinct from label (SPEC §4.3, issue #35)
         val createdAt: Long? = null,            // optional — author-declared Unix timestamp (seconds) this payload was authored; the authoring device's clock, not independently verified (SPEC §3)
-        val domain: String? = null              // optional — human-readable name for tagdrop://<domain>/<slug> links; falls back to slug if absent (SPEC §7)
+        val domain: String? = null,             // optional — human-readable name for tagdrop://<domain>/<slug> links; falls back to slug if absent (SPEC §7)
+        val step: Int? = null                   // optional — 1-based position of this paper within its `set` trail (SPEC §4.3)
     ) : TagDropPayload() {
         override fun equals(other: Any?) = other is Paper && rootHash.contentEquals(other.rootHash)
         override fun hashCode() = rootHash.contentHashCode()

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropCodecTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropCodecTest.kt
@@ -325,6 +325,33 @@ class TagDropCodecTest {
         assertNull(decoded.related[1].radiusM)
     }
 
+    @Test fun paperWithStepAndFork() {
+        val files = listOf(TagDropPayload.FileEntry("index", "text/html", byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)))
+        // SPEC §4.3: two related entries sharing the same set+step are a fork — alternative
+        // next stops — not a collision. A third entry shares step with a *different* set,
+        // so it must NOT be treated as part of the same fork.
+        val related = listOf(
+            TagDropPayload.RelatedPaper("turn left for the pond", set = "sunset-trail", step = 4),
+            TagDropPayload.RelatedPaper("turn right for the meadow", set = "sunset-trail", step = 4),
+            TagDropPayload.RelatedPaper("history trail stop 2", set = "history-trail", step = 4)
+        )
+        val (_, sectors) = TagDropCodec.createPaper(
+            "Trail Stop 3 — Oak Tree", "sunset-trail", "oak-tree", files, related, step = 3
+        )
+
+        val state = assemble(roundTrip(sectors)) as SectorAssembler.State.PaperReady
+        val decoded = state.paper
+        assertEquals(3, decoded.step)
+
+        val forkSiblings = decoded.related.filter { it.set == "sunset-trail" && it.step == 4 }
+        assertEquals(2, forkSiblings.size)
+        assertEquals("turn left for the pond", forkSiblings[0].hint)
+        assertEquals("turn right for the meadow", forkSiblings[1].hint)
+
+        val differentTrail = decoded.related.single { it.set == "history-trail" }
+        assertEquals(4, differentTrail.step)
+    }
+
     @Test fun paperWithTitleAndInReplyTo() {
         val parentId = byteArrayOf(9, 9, 9, 9, 9, 9, 9, 9)
         val files = listOf(TagDropPayload.FileEntry("index", "text/html", byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)))

--- a/tools/generator/index.html
+++ b/tools/generator/index.html
@@ -396,9 +396,15 @@
         <input type="text" id="p-set" placeholder="e.g. sunset-trail">
       </div>
     </div>
-    <div>
-      <label>Slug <small>(optional — this paper's address within the set)</small></label>
-      <input type="text" id="p-slug" placeholder="e.g. oak-tree  →  tagdrop://…/oak-tree">
+    <div class="row">
+      <div>
+        <label>Slug <small>(optional — this paper's address within the set)</small></label>
+        <input type="text" id="p-slug" placeholder="e.g. oak-tree  →  tagdrop://…/oak-tree">
+      </div>
+      <div>
+        <label>Step <small>(optional — 1-based position within the Set trail above, e.g. "3" for the third stop — SPEC §4.3)</small></label>
+        <input type="number" id="p-step" min="1" step="1" placeholder="e.g. 3">
+      </div>
     </div>
     <div>
       <label>Domain <small>(optional — human-readable name finders can type instead of the root hash, e.g. "helloworld"  →  tagdrop://helloworld; falls back to Slug above when absent — SPEC §7 "Domains". Avoid '@' — it's reserved syntax for marking a pinned root hash, e.g. tagdrop://helloworld@&lt;hash&gt;)</small></label>
@@ -815,6 +821,7 @@ const KEY_NAMES = {
   45: 'bulky_meta_compression', 46: 'bulky_meta_compressed_bytes', 47: 'bulky_meta_sha256',
   48: 'radius_m', 49: 'prefer_declared_location',
   50: 'in_reply_to', 51: 'title', 52: 'created_at', 54: 'location_label', 55: 'pixel_art',
+  57: 'step',
 };
 
 function toHexDump(bytes) {
@@ -1001,13 +1008,14 @@ const K = { CACHE_ID:2, HINT:3, MIME:4, CONTENT:5,
              SECTOR_INDEX:42, SECTOR_COUNT:43, PARITY:44,
              BULKY_COMPRESSION:45, BULKY_COMPRESSED_BYTES:46, BULKY_SHA:47,
              RADIUS_M:48, PREFER_DECLARED_LOCATION:49,
-             IN_REPLY_TO:50, TITLE:51, CREATED_AT:52, DOMAIN:53, LOCATION_LABEL:54, PIXEL_ART:55 };
+             IN_REPLY_TO:50, TITLE:51, CREATED_AT:52, DOMAIN:53, LOCATION_LABEL:54, PIXEL_ART:55,
+             STEP:57 };
 // Local keys for files[] sub-map entries (independent namespace, SPEC §3)
 const KF = { SLUG:1, MIME:2, FILE_ID:3, DESCRIPTION:4, PIXEL_ART:5 };
 // Local keys for related[] sub-map entries (independent namespace, SPEC §3)
-const KR = { HINT:1, SET:2, SLUG:3, PAPER_ID:4, LAT:5, LNG:6, RADIUS_M:7, KEY_MATERIAL:8, RETAIN_KEY:9 };
+const KR = { HINT:1, SET:2, SLUG:3, PAPER_ID:4, LAT:5, LNG:6, RADIUS_M:7, KEY_MATERIAL:8, RETAIN_KEY:9, STEP:10 };
 const FILE_ENTRY_KEY_NAMES = { [KF.SLUG]:'slug', [KF.MIME]:'mime_type', [KF.FILE_ID]:'file_id', [KF.DESCRIPTION]:'description', [KF.PIXEL_ART]:'pixel_art' };
-const RELATED_ENTRY_KEY_NAMES = { [KR.HINT]:'hint', [KR.SET]:'set', [KR.SLUG]:'slug', [KR.PAPER_ID]:'paper_id', [KR.LAT]:'lat', [KR.LNG]:'lng', [KR.RADIUS_M]:'radius_m', [KR.KEY_MATERIAL]:'key_material', [KR.RETAIN_KEY]:'retain_key' };
+const RELATED_ENTRY_KEY_NAMES = { [KR.HINT]:'hint', [KR.SET]:'set', [KR.SLUG]:'slug', [KR.PAPER_ID]:'paper_id', [KR.LAT]:'lat', [KR.LNG]:'lng', [KR.RADIUS_M]:'radius_m', [KR.KEY_MATERIAL]:'key_material', [KR.RETAIN_KEY]:'retain_key', [KR.STEP]:'step' };
 const SUB_KEY_NAMES = { 15: FILE_ENTRY_KEY_NAMES, 16: RELATED_ENTRY_KEY_NAMES };
 
 // Sector sizing (mirrors Kotlin TagDropCodec.MAX_URI_LENGTH / MAX_SECTOR_DATA_BYTES):
@@ -1209,7 +1217,7 @@ function createKeyCodeSector({ keyMaterial, retainKey = true, hint }) {
  * structures where a constant ~36-byte cost is negligible next to the cost of an unverified
  * directory.
  */
-async function buildPaperStream({ label, set, slug, domain, files, related, description, collectionId, collectionLabel, collectionTag, icon, keyMaterial, retainKey = true, lat, lng, radiusM, preferDeclaredLocation = false, locationLabel, inReplyTo, title, createdAt }) {
+async function buildPaperStream({ label, set, slug, domain, files, related, description, collectionId, collectionLabel, collectionTag, icon, keyMaterial, retainKey = true, lat, lng, radiusM, preferDeclaredLocation = false, locationLabel, inReplyTo, title, createdAt, step }) {
   const bulky = [
     [K.FILES, files.map(f => subMap([
       [KF.SLUG, f.slug], [KF.MIME, f.mimeType], [KF.FILE_ID, f.fileId],
@@ -1222,6 +1230,7 @@ async function buildPaperStream({ label, set, slug, domain, files, related, desc
       [KR.RADIUS_M, r.radiusM != null ? cfloat(r.radiusM) : null],
       [KR.KEY_MATERIAL, r.keyMaterial || null],
       [KR.RETAIN_KEY, (r.keyMaterial && r.retainKey === false) ? false : null],
+      [KR.STEP, r.step ?? null],
     ]))],
   ];
   const bulkyBytes = cborMap(bulky);
@@ -1244,6 +1253,7 @@ async function buildPaperStream({ label, set, slug, domain, files, related, desc
     [K.TITLE, title || null],
     [K.CREATED_AT, createdAt || null],
     [K.DOMAIN, domain || null],
+    [K.STEP, step ?? null],
     [K.BULKY_SHA, await sha256(bulkyBytes)],
   ];
   return concatBytes(cborMap(core), bulkyBytes);
@@ -2258,6 +2268,7 @@ function addRelatedEntry() {
     <div class="row">
       <div><label>Set <small>(optional)</small></label><input type="text" id="rset-${id}"></div>
       <div><label>Slug <small>(optional)</small></label><input type="text" id="rslug-${id}"></div>
+      <div><label>Step <small>(optional — 1-based position of that paper within the Set above, SPEC §4.3; give two entries the same Set+Step to describe a fork)</small></label><input type="number" id="rstep-${id}" min="1" step="1"></div>
     </div>
     <div class="row">
       <div><label>Latitude <small>(optional — for a placeholder map pin)</small></label><input type="text" id="rlat-${id}" placeholder="e.g. -33.8688"></div>
@@ -2292,6 +2303,8 @@ async function computePaperSectorPlan() {
   const slug        = document.getElementById('p-slug').value.trim() || null;
   const domain      = document.getElementById('p-domain').value.trim() || null;
   const description = document.getElementById('p-description').value.trim() || null;
+  const stepRaw     = parseInt(document.getElementById('p-step').value, 10);
+  const step        = Number.isFinite(stepRaw) ? stepRaw : null;
 
   // Collection/icon fields (SPEC §7) — optional. The same values are stamped onto the
   // Paper AND every file's Content QR below, so the finder's home screen can
@@ -2375,6 +2388,7 @@ async function computePaperSectorPlan() {
     const lat = parseFloat(document.getElementById('rlat-' + id)?.value.trim());
     const lng = parseFloat(document.getElementById('rlng-' + id)?.value.trim());
     const radiusM = parseFloat(document.getElementById('rradius-' + id)?.value.trim());
+    const stepRaw = parseInt(document.getElementById('rstep-' + id)?.value, 10);
     const hint = document.getElementById('rhint-' + id)?.value.trim() || '(hint)';
     let paperId, keyMaterial;
     try { paperId = hexToBytes(document.getElementById('rpaperid-' + id)?.value); }
@@ -2389,6 +2403,7 @@ async function computePaperSectorPlan() {
       lat: Number.isFinite(lat) ? lat : null,
       lng: Number.isFinite(lng) ? lng : null,
       radiusM: Number.isFinite(radiusM) ? radiusM : null,
+      step: Number.isFinite(stepRaw) ? stepRaw : null,
     };
   });
 
@@ -2400,7 +2415,7 @@ async function computePaperSectorPlan() {
       label, set, slug, domain, files: manifestFiles, related, description,
       collectionId, collectionLabel, collectionTag, icon,
       lat, lng, radiusM, preferDeclaredLocation, locationLabel,
-      inReplyTo, title, createdAt,
+      inReplyTo, title, createdAt, step,
     }, targetSectorBytes);
   }
   catch(e) { throw new Error(`Paper encoding failed: ${e.message}`); }

--- a/tools/reader/index.html
+++ b/tools/reader/index.html
@@ -541,12 +541,13 @@ const K = {
   SECTOR_INDEX:42, SECTOR_COUNT:43, PARITY:44,
   BULKY_COMPRESSION:45, BULKY_COMPRESSED_BYTES:46, BULKY_SHA:47,
   RADIUS_M:48, PREFER_DECLARED_LOCATION:49,
-  IN_REPLY_TO:50, TITLE:51, CREATED_AT:52, DOMAIN:53, LOCATION_LABEL:54, PIXEL_ART:55
+  IN_REPLY_TO:50, TITLE:51, CREATED_AT:52, DOMAIN:53, LOCATION_LABEL:54, PIXEL_ART:55,
+  STEP:57
 };
 // Local keys for files[] sub-map entries (independent namespace, SPEC §3)
 const KF = { SLUG:1, MIME:2, FILE_ID:3, DESCRIPTION:4, PIXEL_ART:5 };
 // Local keys for related[] sub-map entries (independent namespace, SPEC §3)
-const KR = { HINT:1, SET:2, SLUG:3, PAPER_ID:4, LAT:5, LNG:6, RADIUS_M:7, KEY_MATERIAL:8, RETAIN_KEY:9 };
+const KR = { HINT:1, SET:2, SLUG:3, PAPER_ID:4, LAT:5, LNG:6, RADIUS_M:7, KEY_MATERIAL:8, RETAIN_KEY:9, STEP:10 };
 
 // CBOR-sequence envelope (SPEC §2):
 // tagdrop:<base41( CBOR(version) || CBOR(type) || CBOR(part_meta) || CBOR(sector_bytes) )>
@@ -616,9 +617,10 @@ const KEY_NAMES = {
   45: 'bulky_meta_compression', 46: 'bulky_meta_compressed_bytes', 47: 'bulky_meta_sha256',
   48: 'radius_m', 49: 'prefer_declared_location',
   50: 'in_reply_to', 51: 'title', 52: 'created_at', 53: 'domain', 54: 'location_label', 55: 'pixel_art',
+  57: 'step',
 };
 const FILE_ENTRY_KEY_NAMES = { [KF.SLUG]:'slug', [KF.MIME]:'mime_type', [KF.FILE_ID]:'file_id', [KF.DESCRIPTION]:'description', [KF.PIXEL_ART]:'pixel_art' };
-const RELATED_ENTRY_KEY_NAMES = { [KR.HINT]:'hint', [KR.SET]:'set', [KR.SLUG]:'slug', [KR.PAPER_ID]:'paper_id', [KR.LAT]:'lat', [KR.LNG]:'lng', [KR.RADIUS_M]:'radius_m', [KR.KEY_MATERIAL]:'key_material', [KR.RETAIN_KEY]:'retain_key' };
+const RELATED_ENTRY_KEY_NAMES = { [KR.HINT]:'hint', [KR.SET]:'set', [KR.SLUG]:'slug', [KR.PAPER_ID]:'paper_id', [KR.LAT]:'lat', [KR.LNG]:'lng', [KR.RADIUS_M]:'radius_m', [KR.KEY_MATERIAL]:'key_material', [KR.RETAIN_KEY]:'retain_key', [KR.STEP]:'step' };
 const SUB_KEY_NAMES = { 15: FILE_ENTRY_KEY_NAMES, 16: RELATED_ENTRY_KEY_NAMES };
 
 function toHexDump(bytes) {
@@ -882,6 +884,7 @@ function paperFromParts(parts, rootHash) {
       radiusM:     entry[KR.RADIUS_M] ?? null,
       keyMaterial: entry[KR.KEY_MATERIAL] ?? null,
       retainKey:   entry[KR.RETAIN_KEY] !== false,
+      step:        entry[KR.STEP] ?? null,
     }];
   }) : [];
 
@@ -908,6 +911,7 @@ function paperFromParts(parts, rootHash) {
     title:           parts.core[K.TITLE] ?? null,
     createdAt:       parts.core[K.CREATED_AT] ?? null,
     domain:          parts.core[K.DOMAIN] ?? null,
+    step:            parts.core[K.STEP] ?? null,
   };
 }
 
@@ -1808,6 +1812,37 @@ async function openReplyTarget(kind, id) {
 // Slugs treated as a paper's homepage/landing page (see renderPaper below).
 const HOME_SLUGS = ['index', 'index.html', 'index.md'];
 
+// Google's documented `dir/?api=1` URL scheme (origin + destination + pipe-separated
+// waypoints) tops out around 25 total stops for the consumer maps.google.com UI.
+const GOOGLE_MAPS_MAX_WAYPOINTS = 25;
+
+/** Every locally-known (scanned) paper sharing `set` with this one, that has both a
+ *  `step` (SPEC §4.3) and a resolved location, ordered ascending by step. A paper
+ *  missing either is left out — there's no wire-format way to place it in the
+ *  sequence or on the map, so silently dropping it (rather than guessing) is the
+ *  only safe option. */
+async function collectTrailWaypoints(set) {
+  const papers = await dbGetAll('papers');
+  return papers
+    .filter(p => p.set === set && p.step != null && p.lat != null && p.lng != null)
+    .sort((a, b) => a.step - b.step);
+}
+
+/** Builds a Google Maps multi-stop walking-directions link from ordered waypoints
+ *  (SPEC §4.3's `step`). This draws a routed path along roads/paths between the
+ *  stops, not a straight line through the exact scanned coordinates — the
+ *  practical tradeoff for a link that opens directly in the Google Maps app with
+ *  no import step. */
+function googleMapsTrailUrl(waypoints) {
+  const points = waypoints.slice(0, GOOGLE_MAPS_MAX_WAYPOINTS).map(p => `${p.lat},${p.lng}`);
+  const params = new URLSearchParams({
+    api: '1', origin: points[0], destination: points[points.length - 1], travelmode: 'walking',
+  });
+  const middle = points.slice(1, -1);
+  if (middle.length) params.set('waypoints', middle.join('|'));
+  return `https://www.google.com/maps/dir/?${params.toString()}`;
+}
+
 async function renderPaper(rootHash) {
   const paper = await dbGet('papers', rootHash);
   if (!paper) return;
@@ -1835,6 +1870,17 @@ async function renderPaper(rootHash) {
   if (homeCache) {
     hdr += ' <button class="secondary open-home" data-id="' + escHtml(homeFile.fileId) +
       '" data-slug="' + escHtml(homeFile.slug) + '">🏠 Open homepage</button>';
+  }
+
+  // Trail steps (SPEC §4.3): once at least two locally-known papers in this `set` have
+  // both a `step` and a resolved location, offer a one-tap route through them in order.
+  if (paper.set) {
+    const waypoints = await collectTrailWaypoints(paper.set);
+    if (waypoints.length >= 2) {
+      const url = googleMapsTrailUrl(waypoints);
+      hdr += ' <button class="secondary open-trail-maps" data-url="' + escHtml(url) +
+        '">🧭 Open trail in Google Maps (' + waypoints.length + ' stops)</button>';
+    }
   }
   document.getElementById('paperHeader').innerHTML = hdr;
 
@@ -2331,10 +2377,14 @@ document.getElementById('fileList').addEventListener('click', async e => {
 });
 
 document.getElementById('paperHeader').addEventListener('click', async e => {
-  const btn = e.target.closest('.open-home');
-  if (!btn) return;
-  const cached = await dbGet('caches', btn.dataset.id);
-  if (cached) await showContent(cached.mimeType, cached.content, btn.dataset.slug, btn.dataset.id);
+  const homeBtn = e.target.closest('.open-home');
+  if (homeBtn) {
+    const cached = await dbGet('caches', homeBtn.dataset.id);
+    if (cached) await showContent(cached.mimeType, cached.content, homeBtn.dataset.slug, homeBtn.dataset.id);
+    return;
+  }
+  const trailBtn = e.target.closest('.open-trail-maps');
+  if (trailBtn) window.open(trailBtn.dataset.url, '_blank', 'noopener');
 });
 
 document.getElementById('paperReplyInfo').addEventListener('click', async e => {


### PR DESCRIPTION
## Summary
- Adds an optional `step` field to the wire format (SPEC.md §4.3) — a 1-based absolute ordinal scoped by `set`, letting a decoder show a Paper's position in a trail (`core_meta_item` key 57, Paper only) or the position of a `related[]` pointer's target (local key 10). No declared trail length exists anywhere in the format, so a decoder only knows about the `step` values it has actually seen.
- A **fork** is two or more `related[]` entries sharing both `set` and `step` — presented as alternative next stops. Entries sharing `step` but not `set` are unrelated trails crossing the same hub paper, not a fork.
- Documents missing-tag resilience as authoring guidance (list more than one stop ahead) since the wire format itself has no "skip" concept.
- Fixes a pre-existing bug in SPEC.md's worked example, which still used pre-refactor global key numbers for `files[]`/`related[]` instead of the local key namespace already documented in §3.
- Implements `step` end-to-end: Android `TagDropCodec`/`TagDropPayload` (encode/decode + round-trip test covering the fork case), `tools/reader` (parses `step` and adds a "🧭 Open trail in Google Maps" button that builds a multi-stop walking-directions link ordered by `step` from every locally-scanned paper sharing a `set`), and `tools/generator`'s Paper Layout tab (new "Step" inputs, both for the paper itself and per related entry).

## Test plan
- [x] Added `paperWithStepAndFork` unit test to `TagDropCodecTest.kt` (round-trips a paper's own `step` plus a fork of two `related[]` entries sharing `set`+`step`, and confirms a third entry sharing `step` but a different `set` is kept distinct). Not run in this environment — this project's AGP requires Gradle 9.4+, whose distribution download is blocked by this session's network egress policy, and no compatible Gradle is cached locally. Should run in CI.
- [x] Verified `tools/reader`'s new waypoint-collection/Google-Maps-URL logic and button wiring in headless Chromium against a seeded IndexedDB (ordering, missing-location exclusion, cross-`set` exclusion, click → `window.open` URL).
- [x] Verified the full generator → reader round trip in headless Chromium: built a stepped/forked Paper through the generator's actual UI code path, encoded it, and decoded the resulting `tagdrop:` URI in the reader (a separate implementation) — `step` and the fork/different-`set` distinction survive correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWhpWgqciyoNNnyJZkSUGd