### PR TITLE
Add sneakerweb.org shoutout and note research idea in backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,24 +197,50 @@ again or a concrete need emerges.
   text, never raw camera frames/bitmaps, so this would need a parallel
   capture pipeline (frame access, contour detection, homography warp,
   crop) built from scratch.
+- ~~**Willow-style deterministic tie-break for domain resolution**~~ —
+  **done.** [sneakerweb.org](https://sneakerweb.org)'s underlying **Willow**
+  protocol orders conflicting entries by newest timestamp, then greater hash
+  as a tie-break. SPEC.md's "Picking the closest match" (domain resolution,
+  §7) now uses the same rule as its second tier, between location proximity
+  (still first) and local scan-recency (still the last-resort fallback):
+  among candidates declaring `created_at` (key 52), prefer the newest, tied
+  by greater `root_hash`. Implemented in
+  `TagDropLinkResolver.pickClosestDomainMatch()` (Android only — the web
+  reader has no domain/collection browsing screen to apply this to, per the
+  homepage-convention note above). Required persisting `created_at` onto
+  `ScannedPaper` (it was already parsed from the wire format onto
+  `TagDropPayload.Paper` but never stored) — see `AppDatabase` migration
+  22→23. No SPEC.md wire-format change; this is a pure resolution-algorithm
+  refinement, since `created_at` already existed as an optional field.
 - **Sneakerweb-inspired collection merge/sync** (assessed: *interesting
-  research idea, not started*). [sneakerweb.org](https://sneakerweb.org) is a
-  kindred "physical-media-instead-of-network" project: a peer-to-peer web
-  publishing protocol with no DNS/registrars/hosts, where `.snk` site
-  bundles are traded over physical storage media ("sneakernet") and merged
-  via the **Willow** protocol (CRDT-style sync + forgery prevention).
-  TagDrop's Paper format already covers half of that idea (a multi-file
-  bundle with an `index` homepage convention, see above), but has no
-  merge/versioning story — a paper is an immutable, author-sealed snapshot,
-  with no way to reconcile two independently-updated copies of the same
-  collection later. If TagDrop ever wants *living*, updatable collections
-  instead of always publishing a new sealed paper, Willow's merge approach
-  is worth studying. Not queued as a feature — unclear how mergeable state
-  would interact with the current content-addressed `cache_id`/`sha256`
-  model, and it's a substantial new subsystem (versioning, conflict
-  resolution, forgery prevention) — but worth a revisit if a concrete need
-  for updatable/synced collections shows up. Given a shoutout in the
-  website's "Related Projects" section (`docs/index.html`).
+  research idea, not started*). Willow (the CRDT-style sync/forgery-
+  prevention protocol sneakerweb.org is built on) has a real merge/versioning
+  story that TagDrop's Paper format lacks entirely — a paper is an
+  immutable, author-sealed snapshot, with no way to reconcile two
+  independently-updated copies of the same collection later (the tie-break
+  above picks *between* snapshots, it doesn't merge them). If TagDrop ever
+  wants *living*, updatable collections instead of always publishing a new
+  sealed paper, Willow's merge approach is worth studying in full. Not
+  queued — unclear how mergeable state would interact with the current
+  content-addressed `cache_id`/`sha256` model, and it's a substantial new
+  subsystem (versioning, conflict resolution, forgery prevention) — but
+  worth a revisit if a concrete need for updatable/synced collections shows
+  up. Given a shoutout in the website's "Related Projects" section
+  (`docs/index.html`).
+- **Sneakerweb/Willow interop, one direction only** (assessed: *plausible,
+  long-term, not started*). Willow's live bidirectional sync (WGPS) doesn't
+  fit TagDrop at all — a printed QR/NFC code is a sealed, fire-and-forget
+  monologue with no return channel, unlike Willow's assumption that both
+  peers are reachable for a multi-round-trip negotiation. But a **one-way**
+  export is plausible: a TagDrop `Paper`'s `files[]` already look like a
+  restricted case of Willow `Entry`s (`slug`≈path, `sha256`≈payload_digest,
+  `created_at`≈timestamp), so the app could in principle export a scanned
+  collection as Willow entries/a `.snk`-like bundle for import into a real
+  Willow store — never the reverse, since there's no way to push a Willow
+  update back down onto an already-printed sticker. Not queued — no known
+  Willow-side import format to target yet, and it's unclear anyone
+  scanning TagDrop codes also runs Willow — but worth a revisit if that
+  changes.
 - **NFC: auto-fallback to standard-record-readable tags when they'd fit
   unsplit** (assessed: *medium usefulness, medium complexity — reasonable
   to defer*; tracked in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,24 @@ again or a concrete need emerges.
   text, never raw camera frames/bitmaps, so this would need a parallel
   capture pipeline (frame access, contour detection, homography warp,
   crop) built from scratch.
+- **Sneakerweb-inspired collection merge/sync** (assessed: *interesting
+  research idea, not started*). [sneakerweb.org](https://sneakerweb.org) is a
+  kindred "physical-media-instead-of-network" project: a peer-to-peer web
+  publishing protocol with no DNS/registrars/hosts, where `.snk` site
+  bundles are traded over physical storage media ("sneakernet") and merged
+  via the **Willow** protocol (CRDT-style sync + forgery prevention).
+  TagDrop's Paper format already covers half of that idea (a multi-file
+  bundle with an `index` homepage convention, see above), but has no
+  merge/versioning story — a paper is an immutable, author-sealed snapshot,
+  with no way to reconcile two independently-updated copies of the same
+  collection later. If TagDrop ever wants *living*, updatable collections
+  instead of always publishing a new sealed paper, Willow's merge approach
+  is worth studying. Not queued as a feature — unclear how mergeable state
+  would interact with the current content-addressed `cache_id`/`sha256`
+  model, and it's a substantial new subsystem (versioning, conflict
+  resolution, forgery prevention) — but worth a revisit if a concrete need
+  for updatable/synced collections shows up. Given a shoutout in the
+  website's "Related Projects" section (`docs/index.html`).
 - **NFC: auto-fallback to standard-record-readable tags when they'd fit
   unsplit** (assessed: *medium usefulness, medium complexity — reasonable
   to defer*; tracked in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,28 @@ again or a concrete need emerges.
   Willow-side import format to target yet, and it's unclear anyone
   scanning TagDrop codes also runs Willow — but worth a revisit if that
   changes.
+  - **Signature scheme mismatch, assessed and rejected as a reason to
+    change TagDrop's own scheme.** Willow/Meadowcap authorizes entries with
+    Ed25519; TagDrop signs with ML-DSA-44 (post-quantum, SPEC §10) on
+    purpose — Ed25519 is smaller and has native platform support, but it's
+    exactly the scheme Shor's algorithm breaks outright and retroactively,
+    which matters far more for TagDrop's permanently-sealed printed
+    artifacts than for Willow's live, migratable store. Condition for
+    revisiting TagDrop's own scheme was "only if Willow's choice has
+    technical parity or superiority" — it doesn't, on the axis TagDrop
+    actually optimized for, so no change. If this interop is ever built,
+    the narrower option is adding Ed25519 *verification only* to the
+    reader, to check imported Willow entries' existing signatures, without
+    TagDrop ever signing anything with Ed25519 itself.
+  - **Outreach lead (not yet contacted):** Willow's protocol and
+    (apparently) sneakerweb are maintained by **Aljoscha Meyer** — Codeberg
+    `AljoschaMeyer` (org `worm-blossom`, e.g.
+    [willow_rs](https://codeberg.org/worm-blossom/willow_rs)), personal
+    site [aljoscha-meyer.de](https://aljoscha-meyer.de). No direct email
+    found yet (site fetch kept hitting transient API errors mid-session).
+    Mirrors the existing deaddrops.com outreach in readme.md ("Community
+    conventions" → "Dead Drops project") — once actually sent, document it
+    there the same way, not here.
 - **NFC: auto-fallback to standard-record-readable tags when they'd fit
   unsplit** (assessed: *medium usefulness, medium complexity — reasonable
   to defer*; tracked in

--- a/SPEC.md
+++ b/SPEC.md
@@ -876,15 +876,27 @@ candidate, the app picks a single one using:
    a known location (declared, or resolved from a live GPS fix when it was
    scanned — §4.2's location/priority rules), pick the candidate nearest to
    the device.
-2. Otherwise — no device position, or no candidate has a location — pick
-   the most recently scanned candidate.
+2. Otherwise, among candidates that declare `created_at` (key 52), pick the
+   one with the newest author-declared timestamp, breaking ties by the
+   greater `root_hash` — a deterministic rule (borrowed from the
+   [Willow protocol](https://willowprotocol.org)'s entry-ordering: newest
+   timestamp wins, hash as a stable tie-break) so that two devices which
+   scanned the same set of candidates agree on the pick regardless of the
+   order they scanned them in. Skipped entirely if no candidate declares
+   `created_at`.
+3. Otherwise — no device position, no candidate location, and no candidate
+   declares `created_at` — pick the most recently *scanned* candidate.
 
-This favours "the one you're standing next to" when that's knowable, and
-"the one you saw most recently" otherwise, both better guesses than an
-arbitrary pick. If no known paper matches the name under either field, the
-app reports the domain as not found (with the requested `slug`, so the UI
-can still show what was being looked for) rather than treating it as
-invalid input — the name may simply not have been scanned yet. A future,
+This favours "the one you're standing next to" when that's knowable, then
+"the one the author most recently made" when that's declared, and "the one
+you personally saw most recently" as a last resort — each a better guess
+than an arbitrary pick, and each weaker than the one before it: rule 2 is
+still just an unverified, self-declared clock (like `created_at` always is,
+§3), and rule 3 reflects this device's own discovery order, not the
+content's actual freshness. If no known paper matches the name under either
+field, the app reports the domain as not found (with the requested `slug`,
+so the UI can still show what was being looked for) rather than treating it
+as invalid input — the name may simply not have been scanned yet. A future,
 backward-compatible refinement could prefer, among several candidates, the
 one whose §10 `signer_id` the device has already trusted under this domain
 — pinning *authority* over a name without giving up the name's

--- a/app/src/main/java/com/github/mofosyne/tagdrop/CreatePaperActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/CreatePaperActivity.kt
@@ -247,7 +247,8 @@ class CreatePaperActivity : AppCompatActivity() {
                     slug        = manifest.slug,
                     domain      = manifest.domain,
                     cborBytes   = TagDropCodec.paperStreamBytes(manifest),
-                    createdByMe = true
+                    createdByMe = true,
+                    createdAt   = manifest.createdAt
                 )
             )
             toast(getString(R.string.cache_saved))

--- a/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
@@ -436,7 +436,8 @@ class ReceiveActivity : AppCompatActivity() {
                     locationRadiusM = resolved.radiusM,
                     locationLabel   = resolved.locationLabel,
                     icon            = paper.icon,
-                    inReplyTo       = paper.inReplyTo?.toHex()
+                    inReplyTo       = paper.inReplyTo?.toHex(),
+                    createdAt       = paper.createdAt
                 )
             )
             paper.keyMaterial?.let { handleDiscoveredKey(it, paper.retainKey, paper.label) }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/AppDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [FoundCache::class, ScannedPaper::class, RetainedKey::class, DropSource::class], version = 22, exportSchema = false)
+@Database(entities = [FoundCache::class, ScannedPaper::class, RetainedKey::class, DropSource::class], version = 23, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun cacheDao(): CacheDao
     abstract fun paperDao(): PaperDao
@@ -206,6 +206,14 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_22_23 = object : Migration(22, 23) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Author-declared created_at (SPEC §3, key 52), used as a deterministic
+                // tie-break when several scanned papers claim the same domain name (SPEC §7).
+                db.execSQL("ALTER TABLE scanned_papers ADD COLUMN createdAt INTEGER")
+            }
+        }
+
         private val MIGRATION_20_21 = object : Migration(20, 21) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL(
@@ -260,7 +268,7 @@ abstract class AppDatabase : RoomDatabase() {
                 AppDatabase::class.java,
                 DB_NAME
             )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23)
             .addCallback(SEED_CALLBACK)
             .build().also { INSTANCE = it }
         }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/db/ScannedPaper.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/db/ScannedPaper.kt
@@ -21,7 +21,8 @@ data class ScannedPaper(
     val icon: String? = null,            // optional emoji icon
     val createdByMe: Boolean = false,    // true if authored in-app (Create Paper), not scanned
     val inReplyTo: String? = null,       // hex-encoded cache_id/root_hash of the single parent this is replying to (SPEC §7)
-    val domain: String? = null           // optional human-readable tagdrop://<domain>/<slug> name; falls back to slug if absent (SPEC §7)
+    val domain: String? = null,          // optional human-readable tagdrop://<domain>/<slug> name; falls back to slug if absent (SPEC §7)
+    val createdAt: Long? = null          // author-declared Unix timestamp (seconds) this payload was authored, unverified (SPEC §3); distinct from scannedAt
 ) {
     override fun equals(other: Any?) = other is ScannedPaper && rootHash == other.rootHash
     override fun hashCode() = rootHash.hashCode()

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolver.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolver.kt
@@ -90,7 +90,8 @@ class TagDropLinkResolver(private val db: AppDatabase) {
     /**
      * Resolves a navigation link. [deviceLat]/[deviceLng] are the device's current position
      * (if known) — used only to pick among several papers that claim the same domain name
-     * (SPEC §7 "Picking the closest match"); omitting them just falls back to recency.
+     * (SPEC §7 "Picking the closest match"); omitting them just falls back to `created_at`, then
+     * scan recency.
      */
     suspend fun resolve(uri: String, deviceLat: Double? = null, deviceLng: Double? = null): Resolution {
         return when {
@@ -153,10 +154,19 @@ class TagDropLinkResolver(private val db: AppDatabase) {
 
     /**
      * Finds scanned papers claiming [domainName] — via `domain`, falling back to `slug` when
-     * `domain` is absent (SPEC §7) — matched case-insensitively, and picks the closest one when
-     * more than one matches (domains are unilateral/uncoordinated, so collisions are expected,
-     * not an error): nearest by device position when both a position and at least one
-     * candidate's location are known, otherwise the most recently scanned candidate.
+     * `domain` is absent (SPEC §7) — matched case-insensitively, and picks one when more than one
+     * matches (domains are unilateral/uncoordinated, so collisions are expected, not an error):
+     *
+     * 1. Nearest by device position, when both a position and at least one candidate's location
+     *    are known.
+     * 2. Otherwise, among candidates that declare `created_at` (SPEC §3, key 52), the one with
+     *    the newest author-declared timestamp — a deterministic, Willow-style tie-break
+     *    (`created_at` first, `root_hash` as a stable secondary key) so two devices that scanned
+     *    the same candidates agree on the pick regardless of the order they scanned them in.
+     *    Skipped entirely if no candidate declares `created_at`.
+     * 3. Otherwise, the most recently *scanned* candidate — a purely local, device-specific
+     *    fallback signal, weaker than 2 because it reflects this device's discovery order, not
+     *    the content's actual authored freshness.
      */
     private suspend fun pickClosestDomainMatch(domainName: String, deviceLat: Double?, deviceLng: Double?): ScannedPaper? {
         val candidates = db.paperDao().getAllPapers().filter {
@@ -168,6 +178,10 @@ class TagDropLinkResolver(private val db: AppDatabase) {
             if (located.isNotEmpty()) {
                 return located.minByOrNull { haversineMeters(deviceLat, deviceLng, it.lat!!, it.lng!!) }
             }
+        }
+        val declaresCreatedAt = candidates.filter { it.createdAt != null }
+        if (declaresCreatedAt.isNotEmpty()) {
+            return declaresCreatedAt.maxWithOrNull(compareBy({ it.createdAt }, { it.rootHash }))
         }
         return candidates.maxByOrNull { it.scannedAt }
     }

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolverTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropLinkResolverTest.kt
@@ -91,7 +91,8 @@ class TagDropLinkResolverTest {
         domain: String? = null,
         scannedAt: Long = 0L,
         lat: Double? = null,
-        lng: Double? = null
+        lng: Double? = null,
+        createdAt: Long? = null
     ): ScannedPaper {
         val (manifest, _) = TagDropCodec.createPaper(label = label, set = null, slug = slug, files = files, domain = domain)
         val paper = ScannedPaper(
@@ -103,6 +104,7 @@ class TagDropLinkResolverTest {
             domain = domain,
             lat = lat,
             lng = lng,
+            createdAt = createdAt,
             cborBytes = TagDropCodec.paperStreamBytes(manifest)
         )
         paperDao.papers[paper.rootHash] = paper
@@ -383,6 +385,43 @@ class TagDropLinkResolverTest {
         // Device position is known, but no candidate declares a location -- falls back to recency.
         val result = resolver.resolve("tagdrop://cafe", deviceLat = 10.0, deviceLng = 10.0)
         assertEquals(TagDropLinkResolver.Resolution.PaperFound(newer, null), result)
+    }
+
+    // ── created_at tie-break (SPEC §7 "Picking the closest match", Willow-style) ─
+
+    @Test fun multipleDomainClaimsPreferNewerCreatedAtOverScanRecency() = runBlocking {
+        // Scanned in the opposite order to createdAt -- the author-declared timestamp wins over
+        // this device's own scan-discovery order, which is only a weaker, last-resort signal.
+        storePaper(label = "Scanned Last, Authored First", domain = "cafe", scannedAt = 2L, createdAt = 100L)
+        val authoredNewer = storePaper(label = "Scanned First, Authored Last", domain = "cafe", scannedAt = 1L, createdAt = 200L)
+        val result = resolver.resolve("tagdrop://cafe")
+        assertEquals(TagDropLinkResolver.Resolution.PaperFound(authoredNewer, null), result)
+    }
+
+    @Test fun multipleDomainClaimsCreatedAtTieBreaksByRootHash() = runBlocking {
+        // Equal created_at: the deterministic secondary key (greater root_hash) decides, not
+        // scan order, so two devices that scanned both candidates always agree on the pick.
+        val a = storePaper(label = "Candidate A", domain = "cafe", scannedAt = 1L, createdAt = 100L)
+        val b = storePaper(label = "Candidate B", domain = "cafe", scannedAt = 2L, createdAt = 100L)
+        val expected = if (a.rootHash > b.rootHash) a else b
+        val result = resolver.resolve("tagdrop://cafe")
+        assertEquals(TagDropLinkResolver.Resolution.PaperFound(expected, null), result)
+    }
+
+    @Test fun multipleDomainClaimsLocationStillTakesPriorityOverCreatedAt() = runBlocking {
+        val near = storePaper(label = "Near Cafe", domain = "cafe", lat = 10.0, lng = 10.0, createdAt = 100L)
+        storePaper(label = "Far Cafe", domain = "cafe", lat = 50.0, lng = 50.0, createdAt = 200L)
+        val result = resolver.resolve("tagdrop://cafe", deviceLat = 10.1, deviceLng = 10.1)
+        assertEquals(TagDropLinkResolver.Resolution.PaperFound(near, null), result)
+    }
+
+    @Test fun multipleDomainClaimsIgnoreCandidatesWithoutCreatedAtWhenAtLeastOneDeclaresIt() = runBlocking {
+        // "Newer Cafe" was scanned more recently, but doesn't declare created_at, so it's
+        // skipped by rule 2 entirely -- the one candidate that does declare it wins.
+        storePaper(label = "Newer Scan, No created_at", domain = "cafe", scannedAt = 2L)
+        val declared = storePaper(label = "Older Scan, Declares created_at", domain = "cafe", scannedAt = 1L, createdAt = 50L)
+        val result = resolver.resolve("tagdrop://cafe")
+        assertEquals(TagDropLinkResolver.Resolution.PaperFound(declared, null), result)
     }
 
     // ── HOME_SLUGS convention ─────────────────────────────────────────────────

--- a/docs/index.html
+++ b/docs/index.html
@@ -215,6 +215,12 @@
         </div>
         <p>The free, community-built map of the world. TagDrop uses OSM for its map view and recommends tagging physical drops with <code>tagdrop=&lt;uri&gt;</code> so the community can find them.</p>
       </a>
+      <a class="tool-card" href="https://sneakerweb.org" target="_blank" rel="noopener">
+        <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px">
+          <h3 style="margin:0">Sneakerweb</h3>
+        </div>
+        <p>A peer-to-peer web publishing protocol with no DNS, registrars, or hosts — sites are traded as <code>.snk</code> files over physical storage media ("sneakernet") and merged with the Willow protocol. Shares TagDrop's physical-media-as-network spirit, at the scale of a whole synced, mergeable website rather than a single sealed drop.</p>
+      </a>
     </div>
   </section>
 


### PR DESCRIPTION
Sneakerweb shares TagDrop's physical-media-as-network spirit (sneakernet
file trading vs. QR/NFC drops) but at website-publishing scale with
Willow-based merge/sync, which TagDrop's sealed Paper snapshots don't
have. Cross-linked on the website and flagged as a future research idea.