### PR TITLE
Adopt `payload_hash` as mandatory Split reassembly integrity (SPEC v18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1668,10 +1668,19 @@ via `scripts/sync-qdef-spec.sh`.
 were deliberately left untouched, unlike every prior QDEF-driven port in
 this file's history):** `TagDropCodec.kt` gained `SK_PAYLOAD_HASH = 11`;
 `splitFragments()` now computes a multihash (`0x12` sha2-256 prefix +
-full 32-byte digest, chosen over `contentHash`'s truncated-8-byte form
-since this field's whole job is tamper detection, not a compact
-identity) of the bytes being split and stamps it onto the `index == 0`
-fragment only — both of `splitFragments`'s two call sites (Paper's
+**8-byte truncated** digest, matching `contentHash`'s/`group_id`'s own
+truncation — QDEF-SPEC.md §4.1 explicitly permits "truncated or full"
+here, and this field only guards against accidental damage, not
+deliberate tampering, which Encrypt/Signature already cover, so a
+signature-grade full digest isn't needed. First implemented with a
+full, untruncated digest, then revisited after a user question about
+byte cost — `SectorAssembler.kt`'s `payloadHashMatches` reads the
+digest length from the field itself (`hash.size - 1`) rather than
+hardcoding 8, so a compliant non-TagDrop encoder's full 32-byte digest
+still verifies correctly; `payloadHashAcceptsFullUntruncatedDigestToo`
+covers that path directly) of the bytes being split and stamps it onto
+the `index == 0` fragment only — both of `splitFragments`'s two call
+sites (Paper's
 `buildCodes`, Content's multi-code path) pick this up for free, since
 neither builds fragments by any other route. `TagDropPayload.kt`'s
 `SplitFragment` gained a `payloadHash: ByteArray?` field (with the same
@@ -1704,17 +1713,20 @@ on, so every existing happy-path test keeps working unmodified); the old
 its comment corrected to explain *why* the same tamper still gets
 caught (fragment 0's `payload_hash`, not `group_id`, is what no longer
 matches); a new `missingPayloadHashRejected` covers the mandatory-field
-rejection path directly. `TagDropCodecTest.kt` got the equivalent
-rename/fix (`multiCodePayloadHashMismatchIsHashMismatch`) plus a new
-`multiCodeMissingPayloadHashOnFragmentZeroIsRejected`, built by hand-
-stripping key `11` from a real encoder-built fragment 0 rather than a
+rejection path directly, and a `payloadHashAcceptsFullUntruncatedDigestToo`
+covering the decoder's length-generic verification (a hand-built
+full-32-byte-digest fragment 0, confirming it still verifies correctly
+even though TagDrop's own encoder never emits one). `TagDropCodecTest.kt`
+got the equivalent rename/fix (`multiCodePayloadHashMismatchIsHashMismatch`)
+plus a new `multiCodeMissingPayloadHashOnFragmentZeroIsRejected`, built by
+hand-stripping key `11` from a real encoder-built fragment 0 rather than a
 synthetic fixture. Verified via the same standalone `kotlinc`+JUnit
 harness this project's QDEF port has used throughout (freshly assembled
 again this session — `kotlin-compiler`/`kotlin-stdlib` 2.0.21,
 `kotlin-reflect` 1.6.10, `bcprov-jdk18on` 1.80, `room-common` 2.6.1 for
 `ScannedPaper`'s `@Entity`/`@PrimaryKey` annotations, all fetched fresh
 from Maven Central/`dl.google.com` since this environment resets
-between sessions): 197/197 tests pass across
+between sessions): 198/198 tests pass across
 `TagDropCodecTest`/`SectorAssemblerTest`/`MiniCborTest`/`Base41Test`/
 `TagDropPayloadTest` — the 2 formerly-pre-existing failures noted in
 earlier sessions' entries are gone (already resolved by an intervening

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1619,6 +1619,121 @@ session's own changes), and this section's legacy-removal/raw-scan-
 preview work. CI (`./gradlew`-based `Unit tests & APK builds`,
 GitHub's own runners) confirmed green on the exact commit tagged.
 
+### Split's `group_id` reframed as a correlation token; new mandatory `payload_hash` field (SPEC.md version 18)
+
+Two related upstream QDEF-SPEC.md commits
+([49d4962](https://github.com/qdef-format/qdef-format.github.io/commit/49d4962),
+[f56220b](https://github.com/qdef-format/qdef-format.github.io/commit/f56220b))
+surfaced a real gap in this repo's own SPEC.md, not just an upstream
+grammar change to port. §4.1's Split Wrapper used to describe `group_id`
+(key `2`) as a content hash "a decoder MUST verify" after reassembly —
+an integrity check. Upstream reframed it as an opaque **correlation
+token** only: every physical QR/Data Matrix/Aztec symbol already carries
+its own Reed-Solomon error correction, so a scanned code either decodes
+cleanly or fails outright — there's no realistic "decoded fine but
+silently wrong bytes" case for a per-fragment field to catch (QR's own
+Structured Append mode makes the same call for the same reason, ISO/IEC
+18004). A new field fills the resulting gap for applications that do
+want reassembly-integrity verification: `payload_hash` (Split Wrapper
+key `11`, OPTIONAL/odd at the QDEF level) — a multihash of the fully
+reassembled payload, present only on the `index == 0` fragment.
+
+The bug this surfaced: SPEC.md's own "Why `contentHash` and `root_hash`
+are scoped differently" note (§3.4) explicitly justified deleting the
+old design's `content_sha256`/`bulky_meta_sha256` multi-sector integrity
+hashes as "superseded by `group_id`'s mandatory decoder-side
+verification" — a real guarantee this repo's own payloads had been
+relying on, that had since been redefined out from under it upstream.
+Fixing the prose alone would have left every real Split-wrapped TagDrop
+payload actually unverified while SPEC.md claimed otherwise, so
+`payload_hash` was adopted as a **TagDrop-MUST**, not left as QDEF's own
+optional field — the same "tighten a QDEF-optional mechanism into a
+TagDrop-MUST where TagDrop specifically needs it" pattern §2.1a's
+mandatory namespace declaration already established: TagDrop encoders
+MUST always set it; TagDrop decoders MUST reject a Split-wrapped payload
+missing it, rather than silently proceeding the way skipping an
+ordinary optional field normally would.
+
+**SPEC.md** (§14's version-18 entry has the full detail): the
+`contentHash`/`root_hash`/`group_id` scoping note (§3.4), §5.1's two
+`group_id`-verification sentences (replaced with a new shared
+"Reassembly integrity (`payload_hash`)" paragraph), §5.2's reassembly
+steps and redundancy-reconstruction paragraph, §9's encrypted-
+override-map ordering note, and §15's version-2 history entry (marked
+superseded in place, this project's standing practice, rather than
+silently rewritten) were all corrected. `QDEF-SPEC-cached.md` refreshed
+via `scripts/sync-qdef-spec.sh`.
+
+**Kotlin implementation (this task's actual scope — the JS web tools
+were deliberately left untouched, unlike every prior QDEF-driven port in
+this file's history):** `TagDropCodec.kt` gained `SK_PAYLOAD_HASH = 11`;
+`splitFragments()` now computes a multihash (`0x12` sha2-256 prefix +
+full 32-byte digest, chosen over `contentHash`'s truncated-8-byte form
+since this field's whole job is tamper detection, not a compact
+identity) of the bytes being split and stamps it onto the `index == 0`
+fragment only — both of `splitFragments`'s two call sites (Paper's
+`buildCodes`, Content's multi-code path) pick this up for free, since
+neither builds fragments by any other route. `TagDropPayload.kt`'s
+`SplitFragment` gained a `payloadHash: ByteArray?` field (with the same
+`contentEquals`-based `equals`/`hashCode` override discipline its other
+`ByteArray` properties already use, per the CI-blocking-test-bug lesson
+above). `SectorAssembler.kt`'s `Group` gained a `payloadHash` field,
+captured in `add()` whenever a fragment carries one; `computeState()`
+was rewritten to require it (`?: return State.HashMismatch`) and verify
+it (`payloadHashMatches`, new — recognizes only sha2-256, `0x12`,
+treating an unrecognized multicodec function code as
+present-but-unverifiable rather than a mismatch, mirroring the
+reference JS `qdef` package's own "skip silently" handling of a hash
+function it doesn't recognize) instead of the old
+`sha256(wrapped).copyOf(8).contentEquals(group.groupId)` check — the
+`State.HashMismatch` terminal state and its doc comment were kept and
+repurposed rather than renamed, since it's still the correct "Split
+reassembly integrity failed" signal, just triggered by a different
+field now. `group_id`'s own generation (`SHA-256(body)[0:8]`, computed
+once per group and reused across every fragment) was left unchanged —
+still a valid correlation token under the new rules (QDEF's own
+"RECOMMENDED: random" guidance is a recommendation, not a requirement;
+"any encoder-chosen scheme producing a value shared identically across
+a group's fragments is valid"), and changing it wasn't part of what
+this task asked for.
+
+**Tests:** `SectorAssemblerTest.kt`'s `splitFragmentBytes`/`splitRecords`
+helpers gained a `payloadHash`/`includePayloadHash` parameter (default
+on, so every existing happy-path test keeps working unmodified); the old
+`groupIdMismatchDetected` was renamed `payloadHashMismatchDetected` with
+its comment corrected to explain *why* the same tamper still gets
+caught (fragment 0's `payload_hash`, not `group_id`, is what no longer
+matches); a new `missingPayloadHashRejected` covers the mandatory-field
+rejection path directly. `TagDropCodecTest.kt` got the equivalent
+rename/fix (`multiCodePayloadHashMismatchIsHashMismatch`) plus a new
+`multiCodeMissingPayloadHashOnFragmentZeroIsRejected`, built by hand-
+stripping key `11` from a real encoder-built fragment 0 rather than a
+synthetic fixture. Verified via the same standalone `kotlinc`+JUnit
+harness this project's QDEF port has used throughout (freshly assembled
+again this session — `kotlin-compiler`/`kotlin-stdlib` 2.0.21,
+`kotlin-reflect` 1.6.10, `bcprov-jdk18on` 1.80, `room-common` 2.6.1 for
+`ScannedPaper`'s `@Entity`/`@PrimaryKey` annotations, all fetched fresh
+from Maven Central/`dl.google.com` since this environment resets
+between sessions): 197/197 tests pass across
+`TagDropCodecTest`/`SectorAssemblerTest`/`MiniCborTest`/`Base41Test`/
+`TagDropPayloadTest` — the 2 formerly-pre-existing failures noted in
+earlier sessions' entries are gone (already resolved by an intervening
+session, not by this change).
+
+**Outstanding gap, same as every prior port**: a full Android Studio
+build hasn't run against this change — this environment's Gradle
+wrapper still can't download its own distribution. The standalone
+`kotlinc`+JUnit harness remains the substitute verification this
+project has relied on throughout its QDEF history. Separately, and
+unlike every prior QDEF-driven change in this file's history: **the JS
+web tools (`tools/generator/index.html`, `tools/reader/index.html`,
+`tools/examples/index.html`, `tools/test-qdef-roundtrip.mjs`) were not
+ported** — this task's own scope explicitly named only the Kotlin
+`data/format` package. This is a real, tracked drift between the two
+implementations (the "Two parallel wire-format implementations" note
+at the top of this file) until a follow-up session ports the JS side
+the same way.
+
 ### Known duplication (not yet deduped)
 
 `tools/generator/index.html`'s codec helpers — Base41 (`base41Encode`/
@@ -1701,24 +1816,30 @@ build step.
 
 ## Wire-format version policy
 
-SPEC.md's `version` field (currently `17` — NFC NDEF now always
-includes the 4-byte QDEF magic header, same as byte-mode QR/JABCode;
-only `tagdrop:` URI still skips it [§2/§12/§14, version 17, since QDEF
-dropped NFC/NDEF from its own scope and, with it, the carrier-specific
-exemption this used to cite]; QDEF Records with declared Type IDs
-`1`/`2`/`3`/`4` wire-encoded **negated** under an explicitly-transmitted
-namespace, scope decided by typeId sign rather than namespace-item
-presence [§2.1a, version 16]; QDEF's own standard Types' payload values
-at reserved map key `0` rather than a positional payload slot [§3.1a/§5,
-version 15]; both the Kotlin app and the web tools are on this shape
-now, see "Two parallel wire-format implementations" above and the
-version-14/15/16/17 history entries) is independent of the Android app's
-`versionName` (currently `2.6.1`, `versionCode` 13) — bumping one never
-requires bumping the other. (This note has drifted stale before —
-previously said `8`/`2.1.0`, then `15`/`2.5.1`, then `16`, for a while —
-a reminder to re-check this line's own numbers against SPEC.md §14's
-actual current entry and `app/build.gradle` rather than trust it
-silently.)
+SPEC.md's `version` field (currently `18` — Split Wrapper's `group_id`
+is now documented purely as an opaque correlation token, not a verified
+content hash; TagDrop adopts a new field, `payload_hash` (Split Wrapper
+key `11`), as its own MANDATORY reassembly-integrity check whenever
+Split is used — QDEF itself leaves this field OPTIONAL/odd [§5.1,
+version 18]; **the Kotlin app is on this shape, the web tools are NOT
+yet** — see the version-18 CLAUDE.md history entry's "Outstanding gap"
+note, a real drift between the two implementations this note now has to
+flag rather than assume away. Older shape, both implementations still
+share: NFC NDEF always includes the 4-byte QDEF magic header, same as
+byte-mode QR/JABCode; only `tagdrop:` URI still skips it [§2/§12/§14,
+version 17]; QDEF Records with declared Type IDs `1`/`2`/`3`/`4`
+wire-encoded **negated** under an explicitly-transmitted namespace,
+scope decided by typeId sign rather than namespace-item presence
+[§2.1a, version 16]; QDEF's own standard Types' payload values at
+reserved map key `0` rather than a positional payload slot [§3.1a/§5,
+version 15]; see "Two parallel wire-format implementations" above and
+the version-14/15/16/17/18 history entries) is independent of the
+Android app's `versionName` (currently `2.6.1`, `versionCode` 13) —
+bumping one never requires bumping the other. (This note has drifted
+stale before — previously said `8`/`2.1.0`, then `15`/`2.5.1`, then
+`16`, for a while — a reminder to re-check this line's own numbers
+against SPEC.md §14's actual current entry and `app/build.gradle`
+rather than trust it silently.)
 
 SPEC.md as a whole is currently a **draft, not frozen** (see its `Status`
 line): no real TagDrop code has been printed or distributed yet, so no

--- a/QDEF-SPEC-cached.md
+++ b/QDEF-SPEC-cached.md
@@ -6,12 +6,14 @@ changes made directly to this file will be overwritten next sync.
 
 # QDEF — Quick Data Exchange Format
 
-**Status: Draft — work in progress. The wire format is settled and
-validated by two prototypes — a Node round-trip prototype covering the
-full design (`/prototype`) and a `no_std`, zero-dependency Rust prototype
-of the mandatory core (`/rust/qdef-core`), which also builds for a bare-metal
-Cortex-M0 target; but there is no reference library and no production use
-yet. This document is normative.**
+**Status: Draft — work in progress. The wire format is settled and has
+reference implementations at
+[qdef-format/qdef](https://github.com/qdef-format/qdef): a JavaScript
+package (`qdef` on npm) covering the full design, including the standard
+record type library (§4), and a `no_std`, zero-dependency Rust crate
+(`qdef-core`) covering the mandatory core (§2/§3) for constrained embedded
+scanners, which also builds for a bare-metal Cortex-M0 target. No
+production use yet. This document is normative.**
 
 QDEF is a general-purpose binary container for multi-action 2D barcodes
 (QR, Data Matrix, Aztec) — "here are one or more typed records in one
@@ -422,8 +424,8 @@ adopts CBOR's own, unchanged.
 This is a requirement on *encoders*, not decoders: a decoder MUST NOT
 reject an otherwise well-formed Record merely for being non-canonically
 encoded (key order never affects whether `map[N]` is findable). The rule
-exists so that anywhere QDEF hashes a Record's bytes for content-
-addressing (§4.1's `group_id` and any future Sign mechanism), two
+exists so that anywhere QDEF hashes a Record's bytes — §4.7's Signature
+recomputing its covered Records' bytes to verify a signature — two
 independent encoders handed identical field values compute the same
 hash — otherwise semantically-identical content could hash differently
 across encoders.
@@ -825,6 +827,46 @@ zero-padded to `chunkLen` before XOR). Splitting a group across
 different-capacity physical codes with different-sized fragments while
 still supporting parity recovery is not yet resolved.
 
+**`group_id` (key `2`, CRITICAL) is an opaque correlation token, not a
+content hash.** Its only job is confirming a set of scanned codes
+belongs to the same Split group — comparable to the parity byte in QR's
+own Structured Append mode (ISO/IEC 18004), which exists to catch a
+symbol from the wrong stack or a stale duplicate, not to detect damage:
+each physical symbol already carries its own Reed-Solomon error
+correction, so a scanned code either decodes cleanly or fails outright —
+there is no realistic "decoded successfully but silently wrong bytes"
+case for `group_id` to catch. A decoder treats two fragments as
+belonging to the same group exactly when their `group_id` bytes are
+equal; nothing is computed or verified beyond that comparison.
+
+RECOMMENDED: a fresh random value, 4 or more bytes (the same
+birthday-bound reasoning as §3.5's namespace guidance — collision
+between unrelated concurrent groups, not security, is what width buys
+here). Any encoder-chosen scheme producing a value shared identically
+across a group's fragments is valid; nothing about reassembly depends on
+how `group_id` was chosen, only that it matches.
+
+**`payload_hash` (key `11`, OPTIONAL/odd)** is what an application
+reaches for if it wants real tamper/corruption detection over the
+reassembled bytes — Split wraps arbitrary Records (§7's key-backup
+example has no media content in it at all), so this can't be delegated
+to §4.5's Media Preview, which only applies when there's actual media
+content to identify. Same multihash encoding as Media Preview's Content
+Hash (a 1-byte multicodec hash-function code, e.g. `0x12` = sha2-256,
+followed by the digest, truncated or full) — reused rather than
+inventing a second hash format. A decoder that doesn't recognize key
+`11` still reassembles correctly; it just skips the extra check, the
+same fallback every odd/optional key gets. Present on exactly one
+fragment — the one carrying `4: 0` — never duplicated across the group:
+it only ever needs checking once, after reassembly completes, so paying
+its cost on every fragment would buy nothing (the same lesson §4.4's
+App Route repetition-cost note already draws for its own single-code
+fields). An application needing resistance against a deliberate
+adversary still wants Encrypt (§4.1) or Signature (§4.7), same as
+before — `payload_hash` catches accidental damage a signature would
+also catch, cheaper, when a full signature is more than the application
+needs.
+
 `parity_scheme` mechanics: **key `9`, OPTIONAL (odd)** — a decoder that
 doesn't understand it can simply ignore it, which is exactly what it
 does: a parity fragment (index ≥ `count`, present only when key `9` is
@@ -959,7 +1001,7 @@ name-to-value consistency, never authorization — anyone can compute the
 same hash from the same name. Use this form only where getting it wrong
 costs *effort*, not *trust*: a fast, per-code pre-filter a scanner uses
 to reject an obviously-unrelated scan before attempting reassembly,
-layered ahead of §4.1's `group_id` integrity check, never as a
+layered ahead of §4.1's `group_id` correlation check, never as a
 replacement for it.
 
 Resolving a domain to a launch target is platform-specific:
@@ -1143,7 +1185,8 @@ framing.** Because CBOR items are self-delimiting and covered Records
 already sit contiguously in the array, this is a direct byte range on
 the wire, not a reconstruction: a decoder recomputes it by re-encoding
 each covered Record from its parsed form and concatenating the results,
-the same canonical-encoding reliance `group_id` (§4.1) already requires.
+relying on §3.4's canonical encoding to make that re-encoding
+byte-identical to the original.
 
 **A decoder that does recognize Type 8 MUST NOT let Algorithm broaden
 which algorithms it's willing to run** — the same allowlist discipline
@@ -1205,9 +1248,12 @@ instead — cheaper, and no Type ID to migrate later.
 
 **On signing:** an adopter whose own signature covers the
 fully-reassembled plaintext (after all splitting/addressing is
-resolved) needs no QDEF-level Sign mechanism — §4.1's `group_id` is
-already a content hash a decoder MUST verify after Split reassembly,
-which is all a whole-payload signature needs from the container.
+resolved) needs no QDEF-level Sign mechanism — their own signature
+verification already fails on a wrongly-reassembled payload, whatever
+caused it. §4.1's `group_id` still helps before that point (correlating
+which scanned codes to attempt reassembling together at all), but the
+actual correctness guarantee comes from the adopter's own signature, not
+from `group_id`.
 
 ## 6. Compression and splitting across multiple tags/codes
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,21 +1,21 @@
 # TagDrop Encoding Specification
 
-**Version:** 17 (QDEF dropped NFC/NDEF from its own scope entirely — it's
-now a 2D-barcode-only format — which removes the carrier-specific
-exemption that used to let an NDEF-embedded payload skip the 4-byte QDEF
-magic header. TagDrop's own NFC NDEF carrier keeps existing independently
-of QDEF's own carrier list [TagDrop, not QDEF, decides what carriers it
-supports], but now follows QDEF's simplified rule instead of citing
-QDEF's [now-removed] own NDEF guidance: only an application's own URI
-scheme skips the magic header; every other carrier, including NFC NDEF,
-always includes it. NFC NDEF's own framing accordingly grows from "Record
-Sequence bytes only" to "QDEF magic (4 bytes) + Record Sequence bytes" —
-identical to byte-mode QR/JABCode's framing now. `tagdrop:` URI is
-unaffected (still skips magic; the scheme itself is still the dispatch
-signal). See §14 "Version history" for the byte-cost accounting and a
-note on a separate QDEF refinement from the same period that TagDrop has
-deliberately not yet adopted. Version 16's namespace/typeId-sign changes
-are otherwise unaffected by this version.
+**Version:** 18 (QDEF-SPEC.md reframed Split Wrapper's `group_id` as an
+opaque correlation token, not a content hash a decoder verifies — every
+physical QR/Data Matrix/Aztec symbol already carries its own
+Reed-Solomon error correction, so there's no realistic "decoded fine but
+silently wrong bytes" case for a per-fragment field like `group_id` to
+catch. QDEF added a new, independent field for applications that do want
+reassembly-integrity verification — `payload_hash` (Split Wrapper key
+`11`), a multihash of the fully reassembled payload, present only on the
+`index == 0` fragment — but leaves it OPTIONAL/odd. TagDrop makes
+`payload_hash` MANDATORY whenever Split is used: encoders MUST always
+set it, decoders MUST reject a Split-wrapped payload that's missing it.
+`content_sha256`/`bulky_meta_sha256` (the old design's own multi-sector
+integrity hashes, removed at version 2) are superseded by `payload_hash`
+now, not by `group_id` as previously documented — see §5.1's
+"Reassembly integrity" note and §14's version-18 entry. Version 17's
+NFC/NDEF magic-header change is otherwise unaffected by this version.
 **Status:** Draft — no real-world deployments yet (no printed or
 distributed codes), so it may still change incompatibly without a version
 bump. Once the first real code ships, that freeze point ends: breaking
@@ -452,7 +452,11 @@ every code in the group, exactly like Content Extension:
 
 (Split Wrapper's field keys are also renumbered in version 15 — see
 §5's own field table below; a ninth key, `9`, is `parity_scheme` when a
-parity fragment is present, omitted from this example since it isn't.)
+parity fragment is present, omitted from this example since it isn't.
+An eleventh key, `11`, is `payload_hash` — TagDrop-MANDATORY reassembly
+integrity (§5.1's "Reassembly integrity" note) — present only on the
+fragment carrying `index == 0`, also omitted from this generic example
+since it shows an arbitrary fragment, not specifically that one.)
 
 Because Content Signature travels *inside* the bytes Split fragments —
 not as a separate repeated Record — `signature`/`signer_pubkey` are
@@ -576,22 +580,25 @@ namespace through transparently regardless of nesting depth.
 | 7 | `signer_pubkey` | bytes (1312, opt) | See §10 |
 
 **Why `contentHash` and `root_hash` are scoped differently, and neither is
-"replaced" by Split's `group_id`.** Content's `contentHash` is deliberately
-`SHA-256(content)` alone, not the whole Preview+Body — this is what lets
-two authors who drop the identical bytes under different
-hints/titles/collections dedup to the same `contentHash` (§4.4). Paper's
-`root_hash` covers everything (there's no bare "content" to isolate a
-Paper's identity to). QDEF's Split Wrapper, when used (§5), separately
-computes its own `group_id` — a content hash of the *wrapped Body Record's*
-bytes, verified by the decoder purely for reassembly integrity. `group_id`
-happens to have the same *scope* as `root_hash` for a multi-code Paper, but
-it is not the same field and must not be conflated in an implementation:
-`group_id` doesn't exist for single-code payloads (nothing to reassemble),
-while `contentHash`/`root_hash` are always present. `content_sha256`/
-`bulky_meta_sha256` — the old design's own multi-sector integrity
-hashes — are gone entirely, superseded by `group_id`'s mandatory
-decoder-side verification (QDEF-SPEC.md FINDINGS.md #5) whenever Split is
-actually in use.
+"replaced" by Split's `group_id` or `payload_hash`.** Content's
+`contentHash` is deliberately `SHA-256(content)` alone, not the whole
+Preview+Body — this is what lets two authors who drop the identical bytes
+under different hints/titles/collections dedup to the same `contentHash`
+(§4.4). Paper's `root_hash` covers everything (there's no bare "content"
+to isolate a Paper's identity to). QDEF's Split Wrapper, when used (§5),
+separately carries its own `group_id` — an **opaque correlation token**,
+not a content hash a decoder verifies (QDEF-SPEC.md's Split Wrapper
+history reframed it this way; see §5.1's "Reassembly integrity" note).
+`group_id` happens to have the same *scope* as `root_hash` for a
+multi-code Paper, but it is not the same field and must not be conflated
+in an implementation: `group_id` doesn't exist for single-code payloads
+(nothing to reassemble), while `contentHash`/`root_hash` are always
+present. `content_sha256`/`bulky_meta_sha256` — the old design's own
+multi-sector integrity hashes — are gone entirely, superseded not by
+`group_id` (which provides no verification of its own) but by
+`payload_hash` (§5.1) — TagDrop's own mandatory reassembly-integrity
+field, distinct again from both `contentHash` and `group_id` — whenever
+Split is actually in use.
 
 **`files[]` entry keys** (each element decoded from Paper-Body's `files`):
 
@@ -1010,10 +1017,9 @@ still a flat Preview/Body pair, Types 3/4):
   version 14).
   If not, Body is Split-wrapped (QDEF-SPEC.md §4.1 Type 1) into `count`
   fragments, and each of those codes carries Preview plus one fragment.
-  `group_id` is a content hash of the fully reassembled, unwrapped Body
-  Record's bytes — decoders MUST verify it after reassembly (QDEF-SPEC.md
-  FINDINGS.md #5) and reject a mismatch, exactly as the old design required
-  for `content_sha256`/`bulky_meta_sha256`, which `group_id` supersedes.
+  `group_id` correlates the fragments as belonging to the same group — an
+  opaque token, not a verified hash (see "Reassembly integrity" below);
+  reassembly is instead verified via the mandatory `payload_hash` field.
 
 **Content** (three Records instead of Paper's two — Content Extension,
 Media Preview, Media Payload; see §3.1/§3.1a for their field tables and
@@ -1042,10 +1048,40 @@ exact nesting):
   embedded, if present) is Split-wrapped (QDEF-SPEC.md §4.1 Type
   1) into `count` fragments; each of those codes carries Content Extension
   plus Media Preview (now Split's own subrecord instead of Media Payload's
-  parent — §3.1a) plus one fragment. `group_id` is a content hash of the
-  fully reassembled, unwrapped `[3, {...}, [-2, {...}]?]` bytes —
-  decoders MUST verify it after reassembly (QDEF-SPEC.md FINDINGS.md #5)
-  and reject a mismatch, same as Paper's `group_id` above.
+  parent — §3.1a) plus one fragment. `group_id` correlates the fragments
+  the same way as Paper's above — an opaque token, not a verified hash;
+  `payload_hash` (below) is what verifies reassembly here too.
+- **Reassembly integrity (`payload_hash`).** QDEF-SPEC.md's Split Wrapper
+  `group_id` (key `2`) is an **opaque correlation token** only, matched by
+  plain equality across a group's fragments — comparable to the parity
+  byte in QR's own Structured Append mode (ISO/IEC 18004), which confirms
+  a symbol belongs to the right stack, not that it survived scanning
+  intact: every physical QR/Data Matrix/Aztec symbol already carries its
+  own Reed-Solomon error correction, so a scanned code either decodes
+  cleanly or fails outright — there's no realistic "decoded fine but
+  silently wrong bytes" case for a per-fragment field like `group_id` to
+  catch. QDEF instead offers a real, independent reassembly-integrity
+  check for applications that want one — `payload_hash` (Split Wrapper
+  key `11`, QDEF's own OPTIONAL/odd framing): a multihash (1-byte
+  multicodec hash-function code + digest, same encoding as Media
+  Preview's `contentHash`, §4.4) of the fully reassembled payload,
+  present on exactly the fragment carrying `index == 0` and never
+  repeated across the group — it only needs checking once, after
+  reassembly completes. QDEF leaves it optional for good reason (not
+  every adopter needs the cost), but **TagDrop makes `payload_hash`
+  MANDATORY whenever Split is used** — the same "tighten a QDEF-optional
+  mechanism into a TagDrop-MUST where TagDrop specifically needs the
+  stronger guarantee" pattern §2.1a's namespace declaration already
+  follows (mandatory on every carrier even though QDEF itself only
+  requires it in-band). TagDrop encoders MUST always set it; TagDrop
+  decoders MUST reject a Split-wrapped TagDrop payload that's missing
+  it, rather than silently proceeding the way skipping an ordinary
+  optional field normally would. `payload_hash` is a **third, distinct**
+  field from `contentHash` and `group_id` (same "must not be conflated"
+  discipline as the note above): it exists purely for Split
+  reassembly integrity, has no scope outside a multi-code group (nothing
+  to reassemble on a single-code payload), and says nothing about
+  content identity or authorship.
 - **Why Content Signature isn't just "part of Body" the way Paper's
   signature fields are part of Paper-Body:** it doesn't need its own
   Record Type at all conceptually — it exists only so `signature`/
@@ -1068,10 +1104,12 @@ exact nesting):
 3. Otherwise, track Split fragments by `group_id` until all `count` are
    collected (QDEF-SPEC.md §4.1's fixed `chunkLen = ceil(total_bytes/count)`
    chunking rule), independently of any fragment at index `≥ count`
-   (parity — see below). When complete, reassemble and verify `group_id` as
-   required above. For Content, reassembly yields Media Payload's own
-   bytes — decode that as one Record to recover `content` and, if the
-   payload is signed, its nested Content Signature subrecord (§3.1a).
+   (parity — see below). When complete, reassemble and verify the
+   mandatory `payload_hash` (carried on the `index == 0` fragment) as
+   required above — reject (don't proceed) if it's missing or doesn't
+   match. For Content, reassembly yields Media Payload's own bytes —
+   decode that as one Record to recover `content` and, if the payload is
+   signed, its nested Content Signature subrecord (§3.1a).
 4. Content: Media Payload's `content` may be a hidden encrypted override
    map — if `content` is ≥ 28 bytes, try AES-256-GCM decryption as
    `nonce(12) || ciphertext || tag(16)` (§9) against every known
@@ -1091,10 +1129,10 @@ the length of the longest data fragment before XOR-ing. If exactly one data
 fragment is missing, reconstruct it: XOR the parity fragment against every
 *other* data fragment already held, then truncate using `total_bytes` to
 discard any padding on a reconstructed final fragment. Verify the
-reconstructed Body against `group_id` (§5.1) before treating it as good —
-if verification fails (e.g. the parity fragment itself was the one that was
-corrupted), discard the attempt and fall back to waiting for the real
-missing fragment. Exactly one parity fragment recovers from exactly one
+reconstructed Body against `payload_hash` (§5.1) before treating it as
+good — if verification fails (e.g. the parity fragment itself was the one
+that was corrupted), discard the attempt and fall back to waiting for the
+real missing fragment. Exactly one parity fragment recovers from exactly one
 lost fragment; additional copies of the same parity fragment would be
 redundant, not additional protection. `parity_scheme` values `2` and up are
 reserved for future schemes tolerating more than one loss (e.g.
@@ -1800,10 +1838,10 @@ all?").
 are high-entropy and don't compress further, so encryption is always the
 last transform applied before transmission, and the first reversed on
 receipt. What gets compressed-then-encrypted is the override map's CBOR
-bytes. When Body is Split-wrapped, `group_id` (§5.1) continues to cover
-`content` exactly as transmitted, i.e. after compression *and* encryption,
-so a partially- or incorrectly-assembled multi-code payload can be detected
-before a decryption key is even available.
+bytes. When Body is Split-wrapped, `payload_hash` (§5.1) continues to
+cover `content` exactly as transmitted, i.e. after compression *and*
+encryption, so a partially- or incorrectly-assembled multi-code payload
+can be detected before a decryption key is even available.
 
 **`contentHash` for a code carrying a hidden override map is random, not
 content-addressed.** §4.4 defines `contentHash = SHA-256(uncompressed
@@ -2360,7 +2398,78 @@ protecting — nothing has been deployed under any version number to date.
 Version history — each entry states only its own delta from the version
 directly above it:
 
-**Version 17** (current) — QDEF dropped NFC/NDEF from its own scope
+**Version 18** (current) — QDEF-SPEC.md §4.1's Split Wrapper reframed
+what `group_id` (key `2`) is actually good for. It used to be described
+as a content hash of the fully reassembled payload that "a decoder MUST
+verify" — an integrity check. That turned out to be the wrong job for
+it: every physical QR/Data Matrix/Aztec symbol already carries its own
+Reed-Solomon error correction, so a scanned code either decodes cleanly
+or fails outright — there's no realistic "decoded fine but silently
+wrong bytes" case for a per-fragment field to catch (the comparable QR
+mechanism, Structured Append's parity byte, ISO/IEC 18004, makes the
+same choice for the same reason: it confirms a symbol belongs to the
+right set, it doesn't try to detect damage). `group_id` is now
+documented purely as an **opaque correlation token**, RECOMMENDED to be
+random (4+ bytes), matched by plain equality across a group's
+fragments — nothing is computed or verified against it anymore.
+
+That reframe left a real gap for any application that *does* want
+reassembly-integrity verification, not just correlation — Split wraps
+arbitrary Records (§7's key-backup example has no media content in it
+at all), so Media Preview's Content Hash (§4.4/§3.1a) can't be the
+general answer, since it only applies when there's actual media content
+to identify. QDEF's fix: a new field, `payload_hash` (Split Wrapper key
+`11`, OPTIONAL/odd — an older decoder that doesn't recognize it still
+reassembles correctly). It's a multihash (same encoding as Media
+Preview's Content Hash: 1-byte multicodec hash-function code + digest)
+of the fully reassembled payload, present on exactly the fragment
+carrying `index == 0` — never repeated across the group, since it only
+ever needs checking once, after reassembly completes.
+
+**TagDrop adopts `payload_hash` as its own MANDATORY field, not just an
+available-if-you-feel-like-it QDEF option** — the same "tighten a
+QDEF-optional mechanism into a TagDrop-MUST where TagDrop specifically
+needs the stronger guarantee" pattern §2.1a's namespace declaration
+already established (mandatory on every carrier even though QDEF itself
+only requires it in-band). This repo's own `content_sha256`/
+`bulky_meta_sha256` (the old design's multi-sector integrity hashes,
+removed at version 2) had been justified as "superseded by `group_id`'s
+mandatory decoder-side verification" — that justification is no longer
+true now that `group_id` provides no verification at all, so TagDrop
+needed a real replacement, not just a documentation fix:
+
+- **Encoders MUST always set `payload_hash`** on a Split-wrapped
+  payload, on the `index == 0` fragment only.
+- **Decoders MUST reject a Split-wrapped payload that's missing
+  `payload_hash`** — not silently proceed the way skipping an ordinary
+  optional field normally would (§2.2's even/odd criticality rule still
+  governs an *unrecognized* field on an old decoder; a *current*
+  TagDrop decoder encountering a Split-wrapped payload with no
+  `payload_hash` at all is a different case — a required TagDrop-level
+  guarantee absent, not merely an optional field left unset).
+- `payload_hash` is a **third, distinct** field from `group_id` and
+  `contentHash` (§5.1's "Reassembly integrity" note keeps the same
+  "must not be conflated" discipline the `contentHash`/`root_hash`
+  scoping note already established) — it exists purely for Split
+  reassembly integrity, has no scope outside a multi-code group, and
+  says nothing about content identity or authorship.
+
+§3's Split Wrapper worked example (§2) and §5's own field description
+were updated to show `payload_hash` at key `11`; §5.1 gained the
+"Reassembly integrity (`payload_hash`)" note explaining the mechanism
+once, referenced from both the Paper and Content bullets above it; §5.2
+step 3 and the redundancy-reconstruction paragraph now verify
+`payload_hash` instead of `group_id`. Every other place this document
+previously credited `group_id` with a verification role (the
+`contentHash`/`root_hash` scoping note in §3.4, §9's encrypted-
+override-map ordering note, §15's version-2 history entry) was corrected
+to either describe `group_id` as correlation-only or point at
+`payload_hash` as the actual check, with the version-2 entry left in
+place and marked superseded (this document's standing practice of
+leaving a visible trail rather than silently rewriting an earlier
+documented belief that turned out wrong).
+
+**Version 17** — QDEF dropped NFC/NDEF from its own scope
 entirely: it's a 2D-barcode-only format now, full stop. This removed the
 one carrier-specific exemption QDEF used to define for NDEF (skip the
 magic header, since NDEF's own MIME-type field already disambiguates
@@ -2831,8 +2940,12 @@ field-level changes.
   replaces the old three-part `core_meta_item || bulky_meta_item ||
   content` stream and bespoke `part_meta` sectoring. `content_sha256`/
   `bulky_meta_sha256`/`bulky_meta_compressed_bytes` are gone, superseded by
-  QDEF's Split Wrapper `group_id` (mandatory decoder-verified) and a
-  Wrapper's already-self-delimiting byte-string framing.
+  QDEF's Split Wrapper `group_id` (mandatory decoder-verified at the time)
+  and a Wrapper's already-self-delimiting byte-string framing.
+  (**Superseded by version 18:** QDEF later reframed `group_id` as an
+  opaque correlation token with no verification role at all — see that
+  version's entry below; the actual integrity check this bullet
+  describes is now TagDrop's own mandatory `payload_hash` field, §5.1.)
 - Every TagDrop-defined key is odd (optional) in this version; even keys
   are reserved headroom for a future must-understand field (§2.2),
   resolving tagdrop#63 by adopting QDEF's even/odd rule directly.
@@ -2926,7 +3039,7 @@ accurate regardless of version.
   - `TagDropCodec.kt` — encode/decode both payload types; `contentId()`, `createContentSectors()`, `createPaper()`
   - `Base41.kt` — TagDrop's own alphabet, packed like RFC 9285 Base45 (§2)
   - `MiniCbor.kt` — minimal CBOR encoder/decoder; supports arrays (major 4), nested maps, float64 (major 7), and top-level CBOR sequences (RFC 8742). Currently limited to 32-bit unsigned integers — no longer a gap for QDEF Record Type IDs specifically, now that all four fit in 16 bits (§2.1, version 6); still a real limitation for any future 64-bit-scale field.
-  - `SectorAssembler.kt` — multi-sector assembly with SHA-256 verification; tracks any number of in-flight `group_id` groups concurrently (Split Wrapper `group_id`, §5.1 — not the old version-1 `(type, cache_id)` keying)
+  - `SectorAssembler.kt` — multi-sector assembly, `payload_hash`-verified (SHA-256, §5.1); tracks any number of in-flight groups concurrently, keyed by Split Wrapper `group_id` (an opaque correlation token, §5.1 — not the old version-1 `(type, cache_id)` keying)
   - `TagDropLinkResolver.kt` — resolves `tagdrop://<domain>/<slug>` and `tagdrop://[<domain>]@<rootHash>/<slug>` navigation links; also locates the `style.css` sibling for `text/markdown` content (§7)
   - `MarkdownRenderer.kt` — renders `text/markdown` content to HTML (§7) via CommonMark
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1063,11 +1063,17 @@ exact nesting):
   catch. QDEF instead offers a real, independent reassembly-integrity
   check for applications that want one — `payload_hash` (Split Wrapper
   key `11`, QDEF's own OPTIONAL/odd framing): a multihash (1-byte
-  multicodec hash-function code + digest, same encoding as Media
-  Preview's `contentHash`, §4.4) of the fully reassembled payload,
+  multicodec hash-function code + digest — QDEF-SPEC.md permits either
+  a full or truncated digest here) of the fully reassembled payload,
   present on exactly the fragment carrying `index == 0` and never
   repeated across the group — it only needs checking once, after
-  reassembly completes. QDEF leaves it optional for good reason (not
+  reassembly completes. TagDrop truncates to 8 bytes (`0x12` sha2-256 +
+  8-byte digest, 9 bytes total), the same truncation Media Preview's
+  `contentHash` (§4.4) and Split's own `group_id` already use — this
+  field only ever guards against *accidental* damage (deliberate
+  tampering is Encrypt's/Signature's job, §9/§10, not this field's), so
+  the full 256-bit collision resistance a signature needs isn't the
+  bar here. QDEF leaves it optional for good reason (not
   every adopter needs the cost), but **TagDrop makes `payload_hash`
   MANDATORY whenever Split is used** — the same "tighten a QDEF-optional
   mechanism into a TagDrop-MUST where TagDrop specifically needs the
@@ -2421,10 +2427,15 @@ general answer, since it only applies when there's actual media content
 to identify. QDEF's fix: a new field, `payload_hash` (Split Wrapper key
 `11`, OPTIONAL/odd — an older decoder that doesn't recognize it still
 reassembles correctly). It's a multihash (same encoding as Media
-Preview's Content Hash: 1-byte multicodec hash-function code + digest)
-of the fully reassembled payload, present on exactly the fragment
-carrying `index == 0` — never repeated across the group, since it only
-ever needs checking once, after reassembly completes.
+Preview's Content Hash: 1-byte multicodec hash-function code + digest,
+which QDEF-SPEC.md permits full or truncated) of the fully reassembled
+payload, present on exactly the fragment carrying `index == 0` — never
+repeated across the group, since it only ever needs checking once,
+after reassembly completes. TagDrop truncates to 8 bytes, matching
+`contentHash`'s and `group_id`'s own established truncation — this
+field is only ever an accidental-damage check (§9/§10's Encrypt/
+Signature already cover deliberate tampering), so it doesn't need a
+signature-grade full digest.
 
 **TagDrop adopts `payload_hash` as its own MANDATORY field, not just an
 available-if-you-feel-like-it QDEF option** — the same "tighten a

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/SectorAssembler.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/SectorAssembler.kt
@@ -373,18 +373,24 @@ class SectorAssembler {
     private fun sha256(data: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(data)
 
     /**
-     * Verifies `payload_hash` (a multihash: 1-byte multicodec function code + digest,
-     * QDEF-SPEC.md §3.6/§4.1) against the reassembled [wrapped] bytes. Recognizes only
-     * sha2-256 (`0x12`), matching every field TagDrop's own encoder emits (`splitFragments`,
-     * `MPK_CONTENT_HASH`); an unrecognized function code is treated as present-but-unverifiable
-     * rather than a mismatch, mirroring QDEF's reference decoder's own "skip silently" handling
-     * of a hash function it doesn't recognize — [computeState] already enforces that the field
-     * is present at all before calling this.
+     * Verifies `payload_hash` (a multihash: 1-byte multicodec function code + digest, full or
+     * truncated — QDEF-SPEC.md §3.6/§4.1 permits either) against the reassembled [wrapped]
+     * bytes. Recognizes only sha2-256 (`0x12`), matching every field TagDrop's own encoder
+     * emits (`splitFragments`, `MPK_CONTENT_HASH`) — both truncated to 8 bytes, matching
+     * `contentHash`'s own truncation, since this field only guards against accidental damage,
+     * not deliberate tampering (Encrypt/Signature already cover that); the digest length here
+     * is read from [hash] itself rather than hardcoded, so a full 32-byte digest (a compliant
+     * non-TagDrop encoder's choice) still verifies correctly. An unrecognized function code is
+     * treated as present-but-unverifiable rather than a mismatch, mirroring QDEF's reference
+     * decoder's own "skip silently" handling of a hash function it doesn't recognize —
+     * [computeState] already enforces that the field is present at all before calling this.
      */
     private fun payloadHashMatches(hash: ByteArray, wrapped: ByteArray): Boolean {
         if (hash.isEmpty()) return false
         if (hash[0] != 0x12.toByte()) return true
-        return hash.copyOfRange(1, hash.size).contentEquals(sha256(wrapped))
+        val digestLen = hash.size - 1
+        if (digestLen <= 0) return false
+        return hash.copyOfRange(1, hash.size).contentEquals(sha256(wrapped).copyOf(digestLen))
     }
 
     private fun ByteArray.toHex() = joinToString("") { "%02x".format(it) }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/SectorAssembler.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/SectorAssembler.kt
@@ -20,6 +20,8 @@ class SectorAssembler {
     private class Group(val kind: PayloadKind, val groupId: ByteArray, val count: Int, val total: Int) {
         val data = mutableMapOf<Int, ByteArray>()
         var parity: ByteArray? = null
+        /** `payload_hash` (SK_PAYLOAD_HASH, SPEC §5.1) — only ever carried on fragment index `0`. */
+        var payloadHash: ByteArray? = null
         // Content (SPEC §3.1/§3.1a) — Content Extension repeats on every code; Media Preview is
         // known as soon as any code in the group has been scanned (§5.1).
         var extensionRaw: ByteArray? = null
@@ -131,7 +133,13 @@ class SectorAssembler {
          */
         data class PaperReady(val paper: TagDropPayload.Paper, val previewRaw: ByteArray, val bodyRaw: ByteArray, val streamBytes: ByteArray) : State()
 
-        /** A Split group fully reassembled but `group_id` didn't match — incomplete or corrupt assembly. */
+        /**
+         * A Split group fully reassembled but its `payload_hash` (SPEC §5.1) is missing or
+         * didn't match — corrupt assembly, or a non-compliant encoder that omitted TagDrop's
+         * own mandatory reassembly-integrity field. (`group_id` itself is just an opaque
+         * correlation token now — QDEF-SPEC.md's Split Wrapper history — so it plays no role
+         * in this check.)
+         */
         object HashMismatch : State()
 
         /** All fragments present but the reassembled bytes weren't a well-formed payload. */
@@ -170,6 +178,7 @@ class SectorAssembler {
             }
         }
         if (frag.isParity) group.parity = frag.data else group.data[frag.index] = frag.data
+        if (frag.payloadHash != null) group.payloadHash = frag.payloadHash
         lastGroupKey = key
         val state = computeState(group)
         if (state.isTerminal) groups.remove(key)
@@ -221,10 +230,14 @@ class SectorAssembler {
     private fun computeState(group: Group): State {
         val wrapped = reassemble(group)
         if (wrapped != null) {
-            // group_id is SHA-256(wrapped fragment bytes)[0:8] (SPEC §5.1) — the reassembly
-            // integrity check over the bytes exactly as transmitted (after Compress-wrap, if
-            // applicable).
-            if (!sha256(wrapped).copyOf(8).contentEquals(group.groupId)) return State.HashMismatch
+            // `group_id` is an opaque correlation token only (QDEF-SPEC.md's Split Wrapper no
+            // longer treats it as a verified content hash, SPEC.md "Reassembly integrity") — it
+            // already did its job just by getting these fragments grouped together ([add]).
+            // The actual reassembly-integrity check is TagDrop's own mandatory `payload_hash`
+            // (fragment index 0): reject a Split-wrapped payload that's missing it outright,
+            // same as a mismatch.
+            val payloadHash = group.payloadHash ?: return State.HashMismatch
+            if (!payloadHashMatches(payloadHash, wrapped)) return State.HashMismatch
             val record = group.toScannedRecord() ?: return State.Failed
             return when (record) {
                 is ScannedRecord.Paper -> finishPaper(record, wrapped)
@@ -358,6 +371,21 @@ class SectorAssembler {
     }
 
     private fun sha256(data: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(data)
+
+    /**
+     * Verifies `payload_hash` (a multihash: 1-byte multicodec function code + digest,
+     * QDEF-SPEC.md §3.6/§4.1) against the reassembled [wrapped] bytes. Recognizes only
+     * sha2-256 (`0x12`), matching every field TagDrop's own encoder emits (`splitFragments`,
+     * `MPK_CONTENT_HASH`); an unrecognized function code is treated as present-but-unverifiable
+     * rather than a mismatch, mirroring QDEF's reference decoder's own "skip silently" handling
+     * of a hash function it doesn't recognize — [computeState] already enforces that the field
+     * is present at all before calling this.
+     */
+    private fun payloadHashMatches(hash: ByteArray, wrapped: ByteArray): Boolean {
+        if (hash.isEmpty()) return false
+        if (hash[0] != 0x12.toByte()) return true
+        return hash.copyOfRange(1, hash.size).contentEquals(sha256(wrapped))
+    }
 
     private fun ByteArray.toHex() = joinToString("") { "%02x".format(it) }
 }

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
@@ -333,6 +333,10 @@ object TagDropCodec {
     private const val SK_COUNT    = 6
     private const val SK_TOTAL    = 7
     private const val SK_PARITY   = 9
+    // `payload_hash` (QDEF-SPEC.md §4.1, added alongside the `group_id` reframe below) —
+    // OPTIONAL/odd at the QDEF level, but TagDrop-MANDATORY whenever Split is used (SPEC.md
+    // "Reassembly integrity" note): present on exactly fragment index 0, never repeated.
+    private const val SK_PAYLOAD_HASH = 11
 
     // Compress Wrapper (Type 4) field keys (QDEF-SPEC.md §4.1). As of SPEC.md v15, its one
     // value (the deflated bytes) is an ordinary field at reserved map key `0` (QDEF-SPEC.md
@@ -361,7 +365,7 @@ object TagDropCodec {
         PPK_SIGNATURE_ALGORITHM, PPK_SIGNER_ID, PPK_SIGNER_LABEL, PPK_IN_REPLY_TO, PPK_CREATED_AT,
         PPK_SOURCE_URL, PPK_TITLE, PPK_DESCRIPTION, PPK_KEY_MATERIAL, PPK_RETAIN_KEY)
     private val KNOWN_PAPER_BODY = setOf(PBK_FILES, PBK_RELATED, PBK_SIGNATURE, PBK_SIGNER_PUBKEY)
-    private val KNOWN_SPLIT = setOf(SK_GROUP_ID, SK_INDEX, SK_COUNT, SK_DATA, SK_TOTAL, SK_PARITY)
+    private val KNOWN_SPLIT = setOf(SK_GROUP_ID, SK_INDEX, SK_COUNT, SK_DATA, SK_TOTAL, SK_PARITY, SK_PAYLOAD_HASH)
     private val KNOWN_COMPRESS = setOf(CK_PAYLOAD)
 
     const val KDF_NONE          = 0
@@ -489,12 +493,18 @@ object TagDropCodec {
     /**
      * Fragments [bytes] into [fragmentCount] QDEF Split Wrapper Records (Type 1, QDEF-SPEC.md
      * §4.1, SPEC §5) of `ceil(total/count)` bytes each (every fragment but the last the same
-     * length), stamped with [groupId] (a content hash of [bytes], computed by the caller). If
-     * [withParity], appends one more fragment at `index == count`: the byte-wise XOR of every
-     * data fragment, each implicitly zero-padded to the widest — SPEC §5's single-loss
-     * redundancy scheme. [extraSubrecords] (SPEC §3.1a) is attached to every fragment Record,
-     * unwrapped and repeated — used to carry Content's Media Preview alongside a Split-wrapped
-     * Media Payload; Paper has none, so it's empty by default.
+     * length), stamped with [groupId] (an opaque correlation token, computed by the caller —
+     * QDEF-SPEC.md's Split Wrapper history no longer treats `group_id` as a verified content
+     * hash, SPEC.md "Reassembly integrity"). Each fragment also carries `payload_hash`
+     * (`SK_PAYLOAD_HASH`, key `11`) on fragment index `0` only — TagDrop-MANDATORY (unlike
+     * QDEF's own OPTIONAL/odd framing of it): a multihash (`0x12` sha2-256 prefix + full
+     * 32-byte digest) of [bytes] itself, the actual reassembly-integrity check now that
+     * `group_id` no longer provides one. If [withParity], appends one more fragment at
+     * `index == count`: the byte-wise XOR of every data fragment, each implicitly zero-padded
+     * to the widest — SPEC §5's single-loss redundancy scheme. [extraSubrecords] (SPEC §3.1a)
+     * is attached to every fragment Record, unwrapped and repeated — used to carry Content's
+     * Media Preview alongside a Split-wrapped Media Payload; Paper has none, so it's empty by
+     * default.
      */
     private fun splitFragments(
         bytes: ByteArray, groupId: ByteArray, fragmentCount: Int, withParity: Boolean,
@@ -502,6 +512,7 @@ object TagDropCodec {
     ): List<ByteArray> {
         val total = bytes.size
         val chunkLen = (total + fragmentCount - 1) / fragmentCount
+        val payloadHash = byteArrayOf(0x12) + sha256(bytes)
         val fragments = mutableListOf<ByteArray>()
         for (i in 0 until fragmentCount) {
             val start = minOf(i * chunkLen, total)
@@ -509,7 +520,8 @@ object TagDropCodec {
             fragments.add(MiniCbor.encodeRecord(TYPE_SPLIT, listOf(
                 SK_GROUP_ID to groupId, SK_INDEX to i, SK_COUNT to fragmentCount,
                 SK_DATA to bytes.copyOfRange(start, end), SK_TOTAL to total,
-                SK_PARITY to (1.takeIf { withParity })
+                SK_PARITY to (1.takeIf { withParity }),
+                SK_PAYLOAD_HASH to (payloadHash.takeIf { i == 0 })
             ), extraSubrecords))
         }
         if (withParity) {
@@ -531,10 +543,13 @@ object TagDropCodec {
      * Builds the codes for one Paper payload: [preview] repeated on every code (SPEC §5.1),
      * plus either [body] directly (single code, if it and [preview] together fit within
      * [maxFragmentDataBytes]), or [body] Split-wrapped across as many codes as needed.
-     * `group_id` is `SHA-256(body)[0:8]` (the wrapped — Compress-wrapped if [compressBody], not
-     * the raw plain — bytes, SPEC §5.1), computed once and reused across every fragment of the
-     * group. Content doesn't use this — its single-code/multi-code nesting differs (§3.1a), see
-     * [createContentSectors].
+     * `group_id` — an opaque correlation token, no longer a verified hash (SPEC.md "Reassembly
+     * integrity") — is `SHA-256(body)[0:8]` (the wrapped — Compress-wrapped if [compressBody],
+     * not the raw plain — bytes), computed once and reused across every fragment of the group;
+     * any encoder-chosen scheme would do, this one is simply convenient and collision-resistant.
+     * `payload_hash` (TagDrop-mandatory reassembly integrity, see [splitFragments]) is computed
+     * from the same `wrapped` bytes. Content doesn't use this — its single-code/multi-code
+     * nesting differs (§3.1a), see [createContentSectors].
      */
     private fun buildCodes(
         preview: ByteArray, body: ByteArray, compressBody: Boolean, withParity: Boolean, maxFragmentDataBytes: Int
@@ -1206,12 +1221,14 @@ object TagDropCodec {
     /** Outcome of parsing a Content payload's reassembled Media Payload (SPEC §5 steps 3-5). */
     sealed class ContentParse {
         /**
-         * Parsed and (if reassembled from a Split group) `group_id`-verified. [mediaPayloadRaw]
-         * is the LOGICAL (Compress-unwrapped, if applicable) Media Payload Record bytes SPEC
-         * §10's signature formula covers — null for a key-only code (no Media Payload at all).
+         * Parsed and (if reassembled from a Split group) `payload_hash`-verified — see
+         * [SectorAssembler]'s `computeState`, which does that check before calling this.
+         * [mediaPayloadRaw] is the LOGICAL (Compress-unwrapped, if applicable) Media Payload
+         * Record bytes SPEC §10's signature formula covers — null for a key-only code (no
+         * Media Payload at all).
          */
         data class Ok(val content: TagDropPayload.Content, val mediaPayloadRaw: ByteArray?) : ContentParse()
-        /** `group_id` was checked and did not match — incomplete or corrupt assembly. */
+        /** Reserved for a Split-reassembly integrity failure caught upstream of [parseContentStream] itself (see [SectorAssembler]); this parser never returns it directly. */
         object HashMismatch : ContentParse()
         /** The bytes aren't a well-formed Content Extension+Media Payload set. */
         object Malformed : ContentParse()
@@ -1397,8 +1414,9 @@ object TagDropCodec {
         val count = frag.uint(SK_COUNT)?.toInt() ?: 1
         val data = frag.bytesOrNull(SK_DATA) ?: return null
         val total = frag.uint(SK_TOTAL)?.toInt() ?: return null
+        val payloadHash = frag.bytesOrNull(SK_PAYLOAD_HASH)
         if (count < 1) return null
-        return SplitFragment(groupId, index, count, data, total, isParity = index >= count)
+        return SplitFragment(groupId, index, count, data, total, isParity = index >= count, payloadHash = payloadHash)
     }
 
     /**
@@ -1533,7 +1551,8 @@ object TagDropCodec {
     )
     private val SPLIT_KEY_NAMES = mapOf(
         SK_GROUP_ID to "group_id", SK_INDEX to "index", SK_COUNT to "count",
-        SK_DATA to "data", SK_TOTAL to "total_bytes", SK_PARITY to "parity"
+        SK_DATA to "data", SK_TOTAL to "total_bytes", SK_PARITY to "parity",
+        SK_PAYLOAD_HASH to "payload_hash"
     )
     private val COMPRESS_KEY_NAMES = mapOf(CK_PAYLOAD to "payload")
 

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropCodec.kt
@@ -497,9 +497,12 @@ object TagDropCodec {
      * QDEF-SPEC.md's Split Wrapper history no longer treats `group_id` as a verified content
      * hash, SPEC.md "Reassembly integrity"). Each fragment also carries `payload_hash`
      * (`SK_PAYLOAD_HASH`, key `11`) on fragment index `0` only — TagDrop-MANDATORY (unlike
-     * QDEF's own OPTIONAL/odd framing of it): a multihash (`0x12` sha2-256 prefix + full
-     * 32-byte digest) of [bytes] itself, the actual reassembly-integrity check now that
-     * `group_id` no longer provides one. If [withParity], appends one more fragment at
+     * QDEF's own OPTIONAL/odd framing of it): a multihash (`0x12` sha2-256 prefix + 8-byte
+     * truncated digest, matching `contentHash`'s/`group_id`'s own truncation — QDEF-SPEC.md
+     * permits either — since this only guards against accidental damage, not deliberate
+     * tampering, which Encrypt/Signature already cover) of [bytes] itself, the actual
+     * reassembly-integrity check now that `group_id` no longer provides one. If [withParity],
+     * appends one more fragment at
      * `index == count`: the byte-wise XOR of every data fragment, each implicitly zero-padded
      * to the widest — SPEC §5's single-loss redundancy scheme. [extraSubrecords] (SPEC §3.1a)
      * is attached to every fragment Record, unwrapped and repeated — used to carry Content's
@@ -512,7 +515,7 @@ object TagDropCodec {
     ): List<ByteArray> {
         val total = bytes.size
         val chunkLen = (total + fragmentCount - 1) / fragmentCount
-        val payloadHash = byteArrayOf(0x12) + sha256(bytes)
+        val payloadHash = byteArrayOf(0x12) + sha256(bytes).copyOf(8)
         val fragments = mutableListOf<ByteArray>()
         for (i in 0 until fragmentCount) {
             val start = minOf(i * chunkLen, total)

--- a/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/data/format/TagDropPayload.kt
@@ -272,7 +272,10 @@ val ScannedRecord.kind: PayloadKind
  * [secondRaw] decoded one level further when `second[0] == TYPE_SPLIT`. A fragment at
  * `index == count` is the optional XOR parity fragment (SPEC §5's redundancy scheme), never
  * a data fragment; [isParity] distinguishes the two cases explicitly rather than leaving
- * callers to compare `index`/`count` themselves.
+ * callers to compare `index`/`count` themselves. [payloadHash] (`payload_hash`, QDEF-SPEC.md
+ * §4.1 key `11`) is only ever present on fragment index `0` — a multihash of the fully
+ * reassembled payload, TagDrop-MANDATORY (SPEC.md "Reassembly integrity") even though QDEF
+ * itself leaves it OPTIONAL/odd.
  */
 data class SplitFragment(
     val groupId: ByteArray,
@@ -280,7 +283,8 @@ data class SplitFragment(
     val count: Int,
     val data: ByteArray,
     val total: Int,
-    val isParity: Boolean
+    val isParity: Boolean,
+    val payloadHash: ByteArray? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -291,6 +295,8 @@ data class SplitFragment(
         if (!data.contentEquals(other.data)) return false
         if (total != other.total) return false
         if (isParity != other.isParity) return false
+        if ((payloadHash == null) != (other.payloadHash == null)) return false
+        if (payloadHash != null && other.payloadHash != null && !payloadHash.contentEquals(other.payloadHash)) return false
         return true
     }
 
@@ -301,6 +307,7 @@ data class SplitFragment(
         result = 31 * result + data.contentHashCode()
         result = 31 * result + total
         result = 31 * result + isParity.hashCode()
+        result = 31 * result + (payloadHash?.contentHashCode() ?: 0)
         return result
     }
 }

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/SectorAssemblerTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/SectorAssemblerTest.kt
@@ -10,7 +10,10 @@ import java.security.MessageDigest
  * functions, which is how TagDropCodecTest.kt already covers most round-trip/erasure-coding/
  * paper scenarios) — isolates the assembler's own reassembly/grouping/state logic from the
  * codec's encode-side field layout. Every fragment here is self-describing (carries its own
- * group_id inline, SPEC §5), matching the real wire format. Records are hand-built as raw QDEF
+ * group_id inline, SPEC §5), matching the real wire format; fragment index 0 also carries
+ * payload_hash (TagDrop-mandatory reassembly integrity, SPEC §5.1 "Reassembly integrity" —
+ * group_id itself is just an opaque correlation token, QDEF-SPEC.md's Split Wrapper history).
+ * Records are hand-built as raw QDEF
  * array-wrapped bytes (SPEC.md v16 §2, §2.1a, §3.1/§3.1a) and turned into [ScannedRecord]s via
  * [TagDropCodec.decodeRaw] — the same decode path a real scan uses — so this file only needs to
  * get the wire *bytes* right, not reimplement Record/subrecord decoding a second time.
@@ -61,13 +64,14 @@ class SectorAssemblerTest {
      * optionally nesting [subrecords] (Media Preview, multi-code case). Renumbered in
      * SPEC.md v15: fragment `data` moves onto reserved map key `0`; `group_id`/`index`/`count`
      * shift up two keys each (2/4/6) to make room; `total_bytes`/`parity_scheme` are unchanged
-     * (7/9).
+     * (7/9). [payloadHash] is `payload_hash` (key `11`) — TagDrop-mandatory reassembly
+     * integrity (SPEC §5.1), normally only passed on fragment index `0`.
      */
     private fun splitFragmentBytes(
         groupId: ByteArray, index: Int, count: Int, data: ByteArray, total: Int, parity: Boolean = false,
-        subrecords: List<ByteArray> = emptyList()
+        subrecords: List<ByteArray> = emptyList(), payloadHash: ByteArray? = null
     ): ByteArray = MiniCbor.encodeRecord(1, listOf(
-        0 to data, 2 to groupId, 4 to index, 6 to count, 7 to total, 9 to (1.takeIf { parity })
+        0 to data, 2 to groupId, 4 to index, 6 to count, 7 to total, 9 to (1.takeIf { parity }), 11 to payloadHash
     ), subrecords)
 
     /** Decodes [extensionRaw]/[secondRaw] the same way a real scan would (SPEC §2, §2.1a, §5.1): wrapped as the QDEF self-delimited root (QDEF-SPEC.md §2/§3.1), namespace declared as the root Bundle's own leading element. */
@@ -78,20 +82,26 @@ class SectorAssemblerTest {
      * Splits [mediaPayloadRaw] into [chunkCount]-many Split Wrapper fragment [ScannedRecord.
      * Content]s sharing [extensionRaw] and [mediaPreviewRaw] (Split's own repeated subrecord in
      * the multi-code case, SPEC.md v9 §3.1a), each carrying its own `group_id`
-     * (SHA-256([mediaPayloadRaw])[0:8]) — mirrors [TagDropCodec]'s own `splitFragments`. Appends
-     * a trailing XOR parity fragment when [withParity].
+     * (SHA-256([mediaPayloadRaw])[0:8], an opaque correlation token only — SPEC §5.1) — mirrors
+     * [TagDropCodec]'s own `splitFragments`. Fragment index `0` also carries `payload_hash`
+     * (a multihash of [mediaPayloadRaw], TagDrop-mandatory reassembly integrity) unless
+     * [includePayloadHash] is false, which builds a group missing the mandatory field on
+     * purpose (for [SectorAssemblerTest]'s own rejection-path test). Appends a trailing XOR
+     * parity fragment when [withParity].
      */
     private fun splitRecords(
-        extensionRaw: ByteArray, mediaPreviewRaw: ByteArray, mediaPayloadRaw: ByteArray, chunkCount: Int, withParity: Boolean = false
+        extensionRaw: ByteArray, mediaPreviewRaw: ByteArray, mediaPayloadRaw: ByteArray, chunkCount: Int,
+        withParity: Boolean = false, includePayloadHash: Boolean = true
     ): List<ScannedRecord.Content> {
         val groupId = sha256(mediaPayloadRaw).copyOf(8)
+        val payloadHash = byteArrayOf(0x12) + sha256(mediaPayloadRaw)
         val chunkLen = (mediaPayloadRaw.size + chunkCount - 1) / chunkCount
         val dataRecords = (0 until chunkCount).map { i ->
             val start = minOf(i * chunkLen, mediaPayloadRaw.size)
             val end = minOf(start + chunkLen, mediaPayloadRaw.size)
             val fragRaw = splitFragmentBytes(
                 groupId, i, chunkCount, mediaPayloadRaw.copyOfRange(start, end), mediaPayloadRaw.size,
-                subrecords = listOf(mediaPreviewRaw)
+                subrecords = listOf(mediaPreviewRaw), payloadHash = payloadHash.takeIf { i == 0 && includePayloadHash }
             )
             recordOf(extensionRaw, fragRaw)
         }
@@ -247,15 +257,16 @@ class SectorAssemblerTest {
         assertArrayEquals(contentB, completedB.content)
     }
 
-    // ── group_id integrity check (SPEC §5.1) ────────────────────────────────────
+    // ── payload_hash integrity check (SPEC §5.1) ────────────────────────────────
 
-    @Test fun groupIdMismatchDetected() {
+    @Test fun payloadHashMismatchDetected() {
         val content = ByteArray(60) { it.toByte() }
         val records = splitRecords(
             extensionBytes(null), mediaPreviewBytes(byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)), mediaPayloadBytes(content), chunkCount = 4
         ).toMutableList()
-        // Tamper one fragment's data in place, without touching its declared group_id —
-        // the reassembled bytes no longer hash to the group_id every fragment still claims.
+        // Tamper one fragment's data in place, without touching group_id (an opaque correlation
+        // token only now, SPEC §5.1 — no longer verified) or fragment 0's payload_hash: the
+        // reassembled bytes no longer hash to what fragment 0's payload_hash still claims.
         val victim = records[1]
         val frag = TagDropCodec.splitFragmentOf(victim)!!
         val tamperedData = frag.data.copyOf().also { it[0] = (it[0].toInt() xor 0xFF).toByte() }
@@ -268,6 +279,22 @@ class SectorAssemblerTest {
         var state: SectorAssembler.State = SectorAssembler.State.Idle
         for (r in records) state = a.add(r)
         assertTrue("expected HashMismatch, got $state", state is SectorAssembler.State.HashMismatch)
+    }
+
+    @Test fun missingPayloadHashRejected() {
+        // TagDrop makes payload_hash mandatory whenever Split is used (SPEC §5.1 "Reassembly
+        // integrity"), stricter than QDEF's own OPTIONAL/odd framing of it -- a Split-wrapped
+        // payload that never carries it on any fragment must be rejected outright once fully
+        // reassembled, not silently accepted the way skipping a merely-optional field would be.
+        val content = ByteArray(60) { it.toByte() }
+        val records = splitRecords(
+            extensionBytes(null), mediaPreviewBytes(byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)), mediaPayloadBytes(content),
+            chunkCount = 4, includePayloadHash = false
+        )
+        val a = SectorAssembler()
+        var state: SectorAssembler.State = SectorAssembler.State.Idle
+        for (r in records) state = a.add(r)
+        assertTrue("expected HashMismatch (missing payload_hash), got $state", state is SectorAssembler.State.HashMismatch)
     }
 
     // ── Resource-exhaustion guards (SPEC §5.1) ──────────────────────────────────

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/SectorAssemblerTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/SectorAssemblerTest.kt
@@ -94,7 +94,7 @@ class SectorAssemblerTest {
         withParity: Boolean = false, includePayloadHash: Boolean = true
     ): List<ScannedRecord.Content> {
         val groupId = sha256(mediaPayloadRaw).copyOf(8)
-        val payloadHash = byteArrayOf(0x12) + sha256(mediaPayloadRaw)
+        val payloadHash = byteArrayOf(0x12) + sha256(mediaPayloadRaw).copyOf(8)
         val chunkLen = (mediaPayloadRaw.size + chunkCount - 1) / chunkCount
         val dataRecords = (0 until chunkCount).map { i ->
             val start = minOf(i * chunkLen, mediaPayloadRaw.size)
@@ -295,6 +295,32 @@ class SectorAssemblerTest {
         var state: SectorAssembler.State = SectorAssembler.State.Idle
         for (r in records) state = a.add(r)
         assertTrue("expected HashMismatch (missing payload_hash), got $state", state is SectorAssembler.State.HashMismatch)
+    }
+
+    @Test fun payloadHashAcceptsFullUntruncatedDigestToo() {
+        // QDEF-SPEC.md permits payload_hash's digest to be full or truncated (§4.1). TagDrop's
+        // own encoder always truncates to 8 bytes (matching contentHash/group_id, since this
+        // field only guards accidental damage, not deliberate tampering) -- but the decoder
+        // must still correctly verify a compliant full-32-byte digest, since nothing about the
+        // wire format requires truncation from every encoder.
+        val mediaPayloadRaw = mediaPayloadBytes(ByteArray(60) { it.toByte() })
+        val mediaPreviewRaw = mediaPreviewBytes(byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8))
+        val extension = extensionBytes(null)
+        val groupId = sha256(mediaPayloadRaw).copyOf(8)
+        val fullPayloadHash = byteArrayOf(0x12) + sha256(mediaPayloadRaw)
+        val chunkLen = (mediaPayloadRaw.size + 1) / 2
+        val frag0 = splitFragmentBytes(
+            groupId, 0, 2, mediaPayloadRaw.copyOfRange(0, chunkLen), mediaPayloadRaw.size,
+            subrecords = listOf(mediaPreviewRaw), payloadHash = fullPayloadHash
+        )
+        val frag1 = splitFragmentBytes(
+            groupId, 1, 2, mediaPayloadRaw.copyOfRange(chunkLen, mediaPayloadRaw.size), mediaPayloadRaw.size,
+            subrecords = listOf(mediaPreviewRaw)
+        )
+        val a = SectorAssembler()
+        a.add(recordOf(extension, frag0))
+        val state = a.add(recordOf(extension, frag1))
+        assertTrue("expected ContentReady with a valid full-digest payload_hash, got $state", state is SectorAssembler.State.ContentReady)
     }
 
     // ── Resource-exhaustion guards (SPEC §5.1) ──────────────────────────────────

--- a/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropCodecTest.kt
+++ b/app/src/test/java/com/github/mofosyne/tagdrop/data/format/TagDropCodecTest.kt
@@ -18,7 +18,8 @@ import org.junit.Test
  * this is what a decoder actually keys off of to tell TagDrop's Content Extension (wire `-1`)
  * apart from QDEF's own global Split Wrapper (wire `+1`), not the bare typeId magnitude alone.
  * Mirrors `tools/test-qdef-roundtrip.mjs`'s adversarial coverage (tamper detection via
- * group_id/root_hash recomputation, SPEC §2.2 even/odd key criticality, key-only codes, the
+ * payload_hash/root_hash recomputation — group_id itself is just an opaque correlation token,
+ * SPEC §5.1 "Reassembly integrity" — SPEC §2.2 even/odd key criticality, key-only codes, the
  * placeholder-then-strip signing round trip) rather than porting the old version-1 envelope's
  * byte-layout assertions, which no longer apply.
  */
@@ -292,9 +293,12 @@ class TagDropCodecTest {
         assertEquals(listOf(build.codes.size - 1), state.missingIndices)
     }
 
-    @Test fun multiCodeGroupIdMismatchIsHashMismatch() {
+    @Test fun multiCodePayloadHashMismatchIsHashMismatch() {
         // Reassembling a truncated/corrupted fragment set that still nominally "completes"
-        // (every index present) but doesn't hash back to the declared group_id.
+        // (every index present) but doesn't hash back to fragment 0's declared payload_hash —
+        // group_id itself is just an opaque correlation token now (SPEC §5.1 "Reassembly
+        // integrity"), so tampering fragment 1 (not the payload_hash-bearing fragment 0) is
+        // caught by TagDrop's own mandatory payload_hash field instead.
         val content = ByteArray(2000) { it.toByte() }
         val build = TagDropCodec.createContentSectors(null, null, "application/octet-stream", content, maxSectorDataBytes = 600)
         assertTrue(build.codes.size >= 3)
@@ -303,6 +307,7 @@ class TagDropCodecTest {
         // once every index is present) by re-decoding a hand-tampered raw record.
         val victim = records[1] as ScannedRecord.Content
         val frag = TagDropCodec.splitFragmentOf(victim)!!
+        assertEquals("must tamper a fragment other than the payload_hash-bearing one", 1, frag.index)
         val tamperedData = frag.data.copyOf().also { it[0] = (it[0].toInt() xor 0xFF).toByte() }
         // Multi-code Content's Split Wrapper (Type 1) carries Media Preview as its own subrecord
         // (SPEC.md §3.1a) — preserve it so the tampered fragment still decodes. Split Wrapper is
@@ -321,6 +326,35 @@ class TagDropCodecTest {
 
         val state = assemble(records)
         assertTrue("expected HashMismatch, got $state", state is SectorAssembler.State.HashMismatch)
+    }
+
+    @Test fun multiCodeMissingPayloadHashOnFragmentZeroIsRejected() {
+        // TagDrop makes payload_hash mandatory whenever Split is used (SPEC §5.1 "Reassembly
+        // integrity"), stricter than QDEF's own OPTIONAL/odd framing of it: unlike an ordinary
+        // unrecognized/absent optional field, a decoder must reject reassembly outright when
+        // it's missing, rather than silently proceeding without a reassembly-integrity check.
+        // Strip it from the one fragment that would carry it (index 0) while leaving every
+        // other field — group_id, index/count/total, the fragment data itself — untouched and
+        // otherwise perfectly valid.
+        val content = ByteArray(2000) { it.toByte() }
+        val build = TagDropCodec.createContentSectors(null, null, "application/octet-stream", content, maxSectorDataBytes = 600)
+        assertTrue(build.codes.size >= 3)
+        val records = roundTrip(build.codes).toMutableList()
+        val victim = records[0] as ScannedRecord.Content
+        val frag = TagDropCodec.splitFragmentOf(victim)!!
+        assertEquals(0, frag.index)
+        assertNotNull("fragment 0 should carry payload_hash before it's stripped", frag.payloadHash)
+        // Split Wrapper's field keys per SPEC.md v15: fragment data at reserved map key `0`,
+        // group_id/index/count shifted up two keys each (2/4/6), total_bytes unchanged (7) —
+        // payload_hash (key 11) simply omitted here.
+        val strippedSplit = MiniCbor.encodeRecord(1, listOf(
+            0 to frag.data, 2 to frag.groupId, 4 to frag.index, 6 to frag.count, 7 to frag.total
+        ), listOf(victim.mediaPreviewRaw!!))
+        val strippedFull = MiniCbor.encodeRootBundle(listOf(victim.extensionRaw, strippedSplit), TagDropCodec.TAGDROP_NAMESPACE)
+        records[0] = (TagDropCodec.decodeRaw(strippedFull) as TagDropScan.RecordScan).record
+
+        val state = assemble(records)
+        assertTrue("expected HashMismatch (missing payload_hash), got $state", state is SectorAssembler.State.HashMismatch)
     }
 
     @Test fun parityReconstructsOneMissingDataFragment() {


### PR DESCRIPTION
## Summary

Ports SPEC.md version 18 changes to the Kotlin implementation, adopting a new mandatory `payload_hash` field for Split Wrapper reassembly integrity. This addresses a critical gap where the old design's integrity guarantees were inadvertently removed when QDEF reframed `group_id` as an opaque correlation token rather than a verified content hash.

## Key Changes

**SPEC.md and documentation:**
- Version bumped to 18; `group_id` now documented as opaque correlation token only (matching QDEF-SPEC.md's reframe)
- New mandatory `payload_hash` field (Split Wrapper key `11`) replaces the integrity-checking role previously attributed to `group_id`
- `payload_hash` is a multihash (8-byte truncated sha2-256, matching `contentHash`/`group_id` truncation) present only on fragment index 0
- Updated all references to reassembly verification throughout §3.4, §5.1, §5.2, §9, and §14
- QDEF-SPEC-cached.md refreshed with upstream Split Wrapper documentation

**Kotlin codec (`TagDropCodec.kt`):**
- Added `SK_PAYLOAD_HASH = 11` constant
- `splitFragments()` now computes and stamps `payload_hash` on fragment index 0 only
- Updated docstring to clarify `group_id` is correlation-only and `payload_hash` provides actual integrity

**Kotlin reassembly (`SectorAssembler.kt`):**
- `Group` class gained `payloadHash: ByteArray?` field
- `add()` captures `payload_hash` from fragments carrying it
- `computeState()` rewritten to require and verify `payload_hash` instead of `group_id`
- New `payloadHashMatches()` helper recognizes sha2-256 (`0x12`), treats unrecognized hash functions as present-but-unverifiable
- `State.HashMismatch` repurposed (not renamed) to signal `payload_hash` verification failure
- Rejects Split-wrapped payloads missing `payload_hash` outright (mandatory field enforcement)

**Kotlin payload model (`TagDropPayload.kt`):**
- `SplitFragment` gained `payloadHash: ByteArray?` field with proper `contentEquals`-based equality

**Tests:**
- `SectorAssemblerTest.kt`: 
  - `splitFragmentBytes()` and `splitRecords()` helpers gained `payloadHash`/`includePayloadHash` parameters
  - Renamed `groupIdMismatchDetected()` → `payloadHashMismatchDetected()` with corrected comment
  - Added `missingPayloadHashRejected()` covering mandatory-field rejection
  - Added `payloadHashAcceptsFullUntruncatedDigestToo()` verifying decoder's length-generic verification
- `TagDropCodecTest.kt`:
  - Renamed `multiCodeGroupIdMismatchIsHashMismatch()` → `multiCodePayloadHashMismatchIsHashMismatch()` with updated explanation
  - Added `multiCodeMissingPayloadHashOnFragmentZeroIsRejected()` with hand-stripped key `11` test case

## Implementation Details

- **Truncation strategy**: 8-byte digest (9 bytes total with `0x12` prefix) matches existing `contentHash`/`group_id` truncation — sufficient for accidental-damage detection; deliberate tampering remains Encrypt/Signature's responsibility
- **Fragment 0 only**: `payload_hash` present only on the fragment carrying `index == 0`, never repeated — only needs checking once after reassembly completes
- **Decoder robustness**: Unrecognized hash function codes treated as present-but-unverifiable (matching reference JS implementation), not as errors
- **Mandatory enforcement**: TagDrop decoders reject Split-wrapped payloads missing `payload_hash`, unlike QDEF's optional/odd framing — follows the same "tighten QDEF-optional where TagDrop needs stronger guarantee" pattern as §2.1a's

https://claude.ai/code/session_01CMMmPJFkqYDN6azUU86T1Y