### PR TITLE
Remove legacy data: URI support; gate non-TagDrop scans behind opt-in…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1536,6 +1536,78 @@ wrapper still can't download its own distribution. The standalone
 `kotlinc`+JUnit harness remains the substitute verification this
 project has relied on throughout its QDEF history.
 
+### Legacy `data:` URI support removed; non-TagDrop scans gated behind an opt-in preview
+
+Two related receiver-side changes, both user-requested and both scoped to
+the Android app only (the JS web tools have no equivalent legacy path or
+raw-scan auto-import behavior to begin with — confirmed by grep before
+concluding no JS changes were needed).
+
+**Legacy `data:` URI support removed.** SPEC.md §11 previously described
+a **legacy mode**: a code containing a raw `data:` URI (not the
+`tagdrop:` scheme) was recognized specially — a single code opened
+directly, multiple codes dumb-appended in scan order (the original V1
+behavior) — with the document stating "legacy support will be maintained
+indefinitely." That promise is withdrawn: `TagDropCodec.decode()` no
+longer special-cases a `data:` prefix (it's now just another
+non-`tagdrop:` string, returning null same as any unrecognized scheme);
+`TagDropPayload.Legacy` and `TagDropScan.LegacyScan` are deleted outright,
+narrowing `decode()`/`decodeRaw()`'s return type from `TagDropScan?` to
+`TagDropScan.RecordScan?` now that it's the sealed class's only remaining
+case (a real type-checker catch during this change: `ReceiveActivity.kt`'s
+`barcodeCallback`'s local `tryBytes()` helper still declared a `TagDropScan?`
+return type feeding into `processScan(scan: TagDropScan.RecordScan)` —
+narrowed to match, or it wouldn't have compiled). `ReceiveActivity.kt`
+loses `legacyChunks`/`tryCompleteLegacy()`/`launchLegacyContent()`/
+`parseLegacyDataUri()` and the "Launch Content (legacy)" button
+(`activity_receive.xml`, `strings.xml`); a scanned `data:` URI now falls
+through to the same generic non-TagDrop content path as a URL, vCard, or
+plain text QR code (see below) instead of being auto-opened. SPEC.md §11's
+heading and section number are kept as a deliberate placeholder ("removed"
+appended to the title, content rewritten to say so) rather than deleting
+the section and renumbering §12 onward — avoids invalidating every other
+`§12`/`§13`/etc. cross-reference elsewhere in the document for a promise
+that's simply being withdrawn, not replaced by a differently-numbered
+one.
+
+**Non-TagDrop scans no longer auto-import.** Follow-up ask, arriving
+mid-session: a scanned code that isn't a TagDrop payload — a URL, vCard,
+Wi-Fi config, or any other content `QrContentClassifier`/`MimeTypeGuesser`
+can't (or can) make sense of — was previously cached and opened
+immediately by `completeRawScan()`. Unlike a `tagdrop:` payload (an
+intentional dead-drop with author-declared metadata), a stray non-TagDrop
+scan is unauthenticated and unvetted — "a tag full of gibberish is not
+something people would care about" was the concrete framing. `completeRawScan()`
+now gates on a new suspend dialog, `askImportRawScan()` (same
+`CompletableDeferred`-bridges-`AlertDialog` pattern already used by
+`askAddSource`/`askPassphrase`): shows the first `RAW_SCAN_PREVIEW_BYTES`
+(64) bytes as hex and as best-effort UTF-8 (Java's `String(bytes,
+Charsets.UTF_8)` replaces invalid sequences with U+FFFD rather than
+throwing, so this never crashes on arbitrary binary) side by side, so the
+user can visually guess what it is, with explicit Import/Discard buttons —
+nothing is cached or opened until Import is tapped. Two cases skip the
+prompt, both because it would be pure friction for content the user has
+already effectively vetted: content already declared by a Paper the user
+is actively scanning (`paperFile` matches the currently-open Paper's
+manifest — an expected, intentional part of a trail the user engaged with
+by scanning the Paper itself, not a stray find) and anything already
+cached (re-scanning something already imported shouldn't re-prompt every
+time). This is reader-side UX, not a wire-format change — no SPEC.md
+entry, matching how §11's rewrite above frames non-TagDrop content
+handling as "an implementation detail, not part of this wire format."
+
+Verified: the `data/format` package (Android-framework-free) recompiles
+clean and the full suite passes (195/195, one fewer than before since the
+removed `legacyDataUriDecodesToLegacyScan` test folded into
+`navigationLinkAndUnknownSchemesReturnNull`, asserting a `data:` URI now
+returns null same as any other unrecognized scheme) via the same
+standalone `kotlinc`+JUnit harness this project's QDEF port has used
+throughout. `ReceiveActivity.kt` itself can't compile in that harness
+(Android framework classes aren't vendored, the same longstanding gap
+noted throughout this file) — verified by careful hand re-reading instead,
+which is what caught the `tryBytes()` return-type mismatch above before
+it could ship.
+
 ### Known duplication (not yet deduped)
 
 `tools/generator/index.html`'s codec helpers — Base41 (`base41Encode`/

--- a/SPEC.md
+++ b/SPEC.md
@@ -2203,14 +2203,24 @@ Media Preview (Type 7) {              // global — no namespace item; no key 0
 
 ---
 
-## 11. Backward Compatibility: Legacy `data:` URIs
+## 11. Backward Compatibility: Legacy `data:` URIs (removed)
 
-Codes containing a raw `data:` URI (without the `tagdrop:` scheme) are recognised and handled in **legacy mode**:
+Earlier versions of this document specified a **legacy mode** recognising a
+raw `data:` URI (without the `tagdrop:` scheme) as TagDrop-originated
+content — a single code opened directly, multiple codes **dumb-appended**
+in scan order (the original V1 behaviour) and the assembled string
+interpreted as a `data:` URI — despite `data:` never having been a TagDrop-
+specific scheme (any QR generator can produce one). This document
+previously stated that "legacy support will be maintained indefinitely";
+that promise is withdrawn as of this version. The reference implementation
+no longer recognises a scanned `data:` URI specially: it is handled the
+same as any other non-`tagdrop:` code — reader-side handling of
+non-TagDrop content is an implementation detail, not part of this wire
+format, and isn't otherwise specified here.
 
-- A single code: the data URI is opened directly in the WebView viewer.
-- Multiple codes: fragments are **dumb-appended** in scan order (the original V1 behaviour). The assembled string is interpreted as a `data:` URI.
-
-New content should use the `tagdrop:` scheme. Legacy support will be maintained indefinitely.
+This section number is kept, unused, rather than renumbering every section
+after it — an existing SPEC.md cross-reference to `§12`/`§13`/etc. should
+keep pointing at what it always has.
 
 ---
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/ReceiveActivity.kt
@@ -71,15 +71,13 @@ import kotlinx.coroutines.launch
  * Every `tagdrop:` code is a sector ([SectorAssembler]); a single-sector cache is saved and
  * opened immediately, while a multi-sector cache accumulates until every sector is collected
  * (order-independent — useful for geographic distribution across a trail). Papers are saved
- * as directories and displayed for browsing. Legacy data: URI fragments use dumb-append mode
- * for backward compatibility.
+ * as directories and displayed for browsing.
  */
 class ReceiveActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityReceiveBinding
 
     private val assembler = SectorAssembler()
-    private val legacyChunks = mutableListOf<String>()
     private var lastPaper: TagDropPayload.Paper? = null
 
     /** All cached items, used to mark a scanned paper's files as found on the scan board. */
@@ -127,7 +125,7 @@ class ReceiveActivity : AppCompatActivity() {
             // use by completeRawScan's MIME guessing for non-TagDrop binary QRs.
             var firstRawBytes: ByteArray? = null
 
-            fun tryBytes(bytes: ByteArray, source: String): TagDropScan? {
+            fun tryBytes(bytes: ByteArray, source: String): TagDropScan.RecordScan? {
                 if (firstRawBytes == null) firstRawBytes = bytes
                 val scan = TagDropCodec.decodeRaw(bytes)
                 if (scan != null) Log.d("ReceiveActivity", "decodeRaw OK ($source): ${bytes.size}B")
@@ -263,7 +261,6 @@ class ReceiveActivity : AppCompatActivity() {
         }
 
         binding.buttonClear.setOnClickListener  { clearState() }
-        binding.buttonLaunch.setOnClickListener { launchLegacyContent() }
         binding.buttonPasteUri.setOnClickListener { decodePastedUri() }
         binding.editPasteUri.setOnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_GO) { decodePastedUri(); true } else false
@@ -378,7 +375,6 @@ class ReceiveActivity : AppCompatActivity() {
     private fun showCameraPermissionDenied() {
         binding.barcodeScanner.visibility = View.GONE
         binding.recyclerScanBoard.visibility = View.GONE
-        binding.buttonLaunch.visibility = View.GONE
         binding.buttonClear.visibility = View.GONE
         binding.textStatus.text = getString(R.string.camera_permission_denied)
         binding.textStatus.setOnClickListener { openAppSettings() }
@@ -387,7 +383,6 @@ class ReceiveActivity : AppCompatActivity() {
     /** Restores the normal scanning UI once camera access is granted. */
     private fun restoreScannerUi() {
         binding.barcodeScanner.visibility = View.VISIBLE
-        binding.buttonLaunch.visibility = View.VISIBLE
         binding.buttonClear.visibility = View.VISIBLE
         binding.textStatus.setOnClickListener(null)
         updateDisplay()
@@ -427,47 +422,25 @@ class ReceiveActivity : AppCompatActivity() {
         when {
             // tagdrop://... is a navigation link meant for use inside a page, not a code to scan.
             scanned.startsWith("tagdrop://") -> toast(getString(R.string.nav_link_scanned))
-            // tagdrop:... that failed to decode: unsupported version or corrupted data — not a legacy fragment.
+            // tagdrop:... that failed to decode: unsupported version or corrupted data.
             scanned.startsWith("tagdrop:") -> toast(getString(R.string.unsupported_code))
-            // Already mid-accumulating a legacy data: URI split across codes (SPEC §11, started by
-            // a prior data:-prefixed scan, handled via TagDropScan.LegacyScan) -- this fragment
-            // continues it.
-            legacyChunks.isNotEmpty() -> {
-                legacyChunks.add(scanned)
-                if (!tryCompleteLegacy()) {
-                    updateDisplay()
-                    toast(getString(R.string.unknown_fragment, legacyChunks.size))
-                }
-            }
-            // A complete, standalone non-TagDrop code (URL, plain text, vCard, Wi-Fi config, ...)
-            // -- SPEC.md defines no multi-fragment scheme for these (§11 is data: URIs only), so
-            // there's no "more fragments" to wait for. Cache it immediately as content-addressed
-            // raw content instead of stranding it in legacyChunks with no way to complete.
+            // A complete, standalone non-TagDrop code (URL, plain text, vCard, Wi-Fi config, ...,
+            // including a raw data: URI, no longer given special multi-fragment handling) — cache
+            // it immediately as content-addressed raw content.
             else -> completeRawScan(scanned, format, rawBytes)
         }
     }
 
     /**
-     * Dispatches an already-decoded scan, regardless of whether it arrived as `tagdrop:` URI
-     * text (Base41) or a fully-binary code's raw CBOR sequence (SPEC §13) — see [barcodeCallback].
-     * A record is fed to [SectorAssembler]; a legacy data: URI joins the dumb-append buffer.
+     * Dispatches an already-decoded [TagDropScan.RecordScan], regardless of whether it arrived
+     * as `tagdrop:` URI text (Base41) or a fully-binary code's raw CBOR sequence (SPEC §13) —
+     * see [barcodeCallback]. Fed straight to [SectorAssembler].
      */
-    private fun processScan(scan: TagDropScan) {
-        when (scan) {
-            is TagDropScan.RecordScan -> {
-                lastScannedRecord = scan.record
-                lastScannedWireBytes = scan.rawWireBytes
-                invalidateOptionsMenu()
-                handleState(assembler.add(scan.record))
-            }
-            is TagDropScan.LegacyScan -> {
-                legacyChunks.add(scan.payload.dataUri)
-                if (!tryCompleteLegacy()) {
-                    updateDisplay()
-                    toast(getString(R.string.legacy_fragment, legacyChunks.size))
-                }
-            }
-        }
+    private fun processScan(scan: TagDropScan.RecordScan) {
+        lastScannedRecord = scan.record
+        lastScannedWireBytes = scan.rawWireBytes
+        invalidateOptionsMenu()
+        handleState(assembler.add(scan.record))
     }
 
     /** Routes a freshly-computed [SectorAssembler.State] for the just-scanned record's payload. */
@@ -825,6 +798,43 @@ class ReceiveActivity : AppCompatActivity() {
     }
 
     /**
+     * Suspends the coroutine while showing a preview of unrecognized, non-TagDrop scanned
+     * content — the first [RAW_SCAN_PREVIEW_BYTES] bytes as hex and as best-effort UTF-8, so
+     * the user can visually guess what it is before deciding whether it's worth keeping.
+     * Random/unsolicited content (a QR code found on a sticker, a gibberish NFC tag, ...) is
+     * never auto-imported or auto-opened; the user must explicitly opt in. Returns true if the
+     * user chose to import.
+     */
+    private suspend fun askImportRawScan(bytes: ByteArray, mimeType: String, title: String?): Boolean {
+        val deferred = CompletableDeferred<Boolean>()
+        runOnUiThread {
+            AlertDialog.Builder(this)
+                .setTitle(title ?: getString(R.string.raw_scan_preview_title))
+                .setMessage(getString(R.string.raw_scan_preview_message, mimeType, previewBytesText(bytes)))
+                .setPositiveButton(getString(R.string.raw_scan_import)) { _, _ -> deferred.complete(true) }
+                .setNegativeButton(getString(R.string.raw_scan_discard)) { _, _ -> deferred.complete(false) }
+                .setOnCancelListener { deferred.complete(false) }
+                .show()
+        }
+        return deferred.await()
+    }
+
+    /** First [RAW_SCAN_PREVIEW_BYTES] of [bytes], rendered as hex and as best-effort UTF-8 (invalid
+     *  sequences become U+FFFD) side by side, for [askImportRawScan]'s preview dialog. */
+    private fun previewBytesText(bytes: ByteArray): String {
+        val slice = bytes.copyOfRange(0, minOf(RAW_SCAN_PREVIEW_BYTES, bytes.size))
+        val hex = slice.joinToString(" ") { "%02x".format(it) }
+        val utf8 = String(slice, Charsets.UTF_8)
+        val sizeNote = if (bytes.size > slice.size) {
+            getString(R.string.raw_scan_preview_truncated, slice.size, bytes.size)
+        } else {
+            getString(R.string.raw_scan_preview_full, bytes.size)
+        }
+        return "$sizeNote\n\n${getString(R.string.raw_scan_preview_hex_label)}\n$hex\n\n" +
+            "${getString(R.string.raw_scan_preview_utf8_label)}\n$utf8"
+    }
+
+    /**
      * A `key_material` (SPEC §9) was just discovered — retain it (if recommended), then try
      * it against everything currently locked: cached ciphertext awaiting a key, and any
      * in-progress encrypted assembly. "Discovery, not declaration": scan order between a key
@@ -907,29 +917,8 @@ class ReceiveActivity : AppCompatActivity() {
     }
 
     /**
-     * After each legacy fragment is appended, try to parse the joined string as a
-     * complete `data:` URI. If it parses and the base64 decodes cleanly, save it as
-     * a [FoundCache] entry and open it — no button press needed.
-     * Returns true if completed (caller should skip the "N fragment(s)" toast).
-     */
-    private fun tryCompleteLegacy(): Boolean {
-        val joined = legacyChunks.joinToString("")
-        val parsed = parseLegacyDataUri(joined) ?: return false
-        val (mimeType, bytes) = parsed
-        legacyChunks.clear()
-        completeSingle(
-            cacheId    = TagDropCodec.contentId(bytes).toHex(),
-            hint       = null,
-            filename   = null,
-            mimeType   = mimeType,
-            content    = bytes
-        )
-        return true
-    }
-
-    /**
-     * Caches a complete non-TagDrop, non-legacy scan (a URL, plain text, vCard, Wi-Fi config,
-     * ...) as standalone content, the same way any other found item is cached -- content-
+     * Caches a complete non-TagDrop scan (a URL, plain text, vCard, Wi-Fi config, ...) as
+     * standalone content, the same way any other found item is cached -- content-
      * addressed by [TagDropCodec.contentId] so re-scanning the same code is recognised as
      * "already found" rather than duplicated. [QrContentClassifier] tags recognised content
      * (vCard, calendar event, Wi-Fi config, URL, ...) with a hashtag-style collectionTag, an
@@ -938,6 +927,14 @@ class ReceiveActivity : AppCompatActivity() {
      * SSID, event summary, ...) becomes this cache's `hint`, the same field every list/title
      * display already falls back to "Untitled" without -- there's no author-declared hint for
      * non-TagDrop content, so this is the only source of a human-readable title.
+     *
+     * Unsolicited, non-TagDrop content is never auto-imported: it's unauthenticated and
+     * unvetted (a random sticker, a gibberish NFC tag), so [askImportRawScan] previews it
+     * (hex + UTF-8) and requires an explicit opt-in before it's cached or opened. The one
+     * exception is content already declared by a Paper the user is actively scanning
+     * ([paperFile] matches) -- that's a known, intentional part of the trail the user already
+     * engaged with by scanning the Paper itself, so it's cached immediately as before, same as
+     * re-scanning anything already found.
      */
     private fun completeRawScan(text: String, format: BarcodeFormat, rawBytes: ByteArray? = null) {
         // cacheId is always derived from the text representation (UTF-8), matching how the paper
@@ -958,7 +955,8 @@ class ReceiveActivity : AppCompatActivity() {
         } else {
             (MimeTypeGuesser.guess(bytes) ?: "text/plain") to true
         }
-        completeSingle(
+
+        fun cache() = completeSingle(
             cacheId          = cacheId,
             hint             = classification?.title,
             filename         = null,
@@ -969,31 +967,13 @@ class ReceiveActivity : AppCompatActivity() {
             pixelArt         = paperFile?.pixelArt ?: false,
             mimeTypeIsGuessed = isGuessed
         )
-    }
 
-    private fun launchLegacyContent() {
-        if (legacyChunks.isEmpty()) return
-        val joined = legacyChunks.joinToString("")
-        val parsed = parseLegacyDataUri(joined)
-        if (parsed != null) {
-            val (mimeType, bytes) = parsed
-            legacyChunks.clear()
-            completeSingle(TagDropCodec.contentId(bytes).toHex(), null, null, mimeType, bytes)
-        } else {
-            openDataUri(joined)
+        if (paperFile != null) { cache(); return }
+        lifecycleScope.launch {
+            val alreadyFound = AppDatabase.get(this@ReceiveActivity).cacheDao().getById(cacheId) != null
+            if (alreadyFound || askImportRawScan(bytes, mimeType, classification?.title)) cache()
+            else toast(getString(R.string.raw_scan_discarded))
         }
-    }
-
-    private fun parseLegacyDataUri(dataUri: String): Pair<String, ByteArray>? {
-        if (!dataUri.startsWith("data:")) return null
-        val comma = dataUri.indexOf(',')
-        if (comma < 0) return null
-        val header = dataUri.substring(5, comma)
-        if (!header.endsWith(";base64")) return null
-        val bytes = runCatching {
-            android.util.Base64.decode(dataUri.substring(comma + 1), android.util.Base64.NO_WRAP)
-        }.getOrNull()?.takeIf { it.isNotEmpty() } ?: return null
-        return header.removeSuffix(";base64") to bytes
     }
 
     private fun openContent(mimeType: String, bytes: ByteArray, cacheId: String? = null) {
@@ -1012,7 +992,6 @@ class ReceiveActivity : AppCompatActivity() {
 
     private fun clearState() {
         assembler.reset()
-        legacyChunks.clear()
         lastPaper = null
         updateDisplay()
     }
@@ -1027,10 +1006,6 @@ class ReceiveActivity : AppCompatActivity() {
         } else {
             binding.recyclerScanBoard.visibility = View.GONE
             binding.textStatus.text = when {
-                legacyChunks.isNotEmpty() -> {
-                    getString(R.string.status_legacy, legacyChunks.size) + "\n\n" +
-                        legacyChunks.joinToString("").take(300)
-                }
                 !assembler.hasPending -> getString(R.string.status_ready)
                 else -> when (val state = assembler.currentState()) {
                     is SectorAssembler.State.Collecting ->
@@ -1043,7 +1018,6 @@ class ReceiveActivity : AppCompatActivity() {
                 }
             }
         }
-        binding.buttonLaunch.isEnabled = legacyChunks.isNotEmpty()
     }
 
     /** Renders 0-based missing sector indices as 1-based "#1, #2" for display — sectors can be scanned in any order, so list all of them, not just the next. */
@@ -1076,6 +1050,9 @@ class ReceiveActivity : AppCompatActivity() {
 
         /** Expected length of a SPEC §9 AES-256-GCM `key_material`. */
         private const val KEY_MATERIAL_BYTES = 32
+
+        /** How many leading bytes [askImportRawScan]'s hex/UTF-8 preview shows. */
+        private const val RAW_SCAN_PREVIEW_BYTES = 64
 
         private const val PREFS_NAME = "tagdrop_prefs"
         private const val PREF_LOCATION_RATIONALE_SHOWN = "location_rationale_shown"

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
@@ -46,7 +46,7 @@ import javax.crypto.spec.SecretKeySpec
  * or Split-wrapped (with Media Preview becoming *Split's* subrecord instead) when it doesn't.
  * Content Signature (declared Type 2, wire `-2`, TagDrop-scoped), present only when signed, nests as Media
  * Payload's own subrecord, so `signature`/`signer_pubkey` travel once per payload regardless
- * of how many codes it spans. [decode]/[decodeRaw] return a [TagDropScan]; feed each
+ * of how many codes it spans. [decode]/[decodeRaw] return a [TagDropScan.RecordScan]; feed each
  * [ScannedRecord] to [SectorAssembler] to reassemble and parse the payload it belongs to.
  *
  * Paper (SPEC §3.3-§3.4) is a flat Preview/Body pair (Types 3/4).
@@ -1016,12 +1016,10 @@ object TagDropCodec {
     // ── Decoding (SPEC §2, §5.1) ────────────────────────────────────────────────
 
     /**
-     * Decodes one scanned string into a [TagDropScan]: a `tagdrop:` encoding URI becomes a
-     * [TagDropScan.RecordScan]; a raw `data:` URI becomes a [TagDropScan.LegacyScan] (§11).
-     * Navigation links (`tagdrop://`, §2) and anything else return null.
+     * Decodes one scanned string into a [TagDropScan.RecordScan]. Navigation links
+     * (`tagdrop://`, §2) and anything not on the `tagdrop:` scheme return null.
      */
-    fun decode(scanned: String): TagDropScan? {
-        if (scanned.startsWith("data:")) return TagDropScan.LegacyScan(TagDropPayload.Legacy(scanned))
+    fun decode(scanned: String): TagDropScan.RecordScan? {
         if (!scanned.startsWith(SCHEME) || scanned.startsWith(NAV_LINK_PREFIX)) return null
         val bytes = runCatching { Base41.decode(scanned.removePrefix(SCHEME)) }.getOrNull() ?: return null
         return decodeRaw(bytes)
@@ -1033,7 +1031,7 @@ object TagDropCodec {
      * NDEF, byte-mode QR with optional QDEF framing). Returns null for an unrecognized
      * leading Type ID or malformed sequence.
      */
-    fun decodeRaw(bytes: ByteArray): TagDropScan? =
+    fun decodeRaw(bytes: ByteArray): TagDropScan.RecordScan? =
         recordScanResult(stripQdefFraming(bytes))?.let { TagDropScan.RecordScan(it, rawWireBytes = bytes) }
 
     /** SPEC §2.2 even/odd criticality: an unrecognized EVEN key means this decoder can't

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
@@ -156,9 +156,6 @@ sealed class TagDropPayload {
         override fun equals(other: Any?) = other is Paper && rootHash.contentEquals(other.rootHash)
         override fun hashCode() = rootHash.contentHashCode()
     }
-
-    /** Raw data: URI from the original tagdrop format (backward compatibility). */
-    data class Legacy(val dataUri: String) : TagDropPayload()
 }
 
 /** Which payload kind a scanned code's small, always-repeated Record belongs to (SPEC §2.1). */
@@ -309,10 +306,9 @@ data class SplitFragment(
 }
 
 /**
- * What one scanned/printed code decoded to. A [RecordScan] always needs [SectorAssembler]
- * to resolve into a usable [TagDropPayload] — even a single-code payload is technically a
- * one-code group — while a [LegacyScan] is already a complete, displayable
- * [TagDropPayload.Legacy].
+ * What one scanned/printed `tagdrop:` code decoded to. Always needs [SectorAssembler] to
+ * resolve into a usable [TagDropPayload] — even a single-code payload is technically a
+ * one-code group.
  */
 sealed class TagDropScan {
     data class RecordScan(val record: ScannedRecord, val rawWireBytes: ByteArray? = null) : TagDropScan() {
@@ -331,7 +327,6 @@ sealed class TagDropScan {
             return result
         }
     }
-    data class LegacyScan(val payload: TagDropPayload.Legacy) : TagDropScan()
 }
 
 /**

--- a/app/src/main/res/layout/activity_receive.xml
+++ b/app/src/main/res/layout/activity_receive.xml
@@ -50,14 +50,6 @@
             android:visibility="gone" />
 
         <Button
-            android:id="@+id/buttonLaunch"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:enabled="false"
-            android:text="@string/button_launch" />
-
-        <Button
             android:id="@+id/buttonClear"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,6 @@
     <string name="delete_collection_confirm_message">Remove \"%1$s\" and all %2$d cached item(s) in this collection from this device? This cannot be undone.</string>
 
     <!-- Receive screen -->
-    <string name="button_launch">Launch Content (legacy)</string>
     <string name="button_clear">Clear</string>
     <string name="hint_paste_uri">Or paste a tagdrop: URI</string>
     <string name="button_decode_uri">Decode</string>
@@ -54,15 +53,12 @@
     <string name="button_qdef_spec">QDEF Wire Format Spec</string>
     <string name="status_ready">Point the camera at a TagDrop code to begin.</string>
     <string name="status_collecting">Collecting chunks: %1$d / %2$d\nHint: %3$s\n\nStill need: %4$s</string>
-    <string name="status_legacy">Legacy mode: %1$d fragment(s) accumulated.\n\nTap \'Launch Content\' when done.</string>
     <string name="manifest_scanned">Manifest scanned (%1$d chunks expected). Scan chunks now.</string>
     <string name="chunk_progress">Chunk %1$d of %2$d received. Still need: %3$s</string>
     <string name="hash_mismatch">Assembly failed: integrity check failed. Try rescanning.</string>
     <string name="key_code_scanned">🔑 Key received — scan its matching content code to unlock it.</string>
     <string name="awaiting_key">🔒 All chunks assembled, but still locked — scan the key code to unlock.</string>
     <string name="unlocked_items">🔓 Unlocked %1$d item(s) with this key.</string>
-    <string name="legacy_fragment">Legacy fragment %1$d received. Scan more or tap Launch.</string>
-    <string name="unknown_fragment">Fragment %1$d added. Scan more or tap Launch.</string>
     <string name="nav_link_scanned">That\'s a link for use inside a page, not a code to scan directly.</string>
     <string name="unsupported_code">This TagDrop code can\'t be read — it may use an unsupported version or be corrupted.</string>
     <string name="camera_permission_denied">Camera access is needed to scan codes.\nTap here to enable it in Settings.</string>
@@ -70,6 +66,15 @@
     <string name="location_permission_message">TagDrop can record where you scan and create drops, so they show up on the Map tab. This is optional — scanning still works without it.</string>
     <string name="location_permission_allow">Allow</string>
     <string name="location_permission_not_now">Not now</string>
+    <string name="raw_scan_preview_title">Unrecognized code</string>
+    <string name="raw_scan_preview_message">Not a TagDrop code — guessed type: %1$s\n\n%2$s</string>
+    <string name="raw_scan_preview_hex_label">Hex:</string>
+    <string name="raw_scan_preview_utf8_label">UTF-8:</string>
+    <string name="raw_scan_preview_truncated">Showing first %1$d of %2$d bytes.</string>
+    <string name="raw_scan_preview_full">%1$d byte(s).</string>
+    <string name="raw_scan_import">Import</string>
+    <string name="raw_scan_discard">Discard</string>
+    <string name="raw_scan_discarded">Discarded.</string>
 
     <!-- Collection detail ("map") screen -->
     <string name="button_open">Open</string>

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropCodecTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropCodecTest.kt
@@ -599,15 +599,13 @@ class TagDropCodecTest {
         assertNull(TagDropCodec.decodeRaw(partial))
     }
 
-    @Test fun legacyDataUriDecodesToLegacyScan() {
-        val scan = TagDropCodec.decode("data:text/plain;base64,aGVsbG8=")
-        assertTrue(scan is TagDropScan.LegacyScan)
-    }
-
     @Test fun navigationLinkAndUnknownSchemesReturnNull() {
         assertNull(TagDropCodec.decode("tagdrop://example.com/slug"))
         assertNull(TagDropCodec.decode("https://example.com"))
         assertNull(TagDropCodec.decode("not a uri at all"))
+        // Legacy data: URI multi-fragment recognition was removed (SPEC.md §11) — a data:
+        // URI is no longer decoded specially, same as any other non-tagdrop: scheme.
+        assertNull(TagDropCodec.decode("data:text/plain;base64,aGVsbG8="))
     }
 
     // ── Paper (SPEC §3.3-§3.4, §4.4) ─────────────────────────────────────────────


### PR DESCRIPTION
… preview

Legacy data: URI recognition (SPEC.md §11's pre-tagdrop-scheme V1 dumb- append mode) is removed entirely, reversing that section's "maintained indefinitely" promise: TagDropCodec.decode() no longer special-cases a data: prefix, TagDropPayload.Legacy/TagDropScan.LegacyScan are deleted, and the "Launch Content (legacy)" button/UI is gone from ReceiveActivity.

Separately, a scanned code that isn't TagDrop content (a URL, vCard, unrecognized binary, ...) is no longer auto-cached and auto-opened. completeRawScan() now shows a preview dialog first -- the first 64 bytes as hex and best-effort UTF-8, so the user can visually guess what it is -- with explicit Import/Discard actions. Content already declared by the Paper currently being scanned, or already cached, skips the prompt.