### PR TITLE
Re-sync cached QDEF spec; harden ContentExporter's filename sanitization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1795,6 +1795,64 @@ entry above originally flagged — **both implementations are on the
 same `payload_hash` shape now**, and the "Wire-format version policy"
 note below no longer needs its Kotlin-only caveat.
 
+### `ContentExporter.kt` filename sanitization gap (found via a routine cache re-sync)
+
+Prompted by "moving towards a release, don't forget to sync the cached
+spec" — running `scripts/sync-qdef-spec.sh` again turned up two real
+upstream changes since the version-18 sync above: a scope-boundary note
+clarifying Split targets a finite, printed set of codes rather than an
+animated/streamed one (no TagDrop action — matches this project's
+existing usage), and a new security note that Media Preview's
+`filename` (key 5) "MUST be sanitized before any local use, never
+trusted as a safe path component," with an explicit checklist (bare
+basename, strip control characters, substitute a generic name if the
+result is empty, `.`, or `..`).
+
+Traced against real code rather than just logging the note, per this
+project's standing practice: `ContentExporter.kt`'s `suggestFilename()`
+is the one place a scanned `filename` becomes a real filesystem write
+(`File(dir, suggestFilename(cache))`, used by save/share/export).
+`sanitize()` stripped Windows-illegal characters (`\/:*?"<>|`) but
+never checked the *result* against `.`/`..`/empty — normally masked by
+`suggestFilename()` appending a guessed extension afterward, but
+`cache.mimeType` is itself an unauthenticated field: a code declaring
+`filename: ".."` alongside a `mimeType` `MimeTypeMap`/`FALLBACK_EXTENSIONS`
+doesn't recognize hits `extensionFor(...) ?: return base`, returning
+the bare, unextended `".."` — which `File(dir, "..")` then resolves to
+the parent of the app's own `cacheDir/exports/` (still inside the app
+sandbox, not a real off-device traversal, but a genuine escape of the
+intended subdirectory, and exactly the case upstream's new note calls
+out). The web tools were checked too and found not to need this: their
+only equivalent is the browser's native `<a download>` attribute
+(`reader/index.html`'s content-download button,
+`generator/index.html`'s QR-PNG/signing-identity exports), which
+browsers already refuse `../`/path-separator characters in themselves —
+a fundamentally different mechanism from a raw `File()` write, and the
+generator's own `filename` values there are self-authored by whoever's
+using the tool, not scanned/untrusted content anyway.
+
+Fixed with a new `isSafeBaseName()` check (`name.isNotBlank() && name
+!= "." && name != ".."`) applied via `takeIf` alongside the existing
+sanitize-then-check pattern already used for both the `filename` and
+`hint` candidates — a rejected candidate now falls through to the next
+one in the existing `filename ?: hint ?: cacheId-prefix` chain, the
+same way an already-blank result already did, rather than substituting
+a fixed generic name (more consistent with this function's existing
+design, and TagDrop already has good fallbacks available).
+`sanitize()` also gained control-character stripping
+(`\p{Cntrl}`), matching upstream's checklist in full, not just the
+directory-token half of it. `ContentExporter.kt` needs the Android SDK
+(`Context`/`Uri`/`FileProvider`) to compile at all, so it's outside the
+`data/format`+`data/signing` standalone `kotlinc` harness this
+project's QDEF work has relied on throughout — verified instead by
+extracting the pure string logic (`sanitize`/`isSafeBaseName`/
+`hasExtension`/`suggestFilename`, with `extensionFor` stubbed) into a
+disposable standalone script and running it against the exact attack
+case plus five other cases (ordinary filenames, embedded slashes,
+control characters) confirming no regression — not committed, since
+the project has no Robolectric/instrumented test setup for
+`app/src/test` to host a real permanent test in.
+
 ### Known duplication (not yet deduped)
 
 `tools/generator/index.html`'s codec helpers — Base41 (`base41Encode`/

--- a/QDEF-SPEC-cached.md
+++ b/QDEF-SPEC-cached.md
@@ -892,6 +892,28 @@ wrapping avoids a cross-record correctness hazard.
 so this stays strictly opt-in — a Record Type with no need for it stays
 a plain, unwrapped Record.
 
+**Scope boundary: Split targets a finite, printed set of codes, not an
+animated/streamed one.** Split's model is "reassemble exactly `count`
+known fragments" (with single-fragment XOR recovery at best) — the
+right fit for a fixed, static artifact like a set of printed labels,
+where every code is expected to eventually be in hand. It is
+deliberately not a fountain code: an application that scans a live,
+looping display over an unreliable camera (drop rates far higher and
+more variable than a printed code's one-time scan) wants a mechanism
+where the receiver can reconstruct from *any* sufficient subset of an
+open-ended stream, not a specific fixed set — e.g. LT/Luby-transform
+fountain coding, as used by
+[Decimen](https://github.com/bashalarmistalt/decimen-optical-transfer)
+for exactly this animated-QR case. That's a substantially larger
+mechanism (a shared pseudorandom degree distribution that must produce
+bit-identical output across every implementation — Decimen's own build
+notes a real cross-engine desync from a 1-ulp difference in `Math.log`
+between JS engines) for a different physical situation than the one
+Split is scoped to. An application needing it should look at a
+fountain-coding scheme built for that channel rather than QDEF's Split,
+the same considered exclusion as Encrypt's own deniability limit,
+above.
+
 ### 4.2 Open/Hint URI (optional)
 
 Unlike §4.1, this is deliberately **not** a wrapper — a plain standard
@@ -1087,6 +1109,19 @@ The identified content itself is carried as a subrecord, typically a
 [ 7, { 2: "image/png", 3: h'...', 5: "photo.png" },
   [ 3, { 0: h'<payload bytes>', 1: "image/png" } ] ]
 ```
+
+**Key `5` (Filename) MUST be sanitized before any local use, never
+trusted as a safe path component.** It arrives over the same
+un-authenticated optical channel as everything else in the container —
+any scanned code can claim any filename. A decoder that writes it
+straight to a filesystem path, or otherwise treats it as more than a
+display string, is exposed to path traversal (`../../etc/passwd`-style
+values) and embedded control characters. At minimum: reduce to a bare
+basename (strip any `/` or `\` and everything before the last one),
+strip control characters, and substitute a generic name if the result
+is empty, `.`, or `..`. The same caution applies to any other
+QDEF-carried field a decoder is tempted to use as a filesystem path or
+shell argument rather than opaque display text.
 
 **Why not put identification fields on Media Payload's own map?** §4.3
 deliberately stays minimal (media type + bytes, nothing else) so it

--- a/app/src/main/java/com/github/mofosyne/tagdrop/util/ContentExporter.kt
+++ b/app/src/main/java/com/github/mofosyne/tagdrop/util/ContentExporter.kt
@@ -94,8 +94,8 @@ object ContentExporter {
 
     /** Suggested filename for [cache]: its declared filename or hint, with an extension guessed from its MIME type. */
     fun suggestFilename(cache: FoundCache): String {
-        val base = cache.filename?.let(::sanitize)?.takeIf { it.isNotBlank() }
-            ?: cache.hint?.let(::sanitize)?.takeIf { it.isNotBlank() }
+        val base = cache.filename?.let(::sanitize)?.takeIf(::isSafeBaseName)
+            ?: cache.hint?.let(::sanitize)?.takeIf(::isSafeBaseName)
             ?: cache.cacheId.take(12)
         if (hasExtension(base)) return base
         val ext = extensionFor(cache.mimeType) ?: return base
@@ -103,7 +103,21 @@ object ContentExporter {
     }
 
     private fun sanitize(name: String): String =
-        name.trim().replace(Regex("[\\\\/:*?\"<>|]"), "_")
+        name.trim()
+            .replace(Regex("[\\\\/:*?\"<>|]"), "_")
+            .replace(Regex("\\p{Cntrl}"), "")
+
+    /**
+     * A sanitized name is only safe to use as a bare filesystem path component (`File(dir,
+     * name)`) if it isn't blank or a directory-navigation token — `filename` arrives over an
+     * unauthenticated channel (any scanned code can claim any value, QDEF-SPEC.md's Media
+     * Preview note), and `sanitize()` above only strips `/`/`\`, which "." and ".." don't
+     * need to mean "current"/"parent directory" to the underlying filesystem. Without this
+     * check, `filename: ".."` paired with a [cache.mimeType] `extensionFor` doesn't recognize
+     * (so no extension gets appended to mask it) would resolve outside the intended export
+     * subdirectory.
+     */
+    private fun isSafeBaseName(name: String): Boolean = name.isNotBlank() && name != "." && name != ".."
 
     private fun hasExtension(name: String): Boolean {
         val dot = name.lastIndexOf('.')


### PR DESCRIPTION
## Summary

Follow-up to #76/#77, done while double-checking everything before a bugfix release. Re-ran `scripts/sync-qdef-spec.sh` (routine pre-release step) and traced its diff against real code rather than just committing it, per this project's standing practice.

## Changes

**`QDEF-SPEC-cached.md`**: refreshed against upstream. Two real changes since the last sync:
- A scope-boundary note clarifying Split targets a finite, printed set of codes, not an animated/streamed fountain-coded one. No TagDrop action needed — matches this project's existing usage.
- A new security note: Media Preview's `filename` (key 5) "MUST be sanitized before any local use, never trusted as a safe path component," with an explicit checklist (bare basename, strip control characters, substitute a generic name if the result is empty, `.`, or `..`).

**`ContentExporter.kt`**: the filename note above turned out to be a real, if narrow, gap here — this is the one place a scanned `filename` becomes a real filesystem write (`File(dir, suggestFilename(cache))`, used by save/share/export). `sanitize()` stripped Windows-illegal characters but never rejected the *result* being `.`/`..`/empty. That's normally masked by `suggestFilename()` appending a guessed extension afterward — but `mimeType` is itself unauthenticated, so a code declaring `filename: ".."` alongside an unrecognized `mimeType` skips that append, letting `File(dir, "..")` resolve to the parent of the app's own `exports/` subdirectory (still inside the app sandbox, not an off-device traversal, but a genuine escape of the intended subdirectory).

Fixed with a new `isSafeBaseName()` check, applied via the same `takeIf` pattern already used for both `filename`/`hint` candidates — a rejected candidate now falls through to the next one in the existing `filename ?: hint ?: cacheId-prefix` chain, same as an already-blank result already did. `sanitize()` also gained control-character stripping, completing upstream's checklist.

**Web tools checked, found not to need this**: their only equivalent is the browser's native `<a download>` attribute (reader's content-download button, generator's QR-PNG/signing-identity exports) — browsers already refuse `../`/path-separator characters there themselves, a different mechanism from a raw `File()` write, and the generator's own `filename` values are self-authored by whoever's using the tool, not scanned/untrusted content.

**`CLAUDE.md`**: documents both findings.

## Test plan

- [x] `ContentExporter.kt` needs the Android SDK to compile (`Context`/`Uri`/`FileProvider`), outside this project's `data/format`-only standalone `kotlinc` harness — verified instead by extracting the pure string logic (`sanitize`/`isSafeBaseName`/`hasExtension`/`suggestFilename`, with `extensionFor` stubbed) into a disposable script and running it against the exact attack case (`filename: ".."` + unrecognized `mimeType`) plus five other cases (ordinary filenames, embedded slashes, control characters) — all pass, no regression
- [x] `QDEF-SPEC-cached.md` diff reviewed by hand before committing (this project's standard practice for that script)

https://claude.ai/code/session_01CMMmPJFkqYDN6azUU86T1Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMMmPJFkqYDN6azUU86T1Y)_